### PR TITLE
elk.layered: Fixed end label processing

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
@@ -155,6 +155,8 @@ public enum IntermediateProcessorStrategy {
     HORIZONTAL_COMPACTOR,
     /** Takes the reversed edges of a graph and restores their original direction. */
     REVERSED_EDGE_RESTORER,
+    /** Place end labels on edges. */
+    END_LABEL_PROCESSOR,
     /** In hierarchical graphs, maps a child graph to its parent node. */
     HIERARCHICAL_NODE_RESIZER,
     /** Mirrors the graph to perform a right-to-left drawing. */
@@ -162,9 +164,7 @@ public enum IntermediateProcessorStrategy {
     /** Transposes the graph to perform a top-bottom drawing. */
     DOWN_DIR_POSTPROCESSOR,
     /** Mirrors and transposes the graph to perform a bottom-up drawing. */
-    UP_DIR_POSTPROCESSOR,
-    /** Place end labels on edges. */
-    END_LABEL_PROCESSOR;
+    UP_DIR_POSTPROCESSOR;
 
     /**
      * Creates an instance of the layout processor described by this instance.


### PR DESCRIPTION
The processing of end labels was not working due to the graph not being
layered anymore after the HierarchicalNodeResizeProcessor. The change
schedules the EndLabelProcessor before the HierarchicalNodeResizeProcessor.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>