### PR TITLE
elk.graph: Migrated ecore namespace to eclipse

### DIFF
--- a/plugins/org.eclipse.elk.graph/model/kgraph.ecore
+++ b/plugins/org.eclipse.elk.graph/model/kgraph.ecore
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="kgraph" nsURI="http://elk.eclipse.org/KGraph" nsPrefix="kgraph">
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="graph" nsURI="http://elk.eclipse.org/KGraph" nsPrefix="graph">
   <eClassifiers xsi:type="ecore:EClass" name="KGraphElement" abstract="true">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="This is the superclass of all elements of a graph such as nodes, edges, ports,&#xA;and labels. A graph element may contain an arbitrary number of additional&#xA;data instances."/>
@@ -155,10 +155,10 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"
         transient="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EDataType" name="IProperty" instanceClassName="org.eclipse.elk.properties.IProperty">
+  <eClassifiers xsi:type="ecore:EDataType" name="IProperty" instanceClassName="org.eclipse.elk.graph.properties.IProperty">
     <eTypeParameters name="T"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="IPropertyHolder" instanceClassName="org.eclipse.elk.properties.IPropertyHolder"
+  <eClassifiers xsi:type="ecore:EClass" name="IPropertyHolder" instanceClassName="org.eclipse.elk.graph.properties.IPropertyHolder"
       abstract="true" interface="true">
     <eOperations name="setProperty" eType="#//IPropertyHolder">
       <eTypeParameters name="T"/>

--- a/plugins/org.eclipse.elk.graph/model/kgraph.genmodel
+++ b/plugins/org.eclipse.elk.graph/model/kgraph.genmodel
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="KIELER - Kiel Integrated Environment for Layout Eclipse RichClient&#xA;&#xA;http://www.informatik.uni-kiel.de/rtsys/kieler/&#xA;&#xA;Copyright 2009 by&#xA;+ Kiel University&#xA;  + Department of Computer Science&#xA;    + Real-Time and Embedded Systems Group&#xA;&#xA;This code is provided under the terms of the Eclipse Public License (EPL).&#xA;See the file epl-v10.html for the license text."
-    modelDirectory="/de.cau.cs.kieler.core.kgraph/src" editDirectory="/de.cau.cs.kieler.core.kgraph.edit/src"
-    editorDirectory="/de.cau.cs.kieler.core.kgraph.editor/src" modelPluginID="de.cau.cs.kieler.core.kgraph"
-    modelName="KGraph" editPluginClass="de.cau.cs.kieler.core.kgraph.provider.KGraphEditPlugin"
-    editorPluginClass="de.cau.cs.kieler.core.kgraph.presentation.KGraphEditorPlugin"
-    testSuiteClass="de.cau.cs.kieler.core.kgraph.tests.KGraphAllTests" importerID="org.eclipse.emf.importer.ecore"
-    complianceLevel="5.0" copyrightFields="false" editPluginID="de.cau.cs.kieler.core.kgraph.edit"
+    modelDirectory="/org.eclipse.elk.graph/src" editDirectory="/org.eclipse.elk.graph.edit/src"
+    editorDirectory="/org.eclipse.elk.graph.editor/src" modelPluginID="org.eclipse.elk.graph"
+    modelName="KGraph" editPluginClass="org.eclipse.elk.graph.provider.KGraphEditPlugin"
+    editorPluginClass="org.eclipse.elk.graph.presentation.KGraphEditorPlugin"
+    testSuiteClass="org.eclipse.elk.graph.tests.KGraphAllTests" importerID="org.eclipse.emf.importer.ecore"
+    complianceLevel="5.0" copyrightFields="false" editPluginID="org.eclipse.elk.graph.edit"
     language="">
   <foreignModel>kgraph.ecore</foreignModel>
-  <genPackages prefix="KGraph" basePackage="de.cau.cs.kieler.core" disposableProviderFactory="true"
+  <genPackages prefix="KGraph" basePackage="org.eclipse.elk" disposableProviderFactory="true"
       fileExtensions="kgraph,kgx" ecorePackage="kgraph.ecore#/">
     <genDataTypes ecoreDataType="kgraph.ecore#//IProperty">
       <genTypeParameters ecoreTypeParameter="kgraph.ecore#//IProperty/T"/>

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/KGraphPackage.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/KGraphPackage.java
@@ -38,7 +38,7 @@ public interface KGraphPackage extends EPackage {
      * <!-- end-user-doc -->
      * @generated
      */
-    String eNAME = "kgraph";
+    String eNAME = "graph";
 
     /**
      * The package namespace URI.
@@ -54,7 +54,7 @@ public interface KGraphPackage extends EPackage {
      * <!-- end-user-doc -->
      * @generated
      */
-    String eNS_PREFIX = "kgraph";
+    String eNS_PREFIX = "graph";
 
     /**
      * The singleton instance of the package.

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/KGraphSwitch.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/KGraphSwitch.java
@@ -57,7 +57,7 @@ public class KGraphSwitch<T> extends Switch<T> {
      * Checks whether this is a switch for the given package.
      * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @parameter ePackage the package in question.
+     * @param ePackage the package in question.
      * @return whether this is a switch for the given package.
      * @generated
      */


### PR DESCRIPTION
The ecore model still uses the old namespace, leading to broken code when generating new model files for this project or projects depending on the kgraph.

Signed-off-by: Nis Boerge Wechselberg <nbw@informatik.uni-kiel.de>