### PR TITLE
layoutview: Changed layout option collection from lists to set

### DIFF
--- a/plugins/org.eclipse.elk.core.service/src/org/eclipse/elk/core/service/LayoutConfigurationManager.java
+++ b/plugins/org.eclipse.elk.core.service/src/org/eclipse/elk/core/service/LayoutConfigurationManager.java
@@ -11,8 +11,7 @@
 package org.eclipse.elk.core.service;
 
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.elk.core.IGraphLayoutEngine;
@@ -68,10 +67,10 @@ public class LayoutConfigurationManager {
      * @param config a layout configuration store associated to a graph element
      * @return a list of supported options
      */
-    public List<LayoutOptionData> getSupportedOptions(final ILayoutConfigurationStore config) {
+    public Set<LayoutOptionData> getSupportedOptions(final ILayoutConfigurationStore config) {
         LayoutMetaDataService layoutDataService = LayoutMetaDataService.getInstance();
         
-        List<LayoutOptionData> optionData = new LinkedList<LayoutOptionData>();
+        Set<LayoutOptionData> optionData = new LinkedHashSet<LayoutOptionData>();
         Set<LayoutOptionData.Target> optionTargets = config.getOptionTargets();
         if (optionTargets.contains(LayoutOptionData.Target.PARENTS)) {
             LayoutAlgorithmData algoData = getAlgorithm(config);

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertySource.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertySource.java
@@ -13,7 +13,6 @@ package org.eclipse.elk.core.ui.views;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 
 import org.eclipse.elk.core.GraphIssue;
@@ -90,16 +89,15 @@ public class LayoutPropertySource implements IPropertySource {
      */
     public IPropertyDescriptor[] getPropertyDescriptors() {
         if (propertyDescriptors == null) {
-            List<LayoutOptionData> optionData = configManager.getSupportedOptions(layoutConfig);
+            Set<LayoutOptionData> optionData = configManager.getSupportedOptions(layoutConfig);
             
             // Filter the options hidden by visibility settings and option dependencies
             filterOptions(optionData);
             
             propertyDescriptors = new IPropertyDescriptor[optionData.size()];
-            ListIterator<LayoutOptionData> optionIter = optionData.listIterator();
-            while (optionIter.hasNext()) {
-                LayoutOptionData data = optionIter.next();
-                propertyDescriptors[optionIter.previousIndex()] = createPropertyDescriptor(data);
+            Iterator<LayoutOptionData> optionIter = optionData.iterator();
+            for (int i = 0; i < propertyDescriptors.length; ++i) {
+                propertyDescriptors[i] = createPropertyDescriptor(optionIter.next());
             }
         }
         return propertyDescriptors;
@@ -122,11 +120,11 @@ public class LayoutPropertySource implements IPropertySource {
      * 
      * @param optionData a list of option meta data
      */
-    protected void filterOptions(final List<LayoutOptionData> optionData) {
+    protected void filterOptions(final Set<LayoutOptionData> optionData) {
         // the layout algorithm option always affects other options
         dependencyOptions.add(CoreOptions.ALGORITHM.getId());
         
-        ListIterator<LayoutOptionData> optionIter = optionData.listIterator();
+        Iterator<LayoutOptionData> optionIter = optionData.iterator();
         while (optionIter.hasNext()) {
             LayoutOptionData option = optionIter.next();
             boolean visible = option.getVisibility() != LayoutOptionData.Visibility.HIDDEN;


### PR DESCRIPTION
The layout view created ArrayIndexOutOfBoundsExceptions when changing
the selection in diagrams. This was caused by us creating a list of all
available layout options and therefore creating duplicate entries when
multiple targets were allowed. The PropertyView uses sets for the
properties and was creating the exceptions.
This change gets rid of the lists and uses a set instead to prepare the
layout options for the property view.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>