### PR TITLE
remove version restriction on Google Guava

### DIFF
--- a/test/org.eclipse.elk.alg.spore.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.spore.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.elk.alg.spore.test;singleton:=true
 Bundle-Version: 0.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Modeling Project
-Require-Bundle: com.google.guava;bundle-version="[18.0.0,19.0.0)",
+Require-Bundle: com.google.guava;bundle-version="18.0.0",
  org.eclipse.elk.core;bundle-version="0.4.0",
  org.eclipse.elk.graph;bundle-version="0.4.0",
  org.eclipse.elk.alg.common;bundle-version="0.4.0",


### PR DESCRIPTION
All the other bundles use only a minimum version restriction for Guava.
Let's do it similarly in this bundle to avoid version conflicts when
upgrading to a target that contains only Guava 21.

I got a compile error here when using a custom target platform which does not contain Guava 18 anymore.

Signed-off-by: Michael Keppler <Michael.Keppler@gmx.de>