### PR TITLE
Graph: Graph converter now fixes invalid characters. #197

### DIFF
--- a/plugins/org.eclipse.elk.graph.text.ui/src/org/eclipse/elk/graph/text/ui/ConvertGraphHandler.java
+++ b/plugins/org.eclipse.elk.graph.text.ui/src/org/eclipse/elk/graph/text/ui/ConvertGraphHandler.java
@@ -150,6 +150,7 @@ public class ConvertGraphHandler extends AbstractHandler {
         if (targetExtension.equals(EXT_ELK_TEXT) && copy instanceof ElkNode) {
             // we want to convert to the textual format, so write missing identifiers into the graph
             GraphIdentifierGenerator.forGraph((ElkNode) copy)
+                .assertValid()
                 .assertExists()
                 .assertUnique()
                 .execute();

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/GraphIdentifierGenerator.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/GraphIdentifierGenerator.java
@@ -152,10 +152,10 @@ public final class GraphIdentifierGenerator {
             public Object caseElkNode(final ElkNode node) {
                 validateIdentifier(node);
                 
-                node.getLabels().stream().forEach(l -> generateIdentifiers(l));
-                node.getPorts().stream().forEach(p -> generateIdentifiers(p));
-                node.getContainedEdges().stream().forEach(e -> generateIdentifiers(e));
-                node.getChildren().stream().forEach(c -> generateIdentifiers(c));
+                node.getLabels().stream().forEach(l -> validateIdentifier(l));
+                node.getPorts().stream().forEach(p -> validateIdentifier(p));
+                node.getContainedEdges().stream().forEach(e -> validateIdentifier(e));
+                node.getChildren().stream().forEach(c -> validateIdentifier(c));
                 return null;
             }
             
@@ -163,7 +163,7 @@ public final class GraphIdentifierGenerator {
             public Object caseElkPort(final ElkPort port) {
                 validateIdentifier(port);
                 
-                port.getLabels().stream().forEach(l -> generateIdentifiers(l));
+                port.getLabels().stream().forEach(l -> validateIdentifier(l));
                 return null;
             }
             
@@ -171,7 +171,7 @@ public final class GraphIdentifierGenerator {
             public Object caseElkLabel(final ElkLabel label) {
                 validateIdentifier(label);
                 
-                label.getLabels().stream().forEach(l -> generateIdentifiers(l));
+                label.getLabels().stream().forEach(l -> validateIdentifier(l));
                 return null;
             }
             
@@ -179,8 +179,8 @@ public final class GraphIdentifierGenerator {
             public Object caseElkEdge(final ElkEdge edge) {
                 validateIdentifier(edge);
                 
-                edge.getLabels().stream().forEach(l -> generateIdentifiers(l));
-                edge.getSections().stream().forEach(s -> generateIdentifiers(s));
+                edge.getLabels().stream().forEach(l -> validateIdentifier(l));
+                edge.getSections().stream().forEach(s -> validateIdentifier(s));
                 return null;
             }
             


### PR DESCRIPTION
Previously, a graph could be converted into ELKT format with graph element identifiers that did not comply to ELKT's ID rule. Now, these identifiers can be automatically fixed.