### PR TITLE
[oomph] Changed GMF dependency to org.eclipse.gmf.sdk.feature.group

### DIFF
--- a/setups/EclipseLayoutKernel.setup
+++ b/setups/EclipseLayoutKernel.setup
@@ -206,9 +206,7 @@
         <requirement
             name="de.itemis.xtext.antlr.sdk.feature.group"/>
         <requirement
-            name="org.eclipse.gmf.feature.group"/>
-        <requirement
-            name="org.eclipse.gmf.tooling.runtime.feature.group"/>
+            name="org.eclipse.gmf.sdk.feature.group"/>
         <requirement
             name="org.eclipse.graphiti.sdk.feature.feature.group"/>
         <sourceLocator


### PR DESCRIPTION
After performing the Oomph setup I had errors in the connector bundles due to missing dependencies in the target platform. I changed the GMF dependency to `org.eclipse.gmf.sdk.feature.group` ("Graphical Modeling Framework (GMF) Tooling SDK") and then it worked. This one includes the Runtime and Notation SDKs.