### PR TITLE
layered.splines: Improved layer spacing in sloppy spline routing

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredMetaDataProvider.java
+++ b/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredMetaDataProvider.java
@@ -503,6 +503,20 @@ public class LayeredMetaDataProvider implements ILayoutMetaDataProvider {
             null);
   
   /**
+   * Default value for {@link #EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING}.
+   */
+  private final static float EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING_DEFAULT = 0.4f;
+  
+  /**
+   * Spacing factor for routing area between layers when using sloppy spline routing.
+   */
+  public final static IProperty<Float> EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING = new Property<Float>(
+            "org.eclipse.elk.layered.edgeRouting.sloppySplineLayerSpacing",
+            EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING_DEFAULT,
+            null,
+            null);
+  
+  /**
    * Default value for {@link #SPACING_EDGE_NODE_SPACING_FACTOR}.
    */
   private final static float SPACING_EDGE_NODE_SPACING_FACTOR_DEFAULT = 0.5f;
@@ -715,6 +729,16 @@ public class LayeredMetaDataProvider implements ILayoutMetaDataProvider {
    * Required value for dependency between {@link #EDGE_ROUTING_SLOPPY_SPLINE_ROUTING} and {@link #EDGE_ROUTING}.
    */
   private final static EdgeRouting EDGE_ROUTING_SLOPPY_SPLINE_ROUTING_DEP_EDGE_ROUTING = EdgeRouting.SPLINES;
+  
+  /**
+   * Required value for dependency between {@link #EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING} and {@link #EDGE_ROUTING}.
+   */
+  private final static EdgeRouting EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING_DEP_EDGE_ROUTING = EdgeRouting.SPLINES;
+  
+  /**
+   * Required value for dependency between {@link #EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING} and {@link #EDGE_ROUTING_SLOPPY_SPLINE_ROUTING}.
+   */
+  private final static boolean EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING_DEP_EDGE_ROUTING_SLOPPY_SPLINE_ROUTING = true;
   
   /**
    * Required value for dependency between {@link #COMPACTION_CONNECTED_COMPONENTS} and {@link #SEPARATE_CONNECTED_COMPONENTS}.
@@ -1213,6 +1237,29 @@ public class LayeredMetaDataProvider implements ILayoutMetaDataProvider {
         "org.eclipse.elk.layered.edgeRouting.sloppySplineRouting",
         "org.eclipse.elk.edgeRouting",
         EDGE_ROUTING_SLOPPY_SPLINE_ROUTING_DEP_EDGE_ROUTING
+    );
+    registry.register(new LayoutOptionData(
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineLayerSpacing",
+        "edgeRouting",
+        "Sloppy Spline Layer Spacing Factor",
+        "Spacing factor for routing area between layers when using sloppy spline routing.",
+        EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING_DEFAULT,
+        null,
+        null,
+        LayoutOptionData.Type.FLOAT,
+        Float.class,
+        EnumSet.of(LayoutOptionData.Target.PARENTS),
+        LayoutOptionData.Visibility.VISIBLE
+    ));
+    registry.addDependency(
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineLayerSpacing",
+        "org.eclipse.elk.edgeRouting",
+        EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING_DEP_EDGE_ROUTING
+    );
+    registry.addDependency(
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineLayerSpacing",
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineRouting",
+        EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING_DEP_EDGE_ROUTING_SLOPPY_SPLINE_ROUTING
     );
     registry.register(new LayoutOptionData(
         "org.eclipse.elk.layered.spacing.edgeNodeSpacingFactor",

--- a/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredOptions.java
+++ b/plugins/org.eclipse.elk.alg.layered/src-gen/org/eclipse/elk/alg/layered/properties/LayeredOptions.java
@@ -528,6 +528,11 @@ public class LayeredOptions implements ILayoutMetaDataProvider {
    */
   public final static IProperty<Integer> LAYERING_COFFMAN_GRAHAM_LAYER_BOUND = LayeredMetaDataProvider.LAYERING_COFFMAN_GRAHAM_LAYER_BOUND;
   
+  /**
+   * Property constant to access Sloppy Spline Layer Spacing Factor from within the layout algorithm code.
+   */
+  public final static IProperty<Float> EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING = LayeredMetaDataProvider.EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING;
+  
   public void apply(final ILayoutMetaDataProvider.Registry registry) {
     registry.register(new LayoutAlgorithmData(
         "org.eclipse.elk.layered",
@@ -948,6 +953,11 @@ public class LayeredOptions implements ILayoutMetaDataProvider {
         "org.eclipse.elk.layered",
         "org.eclipse.elk.layered.layering.coffmanGraham.layerBound",
         LAYERING_COFFMAN_GRAHAM_LAYER_BOUND.getDefault()
+    );
+    registry.addOptionSupport(
+        "org.eclipse.elk.layered",
+        "org.eclipse.elk.layered.edgeRouting.sloppySplineLayerSpacing",
+        EDGE_ROUTING_SLOPPY_SPLINE_LAYER_SPACING.getDefault()
     );
   }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.elkm
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.elkm
@@ -129,6 +129,7 @@ algorithm layered(LayeredLayoutProvider) {
     supports edgeCenterLabelPlacementStrategy
     supports org.eclipse.elk.margins
     supports edgeRouting.sloppySplineRouting
+    supports edgeRouting.sloppySplineLayerSpacing
     supports layering.coffmanGraham.layerBound
 }
 
@@ -366,6 +367,15 @@ group edgeRouting {
         default = true
         targets parents
         requires org.eclipse.elk.edgeRouting == EdgeRouting.SPLINES
+    }
+    
+    option sloppySplineLayerSpacing: float {
+        label "Sloppy Spline Layer Spacing Factor"
+        description "Spacing factor for routing area between layers when using sloppy spline routing."
+        default = 0.4f
+        targets parents
+        requires org.eclipse.elk.edgeRouting == EdgeRouting.SPLINES
+        requires sloppySplineRouting == true
     }
 }
 


### PR DESCRIPTION
When using sloppy spline routing some additinoal space between layers
can be desired to produce better curves. The new option introduces a
spacing factor to limit the steepness between layers.
The calculation of the space between layers is adapted from the polyline
routing.

In addition a bug in the spline router is fixed, that caused improper
routing when using bignodes.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>