### PR TITLE
mrtree: Removed usage of deprecated Iterators.emptyIterator()

### DIFF
--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeUtil.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeUtil.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree;
 
+import java.util.Collections;
 import java.util.Iterator;
 
 import org.eclipse.elk.alg.mrtree.graph.TNode;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 
 /**
  * Utility class for KLay Tree.
@@ -66,7 +66,7 @@ public final class TreeUtil {
                 Iterable<TNode> nextLevel = new Iterable<TNode>() {
 
                     public Iterator<TNode> iterator() {
-                        return Iterators.emptyIterator();
+                        return Collections.emptyIterator();
                     }
                 };
 
@@ -83,7 +83,7 @@ public final class TreeUtil {
                 Iterable<TNode> nextLevel = new Iterable<TNode>() {
 
                     public Iterator<TNode> iterator() {
-                        return Iterators.emptyIterator();
+                        return Collections.emptyIterator();
                     }
                 };
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelHeightProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelHeightProcessor.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree.intermediate;
 
+import java.util.Collections;
 import java.util.Iterator;
 
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
@@ -19,7 +20,6 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 /**
@@ -87,7 +87,7 @@ public class LevelHeightProcessor implements ILayoutProcessor<TGraph> {
             Iterable<TNode> nextLevel = new Iterable<TNode>() {
 
                 public Iterator<TNode> iterator() {
-                    return Iterators.emptyIterator();
+                    return Collections.emptyIterator();
                 }
             };
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NeighborsProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NeighborsProcessor.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree.intermediate;
 
+import java.util.Collections;
 import java.util.Iterator;
 
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
@@ -19,7 +20,6 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 
 /**
  * A processor which determine the neighbors and siblings for all nodes in the graph. A neighbor is
@@ -87,7 +87,7 @@ public class NeighborsProcessor implements ILayoutProcessor<TGraph> {
             Iterable<TNode> nextLevel = new Iterable<TNode>() {
 
                 public Iterator<TNode> iterator() {
-                    return Iterators.emptyIterator();
+                    return Collections.emptyIterator();
                 }
             };
 


### PR DESCRIPTION
Guava deprecated (and removed) the method emptyIterator().
Instead Collections.emptyIterator() should be used.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>