### PR TITLE
Explicitly list opposite references that must not be cleared in ElkGraph linker

### DIFF
--- a/plugins/org.eclipse.elk.graph.text/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph.text/META-INF/MANIFEST.MF
@@ -16,12 +16,13 @@ Require-Bundle: org.eclipse.elk.core,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.elk.graph.text,
  org.eclipse.elk.graph.text.conversion,
+ org.eclipse.elk.graph.text.formatting2,
+ org.eclipse.elk.graph.text.linking,
  org.eclipse.elk.graph.text.naming,
  org.eclipse.elk.graph.text.parser.antlr,
  org.eclipse.elk.graph.text.parser.antlr.internal,
  org.eclipse.elk.graph.text.scoping,
  org.eclipse.elk.graph.text.serializer,
  org.eclipse.elk.graph.text.services,
- org.eclipse.elk.graph.text.validation,
- org.eclipse.elk.graph.text.formatting2
+ org.eclipse.elk.graph.text.validation
 Import-Package: org.apache.log4j

--- a/plugins/org.eclipse.elk.graph.text/src/org/eclipse/elk/graph/text/ElkGraphRuntimeModule.xtend
+++ b/plugins/org.eclipse.elk.graph.text/src/org/eclipse/elk/graph/text/ElkGraphRuntimeModule.xtend
@@ -8,12 +8,10 @@
 package org.eclipse.elk.graph.text
 
 import org.eclipse.elk.graph.text.conversion.ElkGraphValueConverterService
+import org.eclipse.elk.graph.text.linking.ElkGraphLinker
 import org.eclipse.elk.graph.text.naming.ElkGraphQualifiedNameConverter
 import org.eclipse.elk.graph.text.naming.ElkGraphQualifiedNameProvider
 import org.eclipse.elk.graph.text.serializer.ElkGraphTransientValueService
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.emf.ecore.EReference
-import org.eclipse.xtext.linking.impl.Linker
 import org.eclipse.xtext.naming.IQualifiedNameConverter
 import org.eclipse.xtext.serializer.sequencer.ITransientValueService
 
@@ -39,15 +37,7 @@ class ElkGraphRuntimeModule extends AbstractElkGraphRuntimeModule {
     }
     
     override bindILinker() {
-        MyLinker
-    }
-    
-    static class MyLinker extends Linker {
-        override protected clearReference(EObject obj, EReference ref) {
-            // fix for #170, where otherwise eOpposites aren't loaded properly in elkt files
-            if (ref.EOpposite === null)
-                super.clearReference(obj, ref)
-        }
+        ElkGraphLinker
     }
     
 }

--- a/plugins/org.eclipse.elk.graph.text/src/org/eclipse/elk/graph/text/linking/ElkGraphLinker.xtend
+++ b/plugins/org.eclipse.elk.graph.text/src/org/eclipse/elk/graph/text/linking/ElkGraphLinker.xtend
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.elk.graph.text.linking
+
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.EReference
+import org.eclipse.xtext.linking.impl.Linker
+
+import static org.eclipse.elk.graph.ElkGraphPackage.Literals.*
+
+/**
+ * Cross-reference linker for the ElkGraph language.
+ */
+class ElkGraphLinker extends Linker {
+    
+    // Set of opposite references that are _not_ considered by the ElkGraph text syntax
+    static val OPPOSITE_REFS = #{
+        ELK_CONNECTABLE_SHAPE__INCOMING_EDGES, ELK_CONNECTABLE_SHAPE__OUTGOING_EDGES,
+        ELK_EDGE_SECTION__INCOMING_SECTIONS
+    }
+    
+    override protected clearReference(EObject obj, EReference ref) {
+        // Fix for #170, where otherwise eOpposites aren't loaded properly in elkt files
+        if (!OPPOSITE_REFS.contains(ref))
+            super.clearReference(obj, ref)
+    }
+
+}

--- a/plugins/org.eclipse.elk.graph.text/src/org/eclipse/elk/graph/text/validation/ElkGraphValidator.xtend
+++ b/plugins/org.eclipse.elk.graph.text/src/org/eclipse/elk/graph/text/validation/ElkGraphValidator.xtend
@@ -34,7 +34,7 @@ import static extension org.eclipse.elk.graph.text.ElkGraphTextUtil.*
 import static extension org.eclipse.xtext.EcoreUtil2.*
 
 /**
- * Custom validation rules for the ElkGraph language. 
+ * Custom validation rules for the ElkGraph language.
  */
 class ElkGraphValidator extends AbstractElkGraphValidator {
     


### PR DESCRIPTION
This is an alternative solution for #170. I expect this one to cause fewer follow-up problems compared to the original solution.

@uruuru could you check whether the parsed models are properly linked with this change?