### PR TITLE
Updated version to 0.2.0-SNAPSHOT

### DIFF
--- a/build/org.eclipse.elk.repository/category.xml
+++ b/build/org.eclipse.elk.repository/category.xml
@@ -4,40 +4,40 @@
    <description name="Eclipse Layout Kernel (Nightly Builds)" url="http://build.eclipse.org/modeling/elk/updates/nightly">
       Nightly build update site for the Eclipse Layout Kernel.
    </description>
-   <feature url="features/org.eclipse.elk_0.1.0.qualifier.jar" id="org.eclipse.elk.feature" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk_0.2.0.qualifier.jar" id="org.eclipse.elk.feature" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.source_0.1.0.qualifier.jar" id="org.eclipse.elk.feature.source" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.source_0.2.0.qualifier.jar" id="org.eclipse.elk.feature.source" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.sdk_0.1.0.qualifier.jar" id="org.eclipse.elk.sdk.feature" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.sdk_0.2.0.qualifier.jar" id="org.eclipse.elk.sdk.feature" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.sdk.source_0.1.0.qualifier.jar" id="org.eclipse.elk.sdk.feature.source" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.sdk.source_0.2.0.qualifier.jar" id="org.eclipse.elk.sdk.feature.source" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.gmf_0.1.0.qualifier.jar" id="org.eclipse.elk.gmf.feature" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.gmf_0.2.0.qualifier.jar" id="org.eclipse.elk.gmf.feature" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.gmf.source_0.1.0.qualifier.jar" id="org.eclipse.elk.gmf.feature.source" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.gmf.source_0.2.0.qualifier.jar" id="org.eclipse.elk.gmf.feature.source" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.graphiti_0.1.0.qualifier.jar" id="org.eclipse.elk.graphiti.feature" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.graphiti_0.2.0.qualifier.jar" id="org.eclipse.elk.graphiti.feature" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.graphiti.source_0.1.0.qualifier.jar" id="org.eclipse.elk.graphiti.feature.source" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.graphiti.source_0.2.0.qualifier.jar" id="org.eclipse.elk.graphiti.feature.source" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.graphviz_0.1.0.qualifier.jar" id="org.eclipse.elk.graphviz.feature" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.graphviz_0.2.0.qualifier.jar" id="org.eclipse.elk.graphviz.feature" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.graphviz.source_0.1.0.qualifier.jar" id="org.eclipse.elk.graphviz.feature.source" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.graphviz.source_0.2.0.qualifier.jar" id="org.eclipse.elk.graphviz.feature.source" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.ui_0.1.0.qualifier.jar" id="org.eclipse.elk.ui.feature" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.ui_0.2.0.qualifier.jar" id="org.eclipse.elk.ui.feature" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
-   <feature url="features/org.eclipse.elk.ui.source_0.1.0.qualifier.jar" id="org.eclipse.elk.ui.feature.source" version="0.1.0.qualifier">
+   <feature url="features/org.eclipse.elk.ui.source_0.2.0.qualifier.jar" id="org.eclipse.elk.ui.feature.source" version="0.2.0.qualifier">
       <category name="elk"/>
    </feature>
    <category-def name="elk" label="Eclipse Layout Kernel">

--- a/build/org.eclipse.elk.repository/pom.xml
+++ b/build/org.eclipse.elk.repository/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <artifactId>org.eclipse.elk.repository</artifactId>
   <packaging>eclipse-repository</packaging>
   <name>Eclipse Layout Kernel Repository</name>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/build/org.eclipse.elk.targetplatform/pom.xml
+++ b/build/org.eclipse.elk.targetplatform/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <artifactId>org.eclipse.elk.targetplatform</artifactId>
   <packaging>eclipse-target-definition</packaging>
   <name>Eclipse Layout Kernel Target Platform</name>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.eclipse.elk</groupId>
   <artifactId>parent</artifactId>
   <name>Eclipse Layout Kernel</name>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
 
@@ -142,7 +142,7 @@
             <artifact>
               <groupId>org.eclipse.elk</groupId>
               <artifactId>org.eclipse.elk.targetplatform</artifactId>
-              <version>0.1.0-SNAPSHOT</version>
+              <version>0.2.0-SNAPSHOT</version>
             </artifact>
           </target>
         </configuration>
@@ -206,12 +206,12 @@
             <dependency>
               <groupId>org.eclipse.elk</groupId>
               <artifactId>org.eclipse.elk.graph</artifactId>
-              <version>0.1.0-SNAPSHOT</version>
+              <version>0.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.elk</groupId>
               <artifactId>org.eclipse.elk.core.meta</artifactId>
-              <version>0.1.0-SNAPSHOT</version>
+              <version>0.2.0-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/features/.project
+++ b/features/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>features</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/features/org.eclipse.elk.feature/feature.xml
+++ b/features/org.eclipse.elk.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.elk.feature"
       label="Eclipse Layout Kernel (Incubation) - Core Components"
-      version="0.1.0.qualifier"
+      version="0.2.0.qualifier"
       provider-name="Eclipse Layout Kernel"
       plugin="org.eclipse.elk.core">
 

--- a/features/org.eclipse.elk.feature/pom.xml
+++ b/features/org.eclipse.elk.feature/pom.xml
@@ -15,10 +15,10 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.feature</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.gmf.feature/feature.xml
+++ b/features/org.eclipse.elk.gmf.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.elk.gmf.feature"
       label="Eclipse Layout Kernel (Incubation) - GMF Support"
-      version="0.1.0.qualifier"
+      version="0.2.0.qualifier"
       provider-name="Eclipse Layout Kernel"
       plugin="org.eclipse.elk.core">
 

--- a/features/org.eclipse.elk.gmf.feature/pom.xml
+++ b/features/org.eclipse.elk.gmf.feature/pom.xml
@@ -15,10 +15,10 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.gmf.feature</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.graphiti.feature/feature.xml
+++ b/features/org.eclipse.elk.graphiti.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.elk.graphiti.feature"
       label="Eclipse Layout Kernel (Incubation) - Graphiti Support"
-      version="0.1.0.qualifier"
+      version="0.2.0.qualifier"
       provider-name="Eclipse Layout Kernel"
       plugin="org.eclipse.elk.core">
 
@@ -45,7 +45,7 @@ http://www.eclipse.org/legal/epl-v10.html.
       <import plugin="org.eclipse.ui.ide" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.views.properties.tabbed" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="com.google.guava" version="15.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.elk.feature" version="0.1.0.qualifier"/>
+      <import feature="org.eclipse.elk.feature" version="0.2.0.qualifier"/>
    </requires>
 
    <plugin

--- a/features/org.eclipse.elk.graphiti.feature/pom.xml
+++ b/features/org.eclipse.elk.graphiti.feature/pom.xml
@@ -15,10 +15,10 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graphiti.feature</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.graphviz.feature/feature.xml
+++ b/features/org.eclipse.elk.graphviz.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.elk.graphviz.feature"
       label="Eclipse Layout Kernel (Incubation) - Graphviz Library Support"
-      version="0.1.0.qualifier"
+      version="0.2.0.qualifier"
       provider-name="Eclipse Layout Kernel"
       plugin="org.eclipse.elk.core">
 
@@ -45,7 +45,7 @@ http://www.eclipse.org/legal/epl-v10.html.
       <import plugin="org.antlr.runtime"/>
       <import plugin="org.eclipse.core.runtime" version="3.6.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.ecore" version="2.5.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.elk.feature" version="0.1.0.qualifier"/>
+      <import feature="org.eclipse.elk.feature" version="0.2.0.qualifier"/>
    </requires>
 
    <plugin

--- a/features/org.eclipse.elk.graphviz.feature/pom.xml
+++ b/features/org.eclipse.elk.graphviz.feature/pom.xml
@@ -15,10 +15,10 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graphviz.feature</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.sdk.feature/feature.xml
+++ b/features/org.eclipse.elk.sdk.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.elk.sdk.feature"
       label="Eclipse Layout Kernel (Incubation) - SDK"
-      version="0.1.0.qualifier"
+      version="0.2.0.qualifier"
       provider-name="Eclipse Layout Kernel"
       plugin="org.eclipse.elk.core">
 

--- a/features/org.eclipse.elk.sdk.feature/pom.xml
+++ b/features/org.eclipse.elk.sdk.feature/pom.xml
@@ -16,11 +16,11 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.sdk.feature</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.ui.feature/feature.xml
+++ b/features/org.eclipse.elk.ui.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.elk.ui.feature"
       label="Eclipse Layout Kernel (Incubation) - UI Components"
-      version="0.1.0.qualifier"
+      version="0.2.0.qualifier"
       provider-name="Eclipse Layout Kernel"
       plugin="org.eclipse.elk.core">
 
@@ -45,7 +45,7 @@ http://www.eclipse.org/legal/epl-v10.html.
       <import plugin="org.eclipse.emf.ecore.xmi" version="2.9.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.transaction" version="1.3.0" match="greaterOrEqual"/>
       <import plugin="com.google.guava" version="15.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.elk.feature" version="0.1.0.qualifier"/>
+      <import feature="org.eclipse.elk.feature" version="0.2.0.qualifier"/>
    </requires>
 
    <plugin

--- a/features/org.eclipse.elk.ui.feature/pom.xml
+++ b/features/org.eclipse.elk.ui.feature/pom.xml
@@ -15,10 +15,10 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.ui.feature</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>features</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../build/pom.xml</relativePath>
   </parent>
 

--- a/plugins/org.eclipse.elk.alg.force/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.force/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Force Layout Algorithm
 Bundle-SymbolicName: org.eclipse.elk.alg.force;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava;bundle-version="15.0.0",

--- a/plugins/org.eclipse.elk.alg.force/pom.xml
+++ b/plugins/org.eclipse.elk.alg.force/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.force</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Graphviz Dot Language Parser
 Bundle-Vendor: Eclipse Modeling Project
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-SymbolicName: org.eclipse.elk.alg.graphviz.dot;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.9.0",

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/pom.xml
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.graphviz.dot</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layout Bridge for Graphviz
 Bundle-SymbolicName: org.eclipse.elk.alg.graphviz.layouter;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.eclipse.elk.alg.graphviz.layouter.GraphvizLayouterPlugin
 Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.core.runtime,

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/pom.xml
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.graphviz.layouter</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.alg.layered/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.layered/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layered Layout Algorithm
 Bundle-SymbolicName: org.eclipse.elk.alg.layered;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava;bundle-version="15.0.0",

--- a/plugins/org.eclipse.elk.alg.layered/pom.xml
+++ b/plugins/org.eclipse.elk.alg.layered/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.layered</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.alg.mrtree/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.mrtree/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Mr. Tree Layout Algorithm
 Bundle-SymbolicName: org.eclipse.elk.alg.mrtree;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.elk.graph,

--- a/plugins/org.eclipse.elk.alg.mrtree/pom.xml
+++ b/plugins/org.eclipse.elk.alg.mrtree/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.mrtree</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.conn.gmf/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.conn.gmf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layout Connector for GMF
 Bundle-SymbolicName: org.eclipse.elk.conn.gmf;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.elk.conn.gmf

--- a/plugins/org.eclipse.elk.conn.gmf/pom.xml
+++ b/plugins/org.eclipse.elk.conn.gmf/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.conn.gmf</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.conn.graphiti/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.conn.graphiti/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layout Connector for Graphiti
 Bundle-SymbolicName: org.eclipse.elk.conn.graphiti;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.graphiti;bundle-version="0.8.1",

--- a/plugins/org.eclipse.elk.conn.graphiti/pom.xml
+++ b/plugins/org.eclipse.elk.conn.graphiti/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.conn.graphiti</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.eclipse.elk.core.debug/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Debugging Utilities
 Bundle-SymbolicName: org.eclipse.elk.core.debug;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.eclipse.elk.core.debug.ElkDebugPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.eclipse.elk.core.debug/pom.xml
+++ b/plugins/org.eclipse.elk.core.debug/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.debug</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.eclipse.elk.core.meta.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.meta.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layout Meta Data Language (UI Components)
 Bundle-Vendor: Eclipse Modeling Project
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-SymbolicName: org.eclipse.elk.core.meta.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.elk.core.meta,

--- a/plugins/org.eclipse.elk.core.meta.ui/pom.xml
+++ b/plugins/org.eclipse.elk.core.meta.ui/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.meta.ui</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.meta/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.meta/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layout Meta Data Language
 Bundle-Vendor: Eclipse Modeling Project
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-SymbolicName: org.eclipse.elk.core.meta; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.9.0",

--- a/plugins/org.eclipse.elk.core.meta/pom.xml
+++ b/plugins/org.eclipse.elk.core.meta/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.meta</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.service/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.service/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layout Service Layer
 Bundle-SymbolicName: org.eclipse.elk.core.service;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava;bundle-version="15.0.0",
  com.google.inject;bundle-version="3.0.0";visibility:=reexport,

--- a/plugins/org.eclipse.elk.core.service/pom.xml
+++ b/plugins/org.eclipse.elk.core.service/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.service</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.eclipse.elk.core.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Core Components (UI)
 Bundle-SymbolicName: org.eclipse.elk.core.ui;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Activator: org.eclipse.elk.core.ui.ElkUiPlugin
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.elk.core.ui/pom.xml
+++ b/plugins/org.eclipse.elk.core.ui/pom.xml
@@ -15,11 +15,11 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.ui</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.eclipse.elk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Core Components
 Bundle-SymbolicName: org.eclipse.elk.core;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Eclipse-BuddyPolicy: registered
 Require-Bundle: com.google.guava;bundle-version="15.0.0",
  org.eclipse.emf.ecore,

--- a/plugins/org.eclipse.elk.core/pom.xml
+++ b/plugins/org.eclipse.elk.core/pom.xml
@@ -15,13 +15,13 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.graph.text.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph.text.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Textual Graph Format Generic IDE Services
 Bundle-Vendor: Eclipse Modeling Project
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-SymbolicName: org.eclipse.elk.graph.text.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.elk.graph.text,

--- a/plugins/org.eclipse.elk.graph.text.ide/pom.xml
+++ b/plugins/org.eclipse.elk.graph.text.ide/pom.xml
@@ -15,11 +15,11 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.text.ide</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.eclipse.elk.graph.text.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph.text.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Textual Graph Format UI
 Bundle-Vendor: Eclipse Modeling Project
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-SymbolicName: org.eclipse.elk.graph.text.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.elk.core,

--- a/plugins/org.eclipse.elk.graph.text.ui/pom.xml
+++ b/plugins/org.eclipse.elk.graph.text.ui/pom.xml
@@ -15,11 +15,11 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.text.ui</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.eclipse.elk.graph.text/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Textual Graph Format
 Bundle-Vendor: Eclipse Modeling Project
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-SymbolicName: org.eclipse.elk.graph.text; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.elk.core,

--- a/plugins/org.eclipse.elk.graph.text/pom.xml
+++ b/plugins/org.eclipse.elk.graph.text/pom.xml
@@ -15,11 +15,11 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.text</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.eclipse.elk.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Graph Model
 Bundle-SymbolicName: org.eclipse.elk.graph;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse Modeling Project
 Export-Package: org.eclipse.elk.graph,

--- a/plugins/org.eclipse.elk.graph/pom.xml
+++ b/plugins/org.eclipse.elk.graph/pom.xml
@@ -15,11 +15,11 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>plugins</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../build/pom.xml</relativePath>
   </parent>
 

--- a/test/.project
+++ b/test/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/test/org.eclipse.elk.alg.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Layout Algorithm Tests
 Bundle-SymbolicName: org.eclipse.elk.alg.test;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava;bundle-version="15.0.0",
  org.eclipse.elk.core,

--- a/test/org.eclipse.elk.alg.test/pom.xml
+++ b/test/org.eclipse.elk.alg.test/pom.xml
@@ -15,10 +15,10 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.test</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/test/org.eclipse.elk.graph.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.graph.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ELK Graph Model Tests
 Bundle-SymbolicName: org.eclipse.elk.graph.test;singleton:=true
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava;bundle-version="15.0.0",

--- a/test/org.eclipse.elk.graph.test/pom.xml
+++ b/test/org.eclipse.elk.graph.test/pom.xml
@@ -15,10 +15,10 @@
   <parent>
     <groupId>org.eclipse.elk</groupId>
     <artifactId>plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.test</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>


### PR DESCRIPTION
The current nightly builds are snapshots of the upcoming version 0.2.0, so we should update the versions accordingly. Next time we should do this version upgrade right after the release.