### PR TITLE
setup: Reverted version dependencies of old release streams

### DIFF
--- a/setups/EclipseLayoutKernel.setup
+++ b/setups/EclipseLayoutKernel.setup
@@ -395,7 +395,7 @@
             name="org.eclipse.emf.sdk.feature.group"/>
         <requirement
             name="org.eclipse.xtext.sdk.feature.group"
-            versionRange="[2.12.0,2.13.0)"/>
+            versionRange="[2.10.0,2.11.0)"/>
         <requirement
             name="de.itemis.xtext.antlr.sdk.feature.group"/>
         <requirement
@@ -485,7 +485,7 @@
             name="org.eclipse.emf.sdk.feature.group"/>
         <requirement
             name="org.eclipse.xtext.sdk.feature.group"
-            versionRange="[2.12.0,2.13.0)"/>
+            versionRange="[2.10.0,2.11.0)"/>
         <requirement
             name="de.itemis.xtext.antlr.sdk.feature.group"/>
         <requirement
@@ -575,7 +575,7 @@
             name="org.eclipse.emf.sdk.feature.group"/>
         <requirement
             name="org.eclipse.xtext.sdk.feature.group"
-            versionRange="[2.12.0,2.13.0)"/>
+            versionRange="[2.10.0,2.11.0)"/>
         <requirement
             name="de.itemis.xtext.antlr.sdk.feature.group"/>
         <requirement


### PR DESCRIPTION
The recent change to the required xtext version (#183) also incremented
the versions for already released version streams. This is probably not
a good idea.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>