### PR TITLE
elk.box: Correct handling of padding

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/BoxLayoutProvider.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/BoxLayoutProvider.java
@@ -194,9 +194,7 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
                 expandNodes, aspectRatio);
 
         // adjust parent size
-        double width = padding.getLeft() + (float) parentSize.x + padding.getRight();
-        double height = padding.getTop() + (float) parentSize.y + padding.getBottom();
-        ElkUtil.resizeNode(parentNode, width, height, false, true);
+        ElkUtil.resizeNode(parentNode, parentSize.x, parentSize.y, false, true);
     }
 
     /**
@@ -367,14 +365,8 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
         KVector parentSize = placeInnerBoxes(finalGroup, objSpacing, padding, minSize.x, minSize.y,
                 expandNodes, aspectRatio);
 
-        // account for border spacing
-        finalGroup.translate(padding.getLeft(), padding.getTop());
-        parentSize.add(padding.getHorizontal(), padding.getVertical());
-        
         // adjust parent size
-        double width = padding.getLeft() + parentSize.x + padding.getRight();
-        double height = padding.getTop() + parentSize.y + padding.getBottom();
-        ElkUtil.resizeNode(parentNode, width, height, false, true);
+        ElkUtil.resizeNode(parentNode, parentSize.x, parentSize.y, false, true);
     }
     
     /**


### PR DESCRIPTION
In normal mode the BoxLayouter used to duplicate all paddings when
resizing the parent node. This lead to excessive space at the right and
bottom.
The other modes tripled the paddings and placed the child nodes at
double the needed spacing. 

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>