### PR TITLE
layered.transform: Fixed broken handling of minimal size

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/GraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/GraphTransformer.java
@@ -761,7 +761,7 @@ public final class GraphTransformer implements ILayoutProcessor {
     private void transposeProperties(final LNode node) {
         // Transpose MIN_HEIGHT and MIN_WIDTH
         KVector minSize = node.getProperty(LayeredOptions.NODE_SIZE_MINIMUM);
-        node.setProperty(LayeredOptions.NODE_SIZE_MINIMUM, minSize.clone());
+        node.setProperty(LayeredOptions.NODE_SIZE_MINIMUM, new KVector(minSize.y, minSize.x));
         
         // Transpose ALIGNMENT
         switch (node.getProperty(LayeredOptions.ALIGNMENT)) {


### PR DESCRIPTION
When layouting down or up and setting a minimal node size, the minimum
node size was not properly transposed, leading to broken layouts.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>