### PR TITLE
Layered: Fixed handling of FIXED_SIDE with INCLUDE_CHILDREN

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
@@ -144,10 +144,13 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor {
                 if (nestedGraph.getProperty(InternalProperties.GRAPH_PROPERTIES).contains(
                         GraphProperties.EXTERNAL_PORTS)) {
                     
+                    // We need the port constraints to position external ports (Issues KIPRA-1528, ELK-48) 
+                    PortConstraints portConstraints = node.getProperty(LayeredOptions.PORT_CONSTRAINTS);
+                    
                     for (LPort port : node.getPorts()) {
                         if (dummyNodeMap.get(port) == null) {
                             LNode dummyNode = LGraphUtil.createExternalPortDummy(port,
-                                    PortConstraints.FREE, port.getSide(), -port.getNetFlow(),
+                                    portConstraints, port.getSide(), -port.getNetFlow(),
                                     null, null, port.getSize(),
                                     nestedGraph.getProperty(LayeredOptions.DIRECTION), nestedGraph);
                             dummyNode.setProperty(InternalProperties.ORIGIN, port);


### PR DESCRIPTION
Unconnected external ports were potentially placed on wrong sides of the
parent node. (#48)
Passing the parent node port constraints to the new external port dummy.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>