### PR TITLE
Site: Fixed incubation link

### DIFF
--- a/docs/layouts/partials/nav.html
+++ b/docs/layouts/partials/nav.html
@@ -9,7 +9,7 @@
   </ul>
 
   <div class="incubation-egg">
-    <a href="/projects/what-is-incubation.php">
+    <a href="https://www.eclipse.org/projects/what-is-incubation.php">
       <img src="https://www.eclipse.org/images/egg-incubation.png" alt="Incubation" />
     </a>
   </div>


### PR DESCRIPTION
The relative link caused a 404 because there was an extra /elk/ in the url.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>