### PR TITLE
elk.layered.splines: Introduced new option for sloppy spline routing.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredMetaDataProvider.java
+++ b/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredMetaDataProvider.java
@@ -447,6 +447,20 @@ public class LayeredMetaDataProvider implements ILayoutMetaDataProvider {
             null);
   
   /**
+   * Default value for {@link #EDGE_ROUTING_SLOPPY_SPLINE_ROUTING}.
+   */
+  private final static boolean EDGE_ROUTING_SLOPPY_SPLINE_ROUTING_DEFAULT = true;
+  
+  /**
+   * Use less spline control points at the start and end of an edge. Might lead to crossings edge/node overlap.
+   */
+  public final static IProperty<Boolean> EDGE_ROUTING_SLOPPY_SPLINE_ROUTING = new Property<Boolean>(
+            "org.eclipse.elk.layered.edgeRouting.sloppySplineRouting",
+            EDGE_ROUTING_SLOPPY_SPLINE_ROUTING_DEFAULT,
+            null,
+            null);
+  
+  /**
    * Default value for {@link #SPACING_EDGE_NODE_SPACING_FACTOR}.
    */
   private final static float SPACING_EDGE_NODE_SPACING_FACTOR_DEFAULT = 0.5f;
@@ -624,6 +638,11 @@ public class LayeredMetaDataProvider implements ILayoutMetaDataProvider {
    * Required value for dependency between {@link #EDGE_ROUTING_SELF_LOOP_PLACEMENT} and {@link #EDGE_ROUTING}.
    */
   private final static EdgeRouting EDGE_ROUTING_SELF_LOOP_PLACEMENT_DEP_EDGE_ROUTING = EdgeRouting.SPLINES;
+  
+  /**
+   * Required value for dependency between {@link #EDGE_ROUTING_SLOPPY_SPLINE_ROUTING} and {@link #EDGE_ROUTING}.
+   */
+  private final static EdgeRouting EDGE_ROUTING_SLOPPY_SPLINE_ROUTING_DEP_EDGE_ROUTING = EdgeRouting.SPLINES;
   
   /**
    * Required value for dependency between {@link #COMPACTION_CONNECTED_COMPONENTS} and {@link #SEPARATE_CONNECTED_COMPONENTS}.
@@ -1086,6 +1105,24 @@ public class LayeredMetaDataProvider implements ILayoutMetaDataProvider {
         "org.eclipse.elk.layered.edgeRouting.selfLoopPlacement",
         "org.eclipse.elk.edgeRouting",
         EDGE_ROUTING_SELF_LOOP_PLACEMENT_DEP_EDGE_ROUTING
+    );
+    registry.register(new LayoutOptionData(
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineRouting",
+        "edgeRouting",
+        "Sloppy Spline Routing",
+        "Use less spline control points at the start and end of an edge. Might lead to crossings edge/node overlap.",
+        EDGE_ROUTING_SLOPPY_SPLINE_ROUTING_DEFAULT,
+        null,
+        null,
+        LayoutOptionData.Type.BOOLEAN,
+        Boolean.class,
+        EnumSet.of(LayoutOptionData.Target.PARENTS),
+        LayoutOptionData.Visibility.VISIBLE
+    ));
+    registry.addDependency(
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineRouting",
+        "org.eclipse.elk.edgeRouting",
+        EDGE_ROUTING_SLOPPY_SPLINE_ROUTING_DEP_EDGE_ROUTING
     );
     registry.register(new LayoutOptionData(
         "org.eclipse.elk.layered.spacing.edgeNodeSpacingFactor",

--- a/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredOptions.java
+++ b/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredOptions.java
@@ -518,6 +518,11 @@ public class LayeredOptions implements ILayoutMetaDataProvider {
    */
   public final static IProperty<Spacing.Margins> MARGINS = CoreOptions.MARGINS;
   
+  /**
+   * Property constant to access Sloppy Spline Routing from within the layout algorithm code.
+   */
+  public final static IProperty<Boolean> EDGE_ROUTING_SLOPPY_SPLINE_ROUTING = LayeredMetaDataProvider.EDGE_ROUTING_SLOPPY_SPLINE_ROUTING;
+  
   public void apply(final ILayoutMetaDataProvider.Registry registry) {
     registry.register(new LayoutAlgorithmData(
         "org.eclipse.elk.layered",
@@ -928,6 +933,11 @@ public class LayeredOptions implements ILayoutMetaDataProvider {
         "org.eclipse.elk.layered",
         "org.eclipse.elk.margins",
         MARGINS.getDefault()
+    );
+    registry.addOptionSupport(
+        "org.eclipse.elk.layered",
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineRouting",
+        EDGE_ROUTING_SLOPPY_SPLINE_ROUTING.getDefault()
     );
   }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.elkm
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.elkm
@@ -127,6 +127,7 @@ algorithm layered(LayeredLayoutProvider) {
     supports org.eclipse.elk.alg.layered.layering.nodePromotion.maxIterations
     supports edgeCenterLabelPlacementStrategy
     supports org.eclipse.elk.margins
+    supports edgeRouting.sloppySplineRouting
 }
 
 
@@ -337,7 +338,15 @@ group edgeRouting {
         legacyIds de.cau.cs.kieler.klay.layered.splines.selfLoopPlacement
         requires org.eclipse.elk.edgeRouting == EdgeRouting.SPLINES
     }
-    
+
+    option sloppySplineRouting: boolean {
+        label "Sloppy Spline Routing"
+        description 
+            "Use less spline control points at the start and end of an edge. Might lead to crossings edge/node overlap."
+        default = true
+        targets parents
+        requires org.eclipse.elk.edgeRouting == EdgeRouting.SPLINES
+    }
 }
 
 


### PR DESCRIPTION
The new option reduces the number of spline control points in the spline
edge routing phase. Edge segments connected to normal nodes are routed
on a direct path instead of following the orthogonal edge bend points.
This new option is activated by default.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>