### PR TITLE
elk.layered: Fix hyperedge merging with label dummies

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HyperedgeDummyMerger.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HyperedgeDummyMerger.java
@@ -87,8 +87,8 @@ public final class HyperedgeDummyMerger implements ILayoutProcessor {
                     LPort lastNodeTarget = lastNode.getProperty(InternalProperties.LONG_EDGE_TARGET);
                     
                     // If at least one of the two nodes doesn't have the properties set, skip it
-                    boolean currNodePropertiesSet = currNodeSource != null || currNodeTarget != null;
-                    boolean lastNodePropertiesSet = lastNodeSource != null || lastNodeTarget != null;
+                    boolean currNodePropertiesSet = currNodeSource != null && currNodeTarget != null;
+                    boolean lastNodePropertiesSet = lastNodeSource != null && lastNodeTarget != null;
                     
                     // If the source or the target are identical, merge the current node
                     // into the last


### PR DESCRIPTION
Different Hyperedges were incorrectly merged when there were labels in
both edges. This was caused by allowing merging of edges with null set
as source or target. The change makes the code conform to the comment
that enforces both target and source be not null.

This should fix issue #96 

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>