### PR TITLE
core.layoutEngine: Offset Inside Self Loop Junction Points

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
@@ -373,6 +373,9 @@ public class RecursiveGraphLayoutEngine implements IGraphLayoutEngine {
             for (final ElkBendPoint bend : section.getBendPoints()) {
                 bend.set(bend.getX() + xOffset, bend.getY() + yOffset);
             }
+            
+            // Offset junction points by the node position
+            selfLoop.getProperty(CoreOptions.JUNCTION_POINTS).offset(xOffset, yOffset);
         }
     }
 


### PR DESCRIPTION
The junction points of inside self loops need to be properly offset.
Fixes #168 

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>