### PR TITLE
conn.gmf: Fix to allow Papyrus' MultidiagramEditors

### DIFF
--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfDiagramLayoutConnector.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfDiagramLayoutConnector.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.draw2d.Animation;
 import org.eclipse.draw2d.Connection;
 import org.eclipse.draw2d.ConnectionLocator;
@@ -172,6 +173,8 @@ public class GmfDiagramLayoutConnector implements IDiagramLayoutConnector {
     protected DiagramEditor getDiagramEditor(final IWorkbenchPart workbenchPart) {
         if (workbenchPart instanceof DiagramEditor) {
             return (DiagramEditor) workbenchPart;
+        } else if (workbenchPart instanceof IAdaptable) {
+        	return ((IAdaptable) workbenchPart).getAdapter(DiagramEditor.class);
         }
         return null;
     }

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutSetup.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutSetup.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.conn.gmf;
 
 import java.util.Collection;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.elk.core.service.IDiagramLayoutConnector;
 import org.eclipse.elk.core.service.ILayoutConfigurationStore;
 import org.eclipse.elk.core.service.ILayoutSetup;
@@ -43,7 +44,8 @@ public class GmfLayoutSetup implements ILayoutSetup {
             }
             return false;
         }
-        return object instanceof DiagramEditor || object instanceof IGraphicalEditPart;
+        return object instanceof DiagramEditor || object instanceof IGraphicalEditPart
+                || object instanceof IAdaptable && ((IAdaptable) object).getAdapter(DiagramEditor.class) != null;
     }
     
     /**


### PR DESCRIPTION
- Added a verification to know if the manipulated editor is IAdaptable and get its associated DiagramEditor if any

Signed-off-by: Quentin Le Menez <quentin.lemenez@cea.fr>