### PR TITLE
alg.layered: Implemented predicates for NorthSouth and LongEdge Dummies

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/DotDebugUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/DotDebugUtil.java
@@ -205,7 +205,7 @@ public final class DotDebugUtil {
                 } else {
                     options.append("n_" + node.id + " ");
                 }
-                if (node.getType() == NodeType.NORTH_SOUTH_PORT) {
+                if (node.getType().isNorthSouthDummy()) {
                     Object origin = node.getProperty(InternalProperties.ORIGIN);
                     if (origin instanceof LNode) {
                         options.append("(" + ((LNode) origin).toString() + ")");

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/JsonDebugUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/JsonDebugUtil.java
@@ -693,7 +693,7 @@ public final class JsonDebugUtil {
             } else {
                 name = "n_" + node.id;
             }
-            if (node.getType() == NodeType.NORTH_SOUTH_PORT) {
+            if (node.getType().isNorthSouthDummy()) {
                 Object origin = node.getProperty(InternalProperties.ORIGIN);
                 if (origin instanceof LNode) {
                     name += "(" + ((LNode) origin).toString() + ")";

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphAdapters.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphAdapters.java
@@ -560,7 +560,7 @@ public final class LGraphAdapters {
          * {@inheritDoc}
          */
         public Iterable<EdgeAdapter<?>> getIncomingEdges() {
-            if (transparentNorthSouthEdges && element.getNode().getType() == NodeType.NORTH_SOUTH_PORT) {
+            if (transparentNorthSouthEdges && element.getNode().getType().isNorthSouthDummy()) {
                 return Collections.emptyList();
             } else if (incomingEdgeAdapters == null) {
                 incomingEdgeAdapters = Lists.newArrayList();
@@ -583,7 +583,7 @@ public final class LGraphAdapters {
          * {@inheritDoc}
          */
         public Iterable<EdgeAdapter<?>> getOutgoingEdges() {
-            if (transparentNorthSouthEdges && element.getNode().getType() == NodeType.NORTH_SOUTH_PORT) {
+            if (transparentNorthSouthEdges && element.getNode().getType().isNorthSouthDummy()) {
                 return Collections.emptyList();
             } else if (outgoingEdgeAdapters == null) {
                 outgoingEdgeAdapters = Lists.newArrayList();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
@@ -80,6 +80,23 @@ public final class LNode extends LShape {
             }
         }
 
+        public boolean isNorthSouthDummy() {
+            switch (this) {
+            case NORTH_SOUTH_PORT:
+                return true;
+            default:
+                return false;
+            }
+        }
+        
+        public boolean isLongEdgeDummy() {
+            switch (this) {
+            case LONG_EDGE:
+                return true;
+            default:
+                return false;
+            }
+        }
     }
     
     /** the serial version UID. */

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesSplitter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesSplitter.java
@@ -269,7 +269,7 @@ public class BigNodesSplitter implements ILayoutProcessor<LGraph> {
         // either exactly one incoming edge that originates from a long edge dummy
         if (Iterables.size(westwardEdges) == 1) {
             LNode source = Iterables.get(westwardEdges, 0).getSource().getNode();
-            if (source.getType() == NodeType.LONG_EDGE
+            if (source.getType().isLongEdgeDummy()
             // and the long edge dummy does not represent a self loop
                     && !source.getProperty(InternalProperties.LONG_EDGE_SOURCE).getNode()
                             .equals(node.node)) {
@@ -281,7 +281,7 @@ public class BigNodesSplitter implements ILayoutProcessor<LGraph> {
         // on outgoing edge analog
         if (Iterables.size(eastwardEdges) == 1) {
             LNode target = Iterables.get(eastwardEdges, 0).getTarget().getNode();
-            if (target.getType() == NodeType.LONG_EDGE
+            if (target.getType().isLongEdgeDummy()
                     && !target.getProperty(InternalProperties.LONG_EDGE_TARGET).getNode()
                             .equals(node.node)) {
                 node.type = BigNodeType.OUT_LONG_EDGE;
@@ -415,8 +415,8 @@ public class BigNodesSplitter implements ILayoutProcessor<LGraph> {
             
             // we require exactly one incoming edge
             if (Iterables.size(start.getIncomingEdges()) != 1
-                    || Iterables.get(start.getIncomingEdges(), 0).getSource().getNode()
-                            .getType() != NodeType.LONG_EDGE) {
+                    || !Iterables.get(start.getIncomingEdges(), 0).getSource().getNode()
+                            .getType().isLongEdgeDummy()) {
                 return null;
             }
             
@@ -541,8 +541,8 @@ public class BigNodesSplitter implements ILayoutProcessor<LGraph> {
         private LNode replaceOutLongEdgeDummy(final LNode start) {
 
             if (Iterables.size(start.getOutgoingEdges()) != 1
-                    || Iterables.get(start.getOutgoingEdges(), 0).getTarget().getNode()
-                            .getType() != NodeType.LONG_EDGE) {
+                    || !Iterables.get(start.getOutgoingEdges(), 0).getTarget().getNode()
+                            .getType().isLongEdgeDummy()) {
                 return null;
             }
 
@@ -930,7 +930,7 @@ public class BigNodesSplitter implements ILayoutProcessor<LGraph> {
                 // FIXME this is too restrictive!
                 // It would be better if an interleaving exists.
                 for (LNode n : currentLayer.getNodes()) {
-                    if (n.getType() == NodeType.NORTH_SOUTH_PORT) {
+                    if (n.getType().isNorthSouthDummy()) {
                         return null;
                     }
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HyperedgeDummyMerger.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HyperedgeDummyMerger.java
@@ -87,7 +87,7 @@ public final class HyperedgeDummyMerger implements ILayoutProcessor<LGraph> {
                 currNodeType = currNode.getType();
                 
                 // We're only interested if the current and last nodes are long edge dummies
-                if (currNodeType == NodeType.LONG_EDGE && lastNodeType == NodeType.LONG_EDGE) {
+                if (currNodeType.isLongEdgeDummy() && lastNodeType.isLongEdgeDummy()) {
                     
                     // If the source or the target are identical and we are allowed to merge, merge the current node
                     // into the last
@@ -239,7 +239,7 @@ public final class HyperedgeDummyMerger implements ILayoutProcessor<LGraph> {
             }
         }
         // follow edges connected to the same long edge dummy
-        if (p.getNode().getType() == NodeType.LONG_EDGE) {
+        if (p.getNode().getType().isLongEdgeDummy()) {
             for (LPort p2 : p.getNode().getPorts()) {
                 if (p2 != p && p2.id == -1) {
                     dfs(p2, index);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessor.java
@@ -297,7 +297,7 @@ public final class InvertedPortProcessor implements ILayoutProcessor<LGraph> {
         NodeType targetNodeType = targetNode.getType();
         
         // Set the LONG_EDGE_SOURCE property
-        if (sourceNodeType == NodeType.LONG_EDGE) {
+        if (sourceNodeType.isLongEdgeDummy()) {
             // The source is a LONG_EDGE node; use its LONG_EDGE_SOURCE
             longEdgeDummy.setProperty(InternalProperties.LONG_EDGE_SOURCE,
                     sourceNode.getProperty(InternalProperties.LONG_EDGE_SOURCE));
@@ -307,7 +307,7 @@ public final class InvertedPortProcessor implements ILayoutProcessor<LGraph> {
         }
 
         // Set the LONG_EDGE_TARGET property
-        if (targetNodeType == NodeType.LONG_EDGE) {
+        if (targetNodeType.isLongEdgeDummy()) {
             // The target is a LONG_EDGE node; use its LONG_EDGE_TARGET
             longEdgeDummy.setProperty(InternalProperties.LONG_EDGE_TARGET,
                     targetNode.getProperty(InternalProperties.LONG_EDGE_TARGET));

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummySwitcher.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummySwitcher.java
@@ -622,7 +622,7 @@ public final class LabelDummySwitcher implements ILayoutProcessor<LGraph> {
             final Function<LNode, LNode> nextElement, final boolean value) {
         
         LNode longEdgeDummy = nextElement.apply(labelDummy);
-        while (longEdgeDummy.getType() == NodeType.LONG_EDGE) {
+        while (longEdgeDummy.getType().isLongEdgeDummy()) {
             longEdgeDummy.setProperty(InternalProperties.LONG_EDGE_BEFORE_LABEL_DUMMY, value);
             longEdgeDummy = nextElement.apply(longEdgeDummy);
         }
@@ -698,10 +698,10 @@ public final class LabelDummySwitcher implements ILayoutProcessor<LGraph> {
             LNode source = labelDummy;
             do {
                 source = source.getIncomingEdges().iterator().next().getSource().getNode();
-                if (source.getType() == NodeType.LONG_EDGE) {
+                if (source.getType().isLongEdgeDummy()) {
                     leftLongEdgeDummies.add(source);
                 }
-            } while (source.getType() == NodeType.LONG_EDGE);
+            } while (source.getType().isLongEdgeDummy());
             
             // The list is currently not in the order we would expect, so produce a reversed version
             leftLongEdgeDummies = Lists.reverse(leftLongEdgeDummies);
@@ -716,10 +716,10 @@ public final class LabelDummySwitcher implements ILayoutProcessor<LGraph> {
             LNode target = labelDummy;
             do {
                 target = target.getOutgoingEdges().iterator().next().getTarget().getNode();
-                if (target.getType() == NodeType.LONG_EDGE) {
+                if (target.getType().isLongEdgeDummy()) {
                     rightLongEdgeDummies.add(target);
                 }
-            } while (target.getType() == NodeType.LONG_EDGE);
+            } while (target.getType().isLongEdgeDummy());
         }
         
         /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
@@ -247,7 +247,7 @@ public final class LabelSideSelector implements ILayoutProcessor<LGraph> {
         LNode prevLongEdgeTarget = null;
         
         for (LNode currentDummy : dummyNodes) {
-            assert currentDummy.getType() == NodeType.LABEL || currentDummy.getType() == NodeType.LONG_EDGE;
+            assert currentDummy.getType() == NodeType.LABEL || currentDummy.getType().isLongEdgeDummy();
             
             // Check if we are continuing a previous run
             LNode currLongEdgeSource = getLongEdgeEndNode(currentDummy, true);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoiner.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoiner.java
@@ -79,7 +79,7 @@ public final class LongEdgeJoiner implements ILayoutProcessor<LGraph> {
                 LNode node = nodeIterator.next();
                 
                 // Check if it's a dummy edge we're looking for
-                if (node.getType() == NodeType.LONG_EDGE) {
+                if (node.getType().isLongEdgeDummy()) {
                     joinAt(node, addUnnecessaryBendpoints);
                     
                     // Remove the node

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeSplitter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeSplitter.java
@@ -192,7 +192,7 @@ public final class LongEdgeSplitter implements ILayoutProcessor<LGraph> {
         LNode inEdgeSourceNode = inEdge.getSource().getNode();
         LNode outEdgeTargetNode = outEdge.getTarget().getNode();
         
-        if (inEdgeSourceNode.getType() == NodeType.LONG_EDGE) {
+        if (inEdgeSourceNode.getType().isLongEdgeDummy()) {
             // The incoming edge originates from a long edge dummy node, so we can just copy its properties
             dummyNode.setProperty(InternalProperties.LONG_EDGE_SOURCE,
                     inEdgeSourceNode.getProperty(InternalProperties.LONG_EDGE_SOURCE));

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPostprocessor.java
@@ -62,7 +62,7 @@ public final class NorthSouthPortPostprocessor implements ILayoutProcessor<LGrap
             LNode[] nodeArray = layer.getNodes().toArray(new LNode[layer.getNodes().size()]);
             for (LNode node : nodeArray) {
                 // We only care for North/South Port dummy nodes
-                if (node.getType() != NodeType.NORTH_SOUTH_PORT) {
+                if (!node.getType().isNorthSouthDummy()) {
                     continue;
                 }
                 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/NorthSouthEdgeNeighbouringNodeCrossingsCounter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/NorthSouthEdgeNeighbouringNodeCrossingsCounter.java
@@ -179,11 +179,11 @@ public class NorthSouthEdgeNeighbouringNodeCrossingsCounter {
     }
 
     private boolean isLongEdgeDummy(final LNode node) {
-        return node.getType() == NodeType.LONG_EDGE;
+        return node.getType().isLongEdgeDummy();
     }
 
     private boolean isNorthSouth(final LNode node) {
-        return node.getType() == NodeType.NORTH_SOUTH_PORT;
+        return node.getType().isNorthSouthDummy();
     }
 
     private boolean isNormal(final LNode node) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/SwitchDecider.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/SwitchDecider.java
@@ -184,8 +184,8 @@ public final class SwitchDecider {
 
     private boolean haveLayoutUnitConstraints(final LNode upperNode, final LNode lowerNode) {
         boolean neitherNodeIsLongEdgeDummy =
-                upperNode.getType() != NodeType.LONG_EDGE
-                        && lowerNode.getType() != NodeType.LONG_EDGE;
+                !upperNode.getType().isLongEdgeDummy()
+                        && !lowerNode.getType().isLongEdgeDummy();
 
         // If upperNode and lowerNode are part of a layout unit not only containing themselves,
         // then the layout units must be equal for a switch to be allowed.
@@ -237,7 +237,7 @@ public final class SwitchDecider {
     }
 
     private boolean isNorthSouthPortNode(final LNode node) {
-        return node.getType() == NodeType.NORTH_SOUTH_PORT;
+        return node.getType().isNorthSouthDummy();
     }
 
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointProcessor.java
@@ -365,7 +365,7 @@ public class BreakingPointProcessor implements ILayoutProcessor<LGraph> {
         for (LEdge e : edges) {
             LNode other = e.getOther(start);
             
-            if (other.getType() == NodeType.LONG_EDGE
+            if (other.getType().isLongEdgeDummy()
                     && other.getLayer() != start.getLayer()) {
                 return other;
             } 
@@ -374,7 +374,7 @@ public class BreakingPointProcessor implements ILayoutProcessor<LGraph> {
     }
     
     private boolean isInLayerDummy(final LNode node) {
-        if (node.getType() == NodeType.LONG_EDGE) {
+        if (node.getType().isLongEdgeDummy()) {
             for (LEdge e : node.getConnectedEdges()) {
                 if (!e.isSelfLoop() 
                         && node.getLayer() == e.getOther(node).getLayer()) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/CuttingUtils.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/CuttingUtils.java
@@ -144,7 +144,7 @@ public final class CuttingUtils {
     private static void setDummyProperties(final LNode dummy, final LEdge inEdge, final LEdge outEdge) {
         LNode inEdgeSourceNode = inEdge.getSource().getNode();
         
-        if (inEdgeSourceNode.getType() == NodeType.LONG_EDGE) {
+        if (inEdgeSourceNode.getType().isLongEdgeDummy()) {
             // The incoming edge originates from a long edge dummy node, so we can
             // just copy its properties
             dummy.setProperty(InternalProperties.LONG_EDGE_SOURCE,

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/GraphStats.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/GraphStats.java
@@ -242,7 +242,7 @@ public class GraphStats {
             lH += n.getSize().y + n.getMargin().bottom + n.getMargin().top + inLayerSpacing;
             
             for (LEdge inc : n.getIncomingEdges()) {
-                if (inc.getSource().getNode().getType() == NodeType.NORTH_SOUTH_PORT) {
+                if (inc.getSource().getNode().getType().isNorthSouthDummy()) {
                     LNode src = inc.getSource().getNode();
                     LNode origin = (LNode) src.getProperty(InternalProperties.ORIGIN);
                     lH += origin.getSize().y + origin.getMargin().bottom + origin.getMargin().top; 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/InteractiveCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/InteractiveCrossingMinimizer.java
@@ -117,7 +117,7 @@ public final class InteractiveCrossingMinimizer implements ILayoutPhase<LayeredP
                 // if we have a long edge dummy node, save the calculated position in a property
                 // to be used by the interactive node placer (for dummy nodes other than long edge
                 // dummies, we haven't calculated meaningful positions)
-                if (node.getType() == NodeType.LONG_EDGE) {
+                if (node.getType().isLongEdgeDummy()) {
                     node.setProperty(InternalProperties.ORIGINAL_DUMMY_NODE_POSITION, pos[node.id]);
                 }
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepTypeDecider.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepTypeDecider.java
@@ -202,7 +202,7 @@ public class LayerSweepTypeDecider implements IInitializable {
     }
 
     private boolean isNorthSouthDummy(final LNode node) {
-        return node.getType() == NodeType.NORTH_SOUTH_PORT;
+        return node.getType().isNorthSouthDummy();
     }
 
     private boolean isEasternDummy(final LNode node) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/SweepCopy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/SweepCopy.java
@@ -103,7 +103,7 @@ class SweepCopy {
                 LNode node = nodeOrder[i][j];
                 // use the id field to remember the order within the layer
                 node.id = j;
-                if (node.getType() == NodeType.NORTH_SOUTH_PORT) {
+                if (node.getType().isNorthSouthDummy()) {
                     northSouthPortDummies.add(node);
                 }
                 
@@ -135,7 +135,7 @@ class SweepCopy {
      * @return The {@link LNode} ('origin') whose port {@code dummy} represents. 
      */
     private LNode assertCorrectPortSides(final LNode dummy) {
-        assert dummy.getType() == NodeType.NORTH_SOUTH_PORT;
+        assert dummy.getType().isNorthSouthDummy();
 
         LNode origin = dummy.getProperty(InternalProperties.IN_LAYER_LAYOUT_UNIT);
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/AllCrossingsCounter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/AllCrossingsCounter.java
@@ -90,7 +90,7 @@ public final class AllCrossingsCounter implements IInitializable {
     @Override
     public void initAtNodeLevel(final int l, final int n, final LNode[][] nodeOrder) {
         LNode node = nodeOrder[l][n];
-        hasNorthSouthPorts[l] |= node.getType() == NodeType.NORTH_SOUTH_PORT;
+        hasNorthSouthPorts[l] |= node.getType().isNorthSouthDummy();
     }
 
     @Override

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/LinearSegmentsNodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/LinearSegmentsNodePlacer.java
@@ -494,8 +494,8 @@ public final class LinearSegmentsNodePlacer implements ILayoutPhase<LayeredPhase
         }
         segment.nodeType = nodeType;
 
-        if (nodeType == NodeType.LONG_EDGE
-                || nodeType == NodeType.NORTH_SOUTH_PORT
+        if (nodeType.isLongEdgeDummy()
+                || nodeType.isNorthSouthDummy()
                 || nodeType == NodeType.BIG_NODE) {
 
             // This is a LONG_EDGE, NORTH_SOUTH_PORT or BIG_NODE dummy; check if any of its
@@ -522,8 +522,8 @@ public final class LinearSegmentsNodePlacer implements ILayoutPhase<LayeredPhase
                             }
                         } else {
                             // current no bignode and next node is LONG_EDGE and NORTH_SOUTH_PORT
-                            if (targetNodeType == NodeType.LONG_EDGE
-                                    || targetNodeType == NodeType.NORTH_SOUTH_PORT) {
+                            if (targetNodeType.isLongEdgeDummy()
+                                    || targetNodeType.isNorthSouthDummy()) {
                                 if (fillSegment(targetNode, segment)) {
                                     // We just added another node to this node's linear segment.
                                     // That's quite enough.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/NetworkSimplexPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/NetworkSimplexPlacer.java
@@ -959,12 +959,12 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
             if (this.isEmpty()) {
                 return false;
             }
-            if (get(0).getSource().getNode().getType() == NodeType.LONG_EDGE) {
+            if (get(0).getSource().getNode().getType().isLongEdgeDummy()) {
                 return true;
             }
             return this.stream()
                     .map(e -> e.getTarget().getNode().getType())
-                    .anyMatch(t -> t == NodeType.LONG_EDGE);
+                    .anyMatch(t -> t.isLongEdgeDummy());
         }
         
         /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKAligner.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKAligner.java
@@ -128,7 +128,7 @@ public class BKAligner {
                                     bal.align[u_m.id] = v_i_k;
                                     bal.root[v_i_k.id] = bal.root[u_m.id];
                                     bal.align[v_i_k.id] = bal.root[v_i_k.id];
-                                    bal.od[bal.root[v_i_k.id].id] &= v_i_k.getType() == NodeType.LONG_EDGE;  
+                                    bal.od[bal.root[v_i_k.id].id] &= v_i_k.getType().isLongEdgeDummy();  
                                     
                                     r = ni.nodeIndex[u_m.id];
                                 }
@@ -146,7 +146,7 @@ public class BKAligner {
                                     bal.align[um.id] = v_i_k;
                                     bal.root[v_i_k.id] = bal.root[um.id];
                                     bal.align[v_i_k.id] = bal.root[v_i_k.id];
-                                    bal.od[bal.root[v_i_k.id].id] &= v_i_k.getType() == NodeType.LONG_EDGE;
+                                    bal.od[bal.root[v_i_k.id].id] &= v_i_k.getType().isLongEdgeDummy();
                                     
                                     r = ni.nodeIndex[um.id];
                                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKNodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKNodePlacer.java
@@ -502,11 +502,11 @@ public final class BKNodePlacer implements ILayoutPhase<LayeredPhases, LGraph> {
             }
         }
         
-        if (node.getType() == NodeType.LONG_EDGE) {
+        if (node.getType().isLongEdgeDummy()) {
             for (LEdge edge : node.getIncomingEdges()) {
                 NodeType sourceNodeType = edge.getSource().getNode().getType();
                 
-                if (sourceNodeType == NodeType.LONG_EDGE
+                if (sourceNodeType.isLongEdgeDummy()
                         && ni.layerIndex[edge.getSource().getNode().getLayer().id] == layer2
                         && ni.layerIndex[node.getLayer().id] == layer1) {
                     

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/PolylineEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/PolylineEdgeRouter.java
@@ -463,7 +463,7 @@ public final class PolylineEdgeRouter implements ILayoutPhase<LayeredPhases, LGr
      * an in-layer edge. 
      */
     private boolean isInLayerDummy(final LNode node) {
-        if (node.getType() == NodeType.LONG_EDGE) {
+        if (node.getType().isLongEdgeDummy()) {
             for (LEdge e : node.getConnectedEdges()) {
                 if (e.isInLayerEdge()) {
                     return true;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineEdgeRouter.java
@@ -1023,7 +1023,7 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
     public static boolean isQualifiedAsStartingNode(final LNode node) {
         NodeType nt = node.getType();
         return nt == NodeType.NORMAL 
-            || nt == NodeType.NORTH_SOUTH_PORT 
+            || nt.isNorthSouthDummy() 
             || nt == NodeType.EXTERNAL_PORT 
             || nt == NodeType.BIG_NODE
             || nt == NodeType.BREAKING_POINT;


### PR DESCRIPTION
As a preliminary step to be able to merge north/south dummies with long
edge dummies (#328), this commit replaces most (not all) checks for the
enum values with the corresponding predicates.
There are still some places left where the enum values are used
directly, primarily in some switch/cases in the crossing minimizer and
in the spacing preparation.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>