### PR TITLE
[layered] Several improvements

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/DotDebugUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/DotDebugUtil.java
@@ -195,13 +195,13 @@ public final class DotDebugUtil {
             options.append("label=\"");
             if (node.getType() == NodeType.NORMAL) {
                 // Normal nodes display their name, if any
-                if (node.getName() != null) {
-                    options.append(node.getName().replace("\"", "\\\"") + " ");
+                if (node.getDesignation() != null) {
+                    options.append(node.getDesignation().replace("\"", "\\\"") + " ");
                 }
             } else {
                 // Dummy nodes show their name (if set), or their node ID
-                if (node.getName() != null) {
-                    options.append(node.getName().replace("\"", "\\\"") + " ");
+                if (node.getDesignation() != null) {
+                    options.append(node.getDesignation().replace("\"", "\\\"") + " ");
                 } else {
                     options.append("n_" + node.id + " ");
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/ElkLayered.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/ElkLayered.java
@@ -282,7 +282,7 @@ public final class ElkLayered {
             LGraph nextGraph = continueSearchingTheseGraphs.pop();
             for (LNode node : nextGraph.getLayerlessNodes()) {
                 if (hasNestedGraph(node)) {
-                    LGraph nestedGraph = nestedGraphOf(node);
+                    LGraph nestedGraph = node.getNestedGraph();
                     collectedGraphs.push(nestedGraph);
                     continueSearchingTheseGraphs.push(nestedGraph);
                 }
@@ -328,19 +328,11 @@ public final class ElkLayered {
     }
 
     private boolean isRoot(final LGraph graph) {
-        return parentNodeOf(graph) == null;
-    }
-
-    private LNode parentNodeOf(final LGraph graph) {
-        return graph.getProperty(InternalProperties.PARENT_LNODE);
-    }
-
-    private LGraph nestedGraphOf(final LNode node) {
-        return node.getProperty(InternalProperties.NESTED_LGRAPH);
+        return graph.getParentNode() == null;
     }
 
     private boolean hasNestedGraph(final LNode node) {
-        return nestedGraphOf(node) != null;
+        return node.getNestedGraph() != null;
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/GraphConfigurator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/GraphConfigurator.java
@@ -136,7 +136,7 @@ final class GraphConfigurator {
 
             node.setProperty(InternalProperties.ORIGINAL_PORT_CONSTRAINTS, originalPortconstraints);
 
-            LGraph nestedGraph = node.getProperty(InternalProperties.NESTED_LGRAPH);
+            LGraph nestedGraph = node.getNestedGraph();
             if (nestedGraph != null) {
                 copyPortContraints(nestedGraph);
             }
@@ -148,7 +148,7 @@ final class GraphConfigurator {
 
                 node.setProperty(InternalProperties.ORIGINAL_PORT_CONSTRAINTS, originalPortconstraints);
 
-                LGraph nestedGraph = node.getProperty(InternalProperties.NESTED_LGRAPH);
+                LGraph nestedGraph = node.getNestedGraph();
                 if (nestedGraph != null) {
                     copyPortContraints(nestedGraph);
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/JsonDebugUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/JsonDebugUtil.java
@@ -477,7 +477,7 @@ public final class JsonDebugUtil {
             writeProperties(writer, node.getAllProperties(), indentation + 1);
             writer.write(",\n");
             writePorts(writer, node.getPorts(), indentation + 1);
-            final LGraph nestedGraph = node.getProperty(InternalProperties.NESTED_LGRAPH);
+            final LGraph nestedGraph = node.getNestedGraph();
             if (nestedGraph != null) {
                 writeLgraph(nestedGraph, writer, indentation + 1);
             }
@@ -682,14 +682,14 @@ public final class JsonDebugUtil {
         String name = "";
         if (node.getType() == NodeType.NORMAL) {
             // Normal nodes display their name, if any
-            if (node.getName() != null) {
-                name = node.getName();
+            if (node.getDesignation() != null) {
+                name = node.getDesignation();
             }
             name += " (" + layer + "," + index + ")";
         } else {
             // Dummy nodes show their name (if set), or their node ID
-            if (node.getName() != null) {
-                name = node.getName();
+            if (node.getDesignation() != null) {
+                name = node.getDesignation();
             } else {
                 name = "n_" + node.id;
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/LayeredLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/LayeredLayoutProvider.java
@@ -43,11 +43,10 @@ public final class LayeredLayoutProvider extends AbstractLayoutProvider implemen
 
     @Override
     public void layout(final ElkNode elkgraph, final IElkProgressMonitor progressMonitor) {
-        // Import the graph (layeredGraph won't be null since the KGraphImporter always returns an
-        // LGraph instance, even though the IGraphImporter interface would allow null as a return
-        // value)
-        IGraphTransformer<ElkNode> graphImporter = new ElkGraphTransformer();
-        LGraph layeredGraph = graphImporter.importGraph(elkgraph);
+        // Import the graph (layeredGraph won't be null since the KGraphImporter always returns an LGraph
+        // instance, even though the IGraphTransformer interface would allow null as a return value)
+        IGraphTransformer<ElkNode> graphTransformer = new ElkGraphTransformer();
+        LGraph layeredGraph = graphTransformer.importGraph(elkgraph);
 
         // Check if hierarchy handling for a compound graph is requested
         if (elkgraph.getProperty(LayeredOptions.HIERARCHY_HANDLING) == HierarchyHandling.INCLUDE_CHILDREN) {
@@ -60,7 +59,7 @@ public final class LayeredLayoutProvider extends AbstractLayoutProvider implemen
         
         if (!progressMonitor.isCanceled()) {
             // Apply the layout results to the original graph
-            graphImporter.applyLayout(layeredGraph);
+            graphTransformer.applyLayout(layeredGraph);
         }
     }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/ICGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/ICGraphTransformer.java
@@ -24,7 +24,7 @@ public interface ICGraphTransformer<T> {
      *          the graph to transform into a {@link CGraph}
      * @return a {@link CGraph}
      */
-    CGraph transform(final T inputGraph);
+    CGraph transform(T inputGraph);
     
     /**
      * Updates the properties of the input graph and applies the compacted positions to the

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/ISpacingsHandler.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/ISpacingsHandler.java
@@ -28,7 +28,7 @@ public interface ISpacingsHandler<T extends CNode> {
      *            the second involved node.
      * @return the horizontal spacing that should be preserve between the two passed nodes.
      */
-    double getHorizontalSpacing(final T cNode1, final T cNode2);
+    double getHorizontalSpacing(T cNode1, T cNode2);
 
     /**
      * @param cNode1
@@ -37,7 +37,7 @@ public interface ISpacingsHandler<T extends CNode> {
      *            the second involved node.
      * @return the vertical spacing that should be preserved between the two passed nodes.
      */
-    double getVerticalSpacing(final T cNode1, final T cNode2);
+    double getVerticalSpacing(T cNode1, T cNode2);
 
     /**
      * A default implementation, returning for either spacing the maximum of the two desired

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ICompactionAlgorithm.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ICompactionAlgorithm.java
@@ -25,6 +25,6 @@ public interface ICompactionAlgorithm {
      * @param compactor
      *            the instance of the surrounding {@link OneDimensionalCompactor}.
      */
-    void compact(final OneDimensionalCompactor compactor);
+    void compact(OneDimensionalCompactor compactor);
     
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/IConstraintCalculationAlgorithm.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/IConstraintCalculationAlgorithm.java
@@ -23,6 +23,6 @@ public interface IConstraintCalculationAlgorithm {
      * @param compactor
      *            the instance of the surrounding {@link OneDimensionalCompactor}.
      */
-    void calculateConstraints(final OneDimensionalCompactor compactor);
+    void calculateConstraints(OneDimensionalCompactor compactor);
     
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ScanlineConstraintCalculator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ScanlineConstraintCalculator.java
@@ -146,7 +146,7 @@ public class ScanlineConstraintCalculator implements IConstraintCalculationAlgor
         private boolean low;
         private CNode node;
 
-        public Timestamp(final CNode node, final boolean low) {
+        Timestamp(final CNode node, final boolean low) {
             this.node = node;
             this.low = low;
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/RectilinearConvexHull.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/RectilinearConvexHull.java
@@ -236,7 +236,7 @@ public final class RectilinearConvexHull {
          * @param quadrant
          *            the {@link Quadrant} for which this handler finds points on the hull.
          */
-        public MaximalElementsEventHandler(final Quadrant quadrant) {
+        MaximalElementsEventHandler(final Quadrant quadrant) {
             this.quadrant = quadrant;
             
             switch (quadrant) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/AbstractGraphPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/AbstractGraphPlacer.java
@@ -37,7 +37,7 @@ abstract class AbstractGraphPlacer {
      * @param components the graphs to be combined.
      * @param target the target graph into which the others shall be combined
      */
-    public abstract void combine(final List<LGraph> components, final LGraph target);
+    public abstract void combine(List<LGraph> components, LGraph target);
     
 
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsCompactor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsCompactor.java
@@ -591,7 +591,7 @@ public class ComponentsCompactor {
         private List<IComponent<LNode, Set<LEdge>>> components = Lists.newArrayList();
         private boolean containsExternalPorts = false;
         
-        public InternalConnectedComponents() { }
+        InternalConnectedComponents() { }
         
         @Override
         public Iterator<IComponent<LNode, Set<LEdge>>> iterator() {
@@ -621,7 +621,7 @@ public class ComponentsCompactor {
         private List<ElkRectangle> rectilinearConvexHull;
         private List<IExternalExtension<Set<LEdge>>> externalExtensions = Lists.newArrayList();
         
-        public InternalComponent(final LGraph graph) {
+        InternalComponent(final LGraph graph) {
             this.graph = graph;
             
             containsRegularNodes = false;
@@ -718,7 +718,7 @@ public class ComponentsCompactor {
         private ElkRectangle externalExtension;
         private ElkRectangle parent;
         
-        public InternalExternalExtension(final LEdge edge) {
+        InternalExternalExtension(final LEdge edge) {
             // housekeeping
             this.edge = edge;
             if (edge.getSource().getNode().getType() == NodeType.EXTERNAL_PORT) {
@@ -808,7 +808,7 @@ public class ComponentsCompactor {
         private double[] max = new double[PortSide.values().length];
         private double[] extent = new double[PortSide.values().length];
 
-        public OuterSegments() {
+        OuterSegments() {
             // initialize with proper values
             Arrays.fill(min, Double.POSITIVE_INFINITY);
             Arrays.fill(max, Double.NEGATIVE_INFINITY);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPostprocessor.java
@@ -98,7 +98,7 @@ public class CompoundGraphPostprocessor implements ILayoutProcessor<LGraph> {
             LNode referenceNode = sourcePort.getNode();
             LGraph referenceGraph;
             if (LGraphUtil.isDescendant(targetPort.getNode(), referenceNode)) {
-                referenceGraph = referenceNode.getProperty(InternalProperties.NESTED_LGRAPH);
+                referenceGraph = referenceNode.getNestedGraph();
             } else {
                 referenceGraph = referenceNode.getGraph();
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
@@ -153,7 +153,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         List<ExternalPort> containedExternalPorts = Lists.newArrayList();
         
         for (LNode node : graph.getLayerlessNodes()) {
-            LGraph nestedGraph = node.getProperty(InternalProperties.NESTED_LGRAPH);
+            LGraph nestedGraph = node.getNestedGraph();
             if (nestedGraph != null) {
                 // recursively process the child graph
                 List<ExternalPort> childPorts = transformHierarchyEdges(nestedGraph, node);
@@ -542,7 +542,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
             for (LPort childPort : childNode.getPorts()) {
                 // we treat outgoing and incoming edges separately
                 ExternalPort currentExternalOutputPort = null;
-                for (LEdge outEdge : childPort.getOutgoingEdges().toArray(new LEdge[0])) {
+                for (LEdge outEdge : LGraphUtil.toEdgeArray(childPort.getOutgoingEdges())) {
                     if (!LGraphUtil.isDescendant(outEdge.getTarget().getNode(), parentNode)) {
                         // the edge goes to the outside or to the parent node itself, so create an
                         // external port if necessary and introduce a new dummy edge
@@ -565,7 +565,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
                 }
 
                 ExternalPort currentExternalInputPort = null;
-                for (LEdge inEdge : childPort.getIncomingEdges().toArray(new LEdge[0])) {
+                for (LEdge inEdge : LGraphUtil.toEdgeArray(childPort.getIncomingEdges())) {
                     if (!LGraphUtil.isDescendant(inEdge.getSource().getNode(), parentNode)) {
                         // the edge comes from the outside or from the parent node itself, so create an
                         // external port if necessary and introduce a new dummy edge
@@ -614,8 +614,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         // Iterate over the edges and look for an inside self loop
         for (LPort lport : node.getPorts()) {
             // Avoid ConcurrentModificationExceptions
-            LEdge[] outEdges = lport.getOutgoingEdges().toArray(
-                    new LEdge[lport.getOutgoingEdges().size()]);
+            LEdge[] outEdges = LGraphUtil.toEdgeArray(lport.getOutgoingEdges());
             
             for (LEdge outEdge : outEdges) {
                 boolean isSelfLoop = outEdge.getTarget().getNode() == node;
@@ -929,8 +928,6 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
             break;
         }
         port.setProperty(LayeredOptions.PORT_BORDER_OFFSET, dummyNode.getProperty(LayeredOptions.PORT_BORDER_OFFSET));
-        dummyNode.setProperty(InternalProperties.ORIGIN, port);
-        dummyNodeMap.put(port, dummyNode);
         return port;
     }
     

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CrossHierarchyEdgeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CrossHierarchyEdgeComparator.java
@@ -14,7 +14,6 @@ import java.util.Comparator;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LNode;
-import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.PortType;
 
 /**
@@ -72,7 +71,7 @@ final class CrossHierarchyEdgeComparator implements Comparator<CrossHierarchyEdg
             if (currentGraph == topLevelGraph) {
                 return level;
             }
-            LNode currentNode = currentGraph.getProperty(InternalProperties.PARENT_LNODE);
+            LNode currentNode = currentGraph.getParentNode();
             if (currentNode == null) {
                 // the given node is not an ancestor of the graph node
                 throw new IllegalArgumentException();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LEdge.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LEdge.java
@@ -19,6 +19,7 @@ import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.EdgeLabelPlacement;
 import org.eclipse.elk.core.options.PortSide;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 /**
@@ -45,11 +46,30 @@ public final class LEdge extends LGraphElement {
      * {@inheritDoc}
      */
     public String toString() {
-        if (source != null && target != null) {
-            return source.getNode() + "(" + source + ")->" + target.getNode() + "(" + target + ")";
-        } else {
-            return "e_" + hashCode();
+        StringBuilder result = new StringBuilder();
+        result.append("e_");
+        String designation = getDesignation();
+        if (designation != null) {
+            result.append(designation);
         }
+        if (source != null && target != null) {
+            result.append(" ").append(source.getDesignation());
+            result.append("[").append(source.getNode()).append("]");
+            result.append(" -> ").append(target.getDesignation());
+            result.append("[").append(target.getNode()).append("]");
+        }
+        return result.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+   @Override
+    public String getDesignation() {
+       if (!labels.isEmpty() && !Strings.isNullOrEmpty(labels.get(0).getText())) {
+           return labels.get(0).getText();
+       }
+       return super.getDesignation();
     }
     
     /**
@@ -266,4 +286,5 @@ public final class LEdge extends LGraphElement {
             throw new IllegalArgumentException("'node' must either be the source node or target node of the edge.");
         }
     }
+    
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraph.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraph.java
@@ -68,6 +68,11 @@ public final class LGraph extends LGraphElement implements Iterable<Layer> {
      */
     private final List<Layer> layers = Lists.newArrayList();
     
+    /**
+     * The parent node in which this graph is nested, or {@code null}.
+     */
+    private LNode parentNode;
+    
     
     /**
      * {@inheritDoc}
@@ -152,6 +157,24 @@ public final class LGraph extends LGraphElement implements Iterable<Layer> {
     public List<Layer> getLayers() {
         return layers;
     }
+    
+    /**
+     * Returns the parent node in which this graph is nested, if any.
+     * 
+     * @return the parent node or {@code null}
+     */
+    public LNode getParentNode() {
+        return parentNode;
+    }
+    
+    /**
+     * Sets the parent node in which this graph is nested.
+     * 
+     * @param parentNode the new parent node
+     */
+    public void setParentNode(final LNode parentNode) {
+        this.parentNode = parentNode;
+    }
 
     /**
      * Returns an iterator over the layers.
@@ -174,7 +197,7 @@ public final class LGraph extends LGraphElement implements Iterable<Layer> {
         while (layerIter.hasNext()) {
             Layer layer = layerIter.next();
             int layerIndex = layerIter.previousIndex();
-            lgraphArray[layerIndex] = layer.getNodes().toArray(new LNode[layer.getNodes().size()]);
+            lgraphArray[layerIndex] = LGraphUtil.toNodeArray(layer.getNodes());
         }
         
         return lgraphArray;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphElement.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphElement.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.graph;
 
+import org.eclipse.elk.alg.layered.graph.transform.ElkGraphTransformer;
 import org.eclipse.elk.graph.properties.MapPropertyHolder;
+
+import com.google.common.base.Strings;
 
 /**
  * Abstract superclass for the layers, nodes, ports, and edges of a layered graph
@@ -37,5 +40,18 @@ public abstract class LGraphElement extends MapPropertyHolder {
     /** Identifier value, may be arbitrarily used by algorithms. */
     public int id;
     // CHECKSTYLEON VisibilityModifier
+    
+    /**
+     * Returns a string that is useful to identify the element while debugging.
+     * 
+     * @return the element's designation, or {@code null} if no meaningful designation can be provided
+     */
+    public String getDesignation() {
+        String identifier = ElkGraphTransformer.getOriginIdentifier(this);
+        if (!Strings.isNullOrEmpty(identifier)) {
+            return identifier;
+        }
+        return null;
+    }
     
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
@@ -45,6 +45,36 @@ public final class LGraphUtil {
      */
     private LGraphUtil() { }
     
+    /**
+     * Create a new array by copying the content of the given node collection.
+     * 
+     * @param nodes a collection of nodes
+     * @return an array of nodes
+     */
+    public static LNode[] toNodeArray(final Collection<LNode> nodes) {
+        return nodes.toArray(new LNode[nodes.size()]);
+    }
+    
+    /**
+     * Create a new array by copying the content of the given edge collection.
+     * 
+     * @param edges a collection of edges
+     * @return an array of edges
+     */
+    public static LEdge[] toEdgeArray(final Collection<LEdge> edges) {
+        return edges.toArray(new LEdge[edges.size()]);
+    }
+    
+    /**
+     * Create a new array by copying the content of the given port collection.
+     * 
+     * @param ports a collection of ports
+     * @return an array of ports
+     */
+    public static LPort[] toPortArray(final Collection<LPort> ports) {
+        return ports.toArray(new LPort[ports.size()]);
+    }
+    
     ///////////////////////////////////////////////////////////////////////////////
     // Node Resizing
 
@@ -963,13 +993,13 @@ public final class LGraphUtil {
      */
     public static boolean isDescendant(final LNode child, final LNode parent) {
         LNode current = child;
-        LNode next = current.getGraph().getProperty(InternalProperties.PARENT_LNODE);
+        LNode next = current.getGraph().getParentNode();
         while (next != null) {
             current = next;
             if (current == parent) {
                 return true;
             }
-            next = current.getGraph().getProperty(InternalProperties.PARENT_LNODE);
+            next = current.getGraph().getParentNode();
         }
         return false;
     }
@@ -996,7 +1026,7 @@ public final class LGraphUtil {
         LNode node;
         do {
             point.add(graph.getOffset());
-            node = graph.getProperty(InternalProperties.PARENT_LNODE);
+            node = graph.getParentNode();
             if (node != null) {
                 LPadding padding = graph.getPadding();
                 point.add(padding.left, padding.top);
@@ -1009,7 +1039,7 @@ public final class LGraphUtil {
         graph = newGraph;
         do {
             point.sub(graph.getOffset());
-            node = graph.getProperty(InternalProperties.PARENT_LNODE);
+            node = graph.getParentNode();
             if (node != null) {
                 LPadding padding = graph.getPadding();
                 point.sub(padding.left, padding.top);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LLabel.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LLabel.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.graph;
 
+import com.google.common.base.Strings;
+
 /**
  * A label in the layered graph structure.
  * 
@@ -43,11 +45,23 @@ public final class LLabel extends LShape {
      * {@inheritDoc}
      */
     public String toString() {
-        if (text == null) {
-            return "l_" + id;
+        String designation = getDesignation();
+        if (designation == null) {
+            return "label";
         } else {
-            return "l_" + text;
+            return "l_" + designation;
         }
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDesignation() {
+        if (!Strings.isNullOrEmpty(text)) {
+            return text;
+        }
+        return super.getDesignation();
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
@@ -14,14 +14,15 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 
-import org.eclipse.elk.alg.layered.options.PortType;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.PortType;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -91,6 +92,8 @@ public final class LNode extends LShape {
     private final List<LPort> ports = Lists.newArrayListWithCapacity(6);
     /** this node's labels. */
     private final List<LLabel> labels = Lists.newArrayListWithCapacity(2);
+    /** the nested graph, or @{code null}. */
+    private LGraph nestedGraph;
     /** the margin area around this node. */
     private final LMargin margin = new LMargin();
     /** the padding inside this node, usually reserved for port and label placement. */
@@ -113,34 +116,28 @@ public final class LNode extends LShape {
      * {@inheritDoc}
      */
     public String toString() {
-        return "n_" + getDesignation();
+        StringBuilder result = new StringBuilder();
+        result.append("n");
+        if (type != NodeType.NORMAL) {
+            result.append("(").append(type.toString().toLowerCase()).append(")");
+        }
+        result.append("_").append(getDesignation());
+        return result.toString();
     }
     
     /**
-     * Returns the name of the node. The name is derived from the text of the first label, if any.
-     * 
-     * @return the name, or {@code null}
+     * {@inheritDoc}
      */
-    public String getName() {
-        if (!labels.isEmpty()) {
+    @Override
+    public String getDesignation() {
+        if (!labels.isEmpty() && !Strings.isNullOrEmpty(labels.get(0).getText())) {
             return labels.get(0).getText();
         }
-        return null;
-    }
-    
-    /**
-     * Returns the node's designation. The designation is either the name if that is not {@code null},
-     * or the node's ID otherwise.
-     * 
-     * @return the node's designation.
-     */
-    public String getDesignation() {
-        String name = getName();
-        if (name == null) {
-            return Integer.toString(id);
-        } else {
-            return name;
+        String id = super.getDesignation();
+        if (id != null) {
+            return id;
         }
+        return Integer.toString(getIndex());
     }
 
     /**
@@ -420,6 +417,24 @@ public final class LNode extends LShape {
      */
     public List<LLabel> getLabels() {
         return labels;
+    }
+    
+    /**
+     * Returns a graph that is nested in this node, if any.
+     * 
+     * @return the nested graph, or @{code null}
+     */
+    public LGraph getNestedGraph() {
+        return nestedGraph;
+    }
+    
+    /**
+     * Sets the nested graph.
+     * 
+     * @param nestedGraph the new nested graph
+     */
+    public void setNestedGraph(final LGraph nestedGraph) {
+        this.nestedGraph = nestedGraph;
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LPort.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LPort.java
@@ -17,6 +17,7 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.PortSide;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -353,12 +354,37 @@ public final class LPort extends LShape {
      */
     @Override
     public String toString() {
-        String text = getName();
-        if (text == null) {
-            return "p_" + id;
-        } else {
-            return "p_" + text;
+        StringBuilder result = new StringBuilder();
+        result.append("p_").append(getDesignation());
+        if (owner != null) {
+            result.append("[").append(owner).append("]");
         }
+        if (incomingEdges.size() == 1 && outgoingEdges.isEmpty() && incomingEdges.get(0).getSource() != this) {
+            LPort source = incomingEdges.get(0).getSource();
+            result.append(" << ").append(source.getDesignation());
+            result.append("[").append(source.owner).append("]");
+        }
+        if (incomingEdges.isEmpty() && outgoingEdges.size() == 1 && outgoingEdges.get(0).getTarget() != this) {
+            LPort target = outgoingEdges.get(0).getTarget();
+            result.append(" >> ").append(target.getDesignation());
+            result.append("[").append(target.owner).append("]");
+        }
+        return result.toString();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDesignation() {
+        if (!labels.isEmpty() && !Strings.isNullOrEmpty(labels.get(0).getText())) {
+            return labels.get(0).getText();
+        }
+        String id = super.getDesignation();
+        if (id != null) {
+            return id;
+        }
+        return Integer.toString(getIndex());
     }
 
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -273,7 +273,7 @@ class ElkGraphImporter {
                 LGraph parentLGraph = lgraph;
                 LNode parentLNode = (LNode) nodeAndPortMap.get(elknode.getParent());
                 if (parentLNode != null) {
-                    parentLGraph = parentLNode.getProperty(InternalProperties.NESTED_LGRAPH);
+                    parentLGraph = parentLNode.getNestedGraph();
                 }
                 LNode lnode = transformNode(elknode, parentLGraph);
                 
@@ -287,8 +287,8 @@ class ElkGraphImporter {
                 if (hasHierarchyHandlingEnabled && (hasChildren || hasInsideSelfLoops)) {
                     LGraph nestedGraph = createLGraph(elknode);
                     nestedGraph.setProperty(LayeredOptions.DIRECTION, parentGraphDirection);
-                    lnode.setProperty(InternalProperties.NESTED_LGRAPH, nestedGraph);
-                    nestedGraph.setProperty(InternalProperties.PARENT_LNODE, lnode);
+                    lnode.setNestedGraph(nestedGraph);
+                    nestedGraph.setParentNode(lnode);
                     elknodeQueue.addAll(elknode.getChildren());
                 }
             }
@@ -328,7 +328,7 @@ class ElkGraphImporter {
                         LGraph parentLGraph = lgraph;
                         LNode parentLNode = (LNode) nodeAndPortMap.get(parentKGraph);
                         if (parentLNode != null) {
-                            parentLGraph = parentLNode.getProperty(InternalProperties.NESTED_LGRAPH);
+                            parentLGraph = parentLNode.getNestedGraph();
                         }
                         
                         // Transform the edge, finally...
@@ -409,7 +409,7 @@ class ElkGraphImporter {
             LNode lnode = (LNode) nodeAndPortMap.get(origin);
             if (lnode != null) {
                 // Find the graph that represents the node's insides
-                LGraph lgraph = lnode.getProperty(InternalProperties.NESTED_LGRAPH);
+                LGraph lgraph = lnode.getNestedGraph();
                 if (lgraph != null) {
                     return lgraph;
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
@@ -69,7 +69,7 @@ class ElkGraphLayoutTransferrer {
         ElkNode parentElkNode = (ElkNode) graphOrigin;
         
         // The LNode that represents this graph in the upper hierarchy level, if any
-        LNode parentLNode = (LNode) lgraph.getProperty(InternalProperties.PARENT_LNODE);
+        LNode parentLNode = (LNode) lgraph.getParentNode();
         
         // Get the offset to be added to all coordinates
         KVector offset = new KVector(lgraph.getOffset());
@@ -136,7 +136,7 @@ class ElkGraphLayoutTransferrer {
         
         // Process nested subgraphs
         for (LNode lnode : lgraph.getLayerlessNodes()) {
-            LGraph nestedGraph = lnode.getProperty(InternalProperties.NESTED_LGRAPH);
+            LGraph nestedGraph = lnode.getNestedGraph();
             if (nestedGraph != null) {
                 applyLayout(nestedGraph);
             }
@@ -160,7 +160,7 @@ class ElkGraphLayoutTransferrer {
         
         // Set the node size, if necessary
         if (!elknode.getProperty(LayeredOptions.NODE_SIZE_CONSTRAINTS).isEmpty()
-                || lnode.getProperty(InternalProperties.NESTED_LGRAPH) != null
+                || lnode.getNestedGraph() != null
                 || (lnode.getGraph().getProperty(LayeredOptions.NODE_PLACEMENT_STRATEGY) 
                         == NodePlacementStrategy.NETWORK_SIMPLEX 
                     && NodeFlexibility.getNodeFlexibility(lnode).isFlexibleSizeWhereSpacePermits())) {
@@ -319,7 +319,7 @@ class ElkGraphLayoutTransferrer {
             
             while (currentGraph != targetCoordinateSystem) {
                 // The current graph should always have an upper level if we have not reached the target graph yet;
-                LNode representingNode = currentGraph.getProperty(InternalProperties.PARENT_LNODE);
+                LNode representingNode = currentGraph.getParentNode();
                 currentGraph = representingNode.getGraph();
                 
                 result.add(representingNode.getPosition())
@@ -346,7 +346,7 @@ class ElkGraphLayoutTransferrer {
         boolean sizeConstraintsIncludedPortLabels =
                 elknode.getProperty(LayeredOptions.NODE_SIZE_CONSTRAINTS).contains(SizeConstraint.PORT_LABELS);
 
-        if (lgraph.getProperty(InternalProperties.PARENT_LNODE) == null) {
+        if (lgraph.getParentNode() == null) {
             Set<GraphProperties> graphProps = lgraph.getProperty(InternalProperties.GRAPH_PROPERTIES);
             KVector actualGraphSize = lgraph.getActualSize();
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphTransformer.java
@@ -11,7 +11,12 @@
 package org.eclipse.elk.alg.layered.graph.transform;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphElement;
+import org.eclipse.elk.alg.layered.options.InternalProperties;
+import org.eclipse.elk.graph.ElkGraphElement;
 import org.eclipse.elk.graph.ElkNode;
+
+import com.google.common.base.Strings;
 
 /**
  * Manages the transformation of ELK Graphs to LayeredGraphs. Sets the
@@ -37,6 +42,36 @@ public class ElkGraphTransformer implements IGraphTransformer<ElkNode> {
      */
     public void applyLayout(final LGraph layeredGraph) {
         new ElkGraphLayoutTransferrer().applyLayout(layeredGraph);
+    }
+    
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Utility
+    
+    /**
+     * Returns an identifier string for the original ElkGraph element.
+     * 
+     * @param element an LGraph element
+     * @return the original identifier, or {@code null} if none is defined
+     */
+    public static String getOriginIdentifier(final LGraphElement element) {
+        Object origin = element.getProperty(InternalProperties.ORIGIN);
+        if (origin instanceof ElkGraphElement) {
+            return getIdentifier((ElkGraphElement) origin);
+        }
+        return null;
+    }
+    
+    private static String getIdentifier(final ElkGraphElement element) {
+        String id = element.getIdentifier();
+        if (!Strings.isNullOrEmpty(id)) {
+            String parentId = getIdentifier((ElkGraphElement) element.eContainer());
+            if (parentId != null) {
+                return parentId + '.' + id;
+            }
+            return id;
+        }
+        return null;
     }
     
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesLabelHandler.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesLabelHandler.java
@@ -82,7 +82,7 @@ public final class BigNodesLabelHandler {
          * @param dummies
          *            the created dummy nodes
          */
-        private Handler(final LNode node, final List<LNode> dummies, final double chunkWidth) {
+        Handler(final LNode node, final List<LNode> dummies, final double chunkWidth) {
             this.node = node;
             this.chunks = dummies.size();
 
@@ -305,7 +305,8 @@ public final class BigNodesLabelHandler {
     private static final class CompoundFunction implements Function<Void, Void> {
         private Function<Void, Void>[] funs;
 
-        private CompoundFunction(final Function<Void, Void>... funs) {
+        @SuppressWarnings("unchecked")
+        CompoundFunction(final Function<Void, Void>... funs) {
             this.funs = funs;
         }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesPreProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesPreProcessor.java
@@ -201,7 +201,7 @@ public class BigNodesPreProcessor implements ILayoutProcessor<LGraph> {
         /**
          * Creates a new big node.
          */
-        public BigNode(final LNode node, final int chunks, final double minWidth) {
+        BigNode(final LNode node, final int chunks, final double minWidth) {
             this.node = node;
             this.chunks = chunks;
             this.minWidth = minWidth;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesSplitter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/BigNodesSplitter.java
@@ -312,7 +312,7 @@ public class BigNodesSplitter implements ILayoutProcessor<LGraph> {
         /**
          * Creates a new big node.
          */
-        public BigNode(final LNode node, final int chunks) {
+        BigNode(final LNode node, final int chunks) {
             this.node = node;
             this.chunks = chunks;
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/DummySelfLoopProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/DummySelfLoopProcessor.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
@@ -76,8 +77,7 @@ public final class DummySelfLoopProcessor implements ILayoutProcessor<LGraph> {
             for (LNode node : layer) {
                 for (LPort port : node.getPorts()) {
                     // Go through the port's outgoing edges
-                    LEdge[] edges = port.getOutgoingEdges().toArray(
-                            new LEdge[port.getOutgoingEdges().size()]);
+                    LEdge[] edges = LGraphUtil.toEdgeArray(port.getOutgoingEdges());
                     
                     for (LEdge edge : edges) {
                         // We're only interested in edges whose source and target node are identical

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/EdgeAndLayerConstraintEdgeReverser.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/EdgeAndLayerConstraintEdgeReverser.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.intermediate;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
@@ -159,11 +160,11 @@ public final class EdgeAndLayerConstraintEdgeReverser implements ILayoutProcesso
             final LayerConstraint nodeLayerConstraint, final PortType type) {
         
         // Iterate through the node's edges and reverse them, if necessary
-        LPort[] ports = node.getPorts().toArray(new LPort[node.getPorts().size()]);
+        LPort[] ports = LGraphUtil.toPortArray(node.getPorts());
         for (LPort port : ports) {
             // Only incoming edges
             if (type != PortType.INPUT) {
-                LEdge[] outgoing = port.getOutgoingEdges().toArray(new LEdge[port.getOutgoingEdges().size()]);
+                LEdge[] outgoing = LGraphUtil.toEdgeArray(port.getOutgoingEdges());
                 
                 for (LEdge edge : outgoing) {
                     // Reverse the edge if we're allowed to do so
@@ -175,7 +176,7 @@ public final class EdgeAndLayerConstraintEdgeReverser implements ILayoutProcesso
             
             // Only outgoing edges
             if (type != PortType.OUTPUT) {
-                LEdge[] incoming = port.getIncomingEdges().toArray(new LEdge[port.getIncomingEdges().size()]);
+                LEdge[] incoming = LGraphUtil.toEdgeArray(port.getIncomingEdges());
                 
                 for (LEdge edge : incoming) {
                     // Reverse the edge if we're allowed to do so

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalNodeResizingProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalNodeResizingProcessor.java
@@ -62,13 +62,9 @@ public class HierarchicalNodeResizingProcessor implements ILayoutProcessor<LGrap
         graph.getLayers().clear();
         resizeGraph(graph);
         if (isNested(graph)) {
-            graphLayoutToNode(parentNodeOf(graph), graph);
+            graphLayoutToNode(graph.getParentNode(), graph);
         }
         progressMonitor.done();
-    }
-
-    private LNode parentNodeOf(final LGraph graph) {
-        return graph.getProperty(InternalProperties.PARENT_LNODE);
     }
 
     /**
@@ -110,7 +106,7 @@ public class HierarchicalNodeResizingProcessor implements ILayoutProcessor<LGrap
     }
 
     private boolean isNested(final LGraph graph) {
-        return parentNodeOf(graph) != null;
+        return graph.getParentNode() != null;
     }
 
     // //////////////////////////////////////////////////////////////////////////////

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortConstraintProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortConstraintProcessor.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
@@ -155,7 +156,7 @@ public final class HierarchicalPortConstraintProcessor implements ILayoutProcess
      */
     private void processEasternAndWesternPortDummies(final Layer layer) {
         // Put the nodes into an array
-        LNode[] nodes = layer.getNodes().toArray(new LNode[layer.getNodes().size()]);
+        LNode[] nodes = LGraphUtil.toNodeArray(layer.getNodes());
         
         // Sort the array; hierarchical port dummies are at the top, sorted by
         // position or ratio in ascending order

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
@@ -19,6 +19,7 @@ import org.eclipse.elk.alg.common.nodespacing.NodeDimensionCalculation;
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LGraphAdapters;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LLabel;
 import org.eclipse.elk.alg.layered.graph.LMargin;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -413,7 +414,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
         }
         
         // Turn the list into an array of dummy nodes and sort that by their x coordinate
-        LNode[] dummyArray = dummies.toArray(new LNode[dummies.size()]);
+        LNode[] dummyArray = LGraphUtil.toNodeArray(dummies);
         
         Arrays.sort(dummyArray, new Comparator<LNode>() {
             public int compare(final LNode a, final LNode b) {
@@ -438,7 +439,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
         }
         
         // Turn the list into an array of dummy nodes and sort that by their original x coordinate
-        LNode[] dummyArray = dummies.toArray(new LNode[dummies.size()]);
+        LNode[] dummyArray = LGraphUtil.toNodeArray(dummies);
         
         Arrays.sort(dummyArray, new Comparator<LNode>() {
             public int compare(final LNode a, final LNode b) {
@@ -660,8 +661,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
                 }
                 
                 // Reroute all the output port's edges
-                edges = nodeOutPort.getOutgoingEdges().toArray(
-                        new LEdge[nodeOutPort.getOutgoingEdges().size()]);
+                edges = LGraphUtil.toEdgeArray(nodeOutPort.getOutgoingEdges());
                 
                 for (LEdge edge : edges) {
                     edge.setSource(replacedDummyPort);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessor.java
@@ -13,6 +13,7 @@ package org.eclipse.elk.alg.layered.intermediate;
 import java.util.List;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.Layer;
 import org.eclipse.elk.alg.layered.options.InLayerConstraint;
@@ -64,7 +65,7 @@ public final class InLayerConstraintProcessor implements ILayoutProcessor<LGraph
             List<LNode> bottomConstrainedNodes = Lists.newArrayList();
             
             // Iterate through an array of its nodes
-            LNode[] nodes = layer.getNodes().toArray(new LNode[layer.getNodes().size()]);
+            LNode[] nodes = LGraphUtil.toNodeArray(layer.getNodes());
             
             for (int i = 0; i < nodes.length; i++) {
                 InLayerConstraint constraint =

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessor.java
@@ -15,6 +15,7 @@ import java.util.ListIterator;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LLabel;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
@@ -123,7 +124,7 @@ public final class InvertedPortProcessor implements ILayoutProcessor<LGraph> {
                     // a copy of the current list of edges, since the edges are modified when
                     // dummy nodes are created)
                     List<LEdge> edges = port.getIncomingEdges();
-                    LEdge[] edgeArray = edges.toArray(new LEdge[edges.size()]);
+                    LEdge[] edgeArray = LGraphUtil.toEdgeArray(edges);
                     
                     for (LEdge edge : edgeArray) {
                         createEastPortSideDummies(layeredGraph, port, edge, unassignedNodes);
@@ -136,7 +137,7 @@ public final class InvertedPortProcessor implements ILayoutProcessor<LGraph> {
                     // a copy of the current list of edges, since the edges are modified when
                     // dummy nodes are created)
                     List<LEdge> edges = port.getOutgoingEdges();
-                    LEdge[] edgeArray = edges.toArray(new LEdge[edges.size()]);
+                    LEdge[] edgeArray = LGraphUtil.toEdgeArray(edges);
                     
                     for (LEdge edge : edgeArray) {
                         createWestPortSideDummies(layeredGraph, port, edge, unassignedNodes);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummySwitcher.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummySwitcher.java
@@ -568,10 +568,10 @@ public final class LabelDummySwitcher implements ILayoutProcessor<LGraph> {
         LPort outputPort2 = longEdgeDummy.getPorts(PortType.OUTPUT).iterator().next();
         
         // Store incoming and outgoing edges
-        LEdge[] incomingEdges1 = inputPort1.getIncomingEdges().toArray(new LEdge[1]);
-        LEdge[] outgoingEdges1 = outputPort1.getOutgoingEdges().toArray(new LEdge[1]);
-        LEdge[] incomingEdges2 = inputPort2.getIncomingEdges().toArray(new LEdge[1]);
-        LEdge[] outgoingEdges2 = outputPort2.getOutgoingEdges().toArray(new LEdge[1]);
+        LEdge[] incomingEdges1 = LGraphUtil.toEdgeArray(inputPort1.getIncomingEdges());
+        LEdge[] outgoingEdges1 = LGraphUtil.toEdgeArray(outputPort1.getOutgoingEdges());
+        LEdge[] incomingEdges2 = LGraphUtil.toEdgeArray(inputPort2.getIncomingEdges());
+        LEdge[] outgoingEdges2 = LGraphUtil.toEdgeArray(outputPort2.getOutgoingEdges());
 
         // Put first dummy into second dummy's layer and reroute second dummy's edges to first dummy
         labelDummy.setLayer(dummy2LayerPosition, layer2);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelManagementProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelManagementProcessor.java
@@ -127,8 +127,8 @@ public final class LabelManagementProcessor implements ILayoutProcessor<LGraph> 
                         for (SelfLoopComponent component : slNode.getSelfLoopComponents()) {
                             SelfLoopLabel slLabel = component.getSelfLoopLabel();
                             if (slLabel != null) {
-                                doManageLabels(labelManager, slLabel.getLabels(), MIN_WIDTH_EDGE_LABELS, labelLabelSpacing,
-                                        verticalLayout);
+                                doManageLabels(labelManager, slLabel.getLabels(), MIN_WIDTH_EDGE_LABELS,
+                                        labelLabelSpacing, verticalLayout);
                             }
                         }
                     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LayerConstraintProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LayerConstraintProcessor.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.graph.Layer;
@@ -75,7 +76,7 @@ public final class LayerConstraintProcessor implements ILayoutProcessor<LGraph> 
         // Iterate through the current list of layers
         for (Layer layer : layers) {
             // Iterate through a node array to avoid ConcurrentModificationExceptions
-            LNode [] nodes = layer.getNodes().toArray(new LNode[layer.getNodes().size()]);
+            LNode [] nodes = LGraphUtil.toNodeArray(layer.getNodes());
             
             for (LNode node : nodes) {
                 LayerConstraint constraint = node.getProperty(LayeredOptions.LAYERING_LAYER_CONSTRAINT);
@@ -133,7 +134,7 @@ public final class LayerConstraintProcessor implements ILayoutProcessor<LGraph> 
             }
             if (moveAllowed) {
                 // Iterate through a node array to avoid ConcurrentModificationExceptions
-                LNode [] nodes = firstLayer.getNodes().toArray(new LNode[firstLayer.getNodes().size()]);
+                LNode [] nodes = LGraphUtil.toNodeArray(firstLayer.getNodes());
                 for (LNode node : nodes) {
                     node.setLayer(sndFirstLayer);
                 }
@@ -163,7 +164,7 @@ public final class LayerConstraintProcessor implements ILayoutProcessor<LGraph> 
             }
             if (moveAllowed) {
                 // Iterate through a node array to avoid ConcurrentModificationExceptions
-                LNode [] nodes = lastLayer.getNodes().toArray(new LNode[lastLayer.getNodes().size()]);
+                LNode [] nodes = LGraphUtil.toNodeArray(lastLayer.getNodes());
                 for (LNode node : nodes) {
                     node.setLayer(sndLastLayer);
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPostprocessor.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
@@ -59,7 +60,7 @@ public final class NorthSouthPortPostprocessor implements ILayoutProcessor<LGrap
         // Iterate through the layers
         for (Layer layer : layeredGraph) {
             // Iterate through the nodes (use an array to avoid concurrent modification exceptions)
-            LNode[] nodeArray = layer.getNodes().toArray(new LNode[layer.getNodes().size()]);
+            LNode[] nodeArray = LGraphUtil.toNodeArray(layer.getNodes());
             for (LNode node : nodeArray) {
                 // We only care for North/South Port dummy nodes
                 if (node.getType() != NodeType.NORTH_SOUTH_PORT) {
@@ -146,8 +147,7 @@ public final class NorthSouthPortPostprocessor implements ILayoutProcessor<LGrap
         double y = inputPort.getNode().getPosition().y;
         
         // Reroute the edges, inserting a new bend point at the position of the dummy node
-        LEdge[] edgeArray = inputPort.getIncomingEdges().toArray(
-                new LEdge[inputPort.getIncomingEdges().size()]);
+        LEdge[] edgeArray = LGraphUtil.toEdgeArray(inputPort.getIncomingEdges());
         for (LEdge inEdge : edgeArray) {
             inEdge.setTarget(originPort);
             inEdge.getBendPoints().addLast(x, y);
@@ -183,8 +183,7 @@ public final class NorthSouthPortPostprocessor implements ILayoutProcessor<LGrap
         double y = outputPort.getNode().getPosition().y;
         
         // Reroute the edges, inserting a new bend point at the position of the dummy node
-        LEdge[] edgeArray = outputPort.getOutgoingEdges().toArray(
-                new LEdge[outputPort.getOutgoingEdges().size()]);
+        LEdge[] edgeArray = LGraphUtil.toEdgeArray(outputPort.getOutgoingEdges());
         for (LEdge outEdge : edgeArray) {
             outEdge.setSource(originPort);
             outEdge.getBendPoints().addFirst(x, y);
@@ -240,8 +239,7 @@ public final class NorthSouthPortPostprocessor implements ILayoutProcessor<LGrap
         originPort.setProperty(InternalProperties.SPLINE_NS_PORT_Y_COORD, inputPort.getNode().getPosition().y);
         
         // Reroute the edges
-        LEdge[] edgeArray = inputPort.getIncomingEdges().toArray(
-                new LEdge[inputPort.getIncomingEdges().size()]);
+        LEdge[] edgeArray = LGraphUtil.toEdgeArray(inputPort.getIncomingEdges());
         for (LEdge inEdge : edgeArray) {
             inEdge.setTarget(originPort);
         }
@@ -259,8 +257,7 @@ public final class NorthSouthPortPostprocessor implements ILayoutProcessor<LGrap
         originPort.setProperty(InternalProperties.SPLINE_NS_PORT_Y_COORD, outputPort.getNode().getPosition().y);
 
         // Reroute the edges
-        LEdge[] edgeArray = outputPort.getOutgoingEdges().toArray(
-                new LEdge[outputPort.getOutgoingEdges().size()]);
+        LEdge[] edgeArray = LGraphUtil.toEdgeArray(outputPort.getOutgoingEdges());
         for (LEdge outEdge : edgeArray) {
             outEdge.setSource(originPort);
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPreprocessor.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
@@ -157,7 +158,7 @@ public final class NorthSouthPortPreprocessor implements ILayoutProcessor<LGraph
             pointer = -1;
 
             // Iterate through the nodes (use an array to avoid concurrent modification exceptions)
-            LNode[] nodeArray = layer.getNodes().toArray(new LNode[layer.getNodes().size()]);
+            LNode[] nodeArray = LGraphUtil.toNodeArray(layer.getNodes());
             for (LNode node : nodeArray) {
                 pointer++;
 
@@ -539,8 +540,7 @@ public final class NorthSouthPortPreprocessor implements ILayoutProcessor<LGraph
             dummyInputPort.setNode(dummy);
 
             // Reroute edges
-            LEdge[] edgeArray =
-                    inPort.getIncomingEdges().toArray(new LEdge[inPort.getIncomingEdges().size()]);
+            LEdge[] edgeArray = LGraphUtil.toEdgeArray(inPort.getIncomingEdges());
             for (LEdge edge : edgeArray) {
                 edge.setTarget(dummyInputPort);
             }
@@ -563,9 +563,7 @@ public final class NorthSouthPortPreprocessor implements ILayoutProcessor<LGraph
             dummyOutputPort.setNode(dummy);
 
             // Reroute edges
-            LEdge[] edgeArray =
-                    outPort.getOutgoingEdges()
-                            .toArray(new LEdge[outPort.getOutgoingEdges().size()]);
+            LEdge[] edgeArray = LGraphUtil.toEdgeArray(outPort.getOutgoingEdges());
             for (LEdge edge : edgeArray) {
                 edge.setSource(dummyOutputPort);
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorer.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.intermediate;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.graph.Layer;
@@ -50,8 +51,7 @@ public final class ReversedEdgeRestorer implements ILayoutProcessor<LGraph> {
                 // Iterate over all the ports, looking for outgoing edges that should be reversed
                 for (LPort port : node.getPorts()) {
                     // Iterate over a copy of the edges to avoid concurrent modification exceptions
-                    LEdge[] edgeArray = port.getOutgoingEdges().toArray(
-                            new LEdge[port.getOutgoingEdges().size()]);
+                    LEdge[] edgeArray = LGraphUtil.toEdgeArray(port.getOutgoingEdges());
                     
                     for (LEdge edge : edgeArray) {
                         if (edge.getProperty(InternalProperties.REVERSED)) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointInserter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointInserter.java
@@ -238,6 +238,7 @@ public class BreakingPointInserter implements ILayoutProcessor<LGraph> {
         return noSplitEdges;
     }
     
+    @SuppressWarnings("unused")
     private List<Integer> improveCuts(final LGraph graph, final List<Integer> cuts) {
         
         List<Integer> improvedCuts = Lists.newArrayList();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/InternalProperties.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/InternalProperties.java
@@ -85,17 +85,6 @@ public final class InternalProperties {
             "insideConnections", false);
 
     /**
-     * An LNode that represents a compound node can hold a reference to a nested LGraph which
-     * represents the graph that is contained within the compound node.
-     */
-    public static final IProperty<LGraph> NESTED_LGRAPH = new Property<LGraph>("nestedLGraph");
-
-    /**
-     * A nested LGraph has a reference to the LNode that contains it.
-     */
-    public static final IProperty<LNode> PARENT_LNODE = new Property<LNode>("parentLNode");
-
-    /**
      * The original bend points of an edge.
      */
     public static final IProperty<KVectorChain> ORIGINAL_BENDPOINTS = new Property<KVectorChain>(

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
@@ -17,6 +17,7 @@ import java.util.Random;
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.intermediate.IntermediateProcessorStrategy;
@@ -193,10 +194,9 @@ public final class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
 
         // reverse edges that point left
         for (LNode node : nodes) {
-            LPort[] ports = node.getPorts().toArray(new LPort[node.getPorts().size()]);
+            LPort[] ports = LGraphUtil.toPortArray(node.getPorts());
             for (LPort port : ports) {
-                LEdge[] outgoingEdges = port.getOutgoingEdges().toArray(
-                        new LEdge[port.getOutgoingEdges().size()]);
+                LEdge[] outgoingEdges = LGraphUtil.toEdgeArray(port.getOutgoingEdges());
                 
                 // look at the node's outgoing edges
                 for (LEdge edge : outgoingEdges) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/AbstractBarycenterPortDistributor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/AbstractBarycenterPortDistributor.java
@@ -325,7 +325,7 @@ public abstract class AbstractBarycenterPortDistributor implements ISweepPortDis
     }
 
     private boolean hasNestedGraph(final LNode node) {
-        return node.getProperty(InternalProperties.NESTED_LGRAPH) != null;
+        return node.getNestedGraph() != null;
     }
 
     private boolean isNotFirstLayer(final int length, final int currentIndex,

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GraphInfoHolder.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GraphInfoHolder.java
@@ -78,7 +78,7 @@ public class GraphInfoHolder implements IInitializable {
         currentNodeOrder = graph.toNodeArray();
         
         // Hierarchy information.
-        parent = lGraph.getProperty(InternalProperties.PARENT_LNODE);
+        parent = lGraph.getParentNode();
         hasParent = parent != null;
         parentGraphData = hasParent ? graphs.get(parent.getGraph().id) : null;
         Set<GraphProperties> graphProperties = graph.getProperty(InternalProperties.GRAPH_PROPERTIES);
@@ -256,7 +256,7 @@ public class GraphInfoHolder implements IInitializable {
     @Override
     public void initAtNodeLevel(final int l, final int n, final LNode[][] nodeOrder) {
         LNode node = nodeOrder[l][n];
-        LGraph nestedGraph = node.getProperty(InternalProperties.NESTED_LGRAPH);
+        LGraph nestedGraph = node.getNestedGraph();
         if (nestedGraph != null) {
             childGraphs.add(nestedGraph);
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GreedyPortDistributor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GreedyPortDistributor.java
@@ -53,7 +53,7 @@ public class GreedyPortDistributor implements ISweepPortDistributor, IInitializa
             if (node.getProperty(LayeredOptions.PORT_CONSTRAINTS).isOrderFixed()) {
                 continue;
             }
-            LGraph nestedGraph = node.getProperty(InternalProperties.NESTED_LGRAPH);
+            LGraph nestedGraph = node.getNestedGraph();
             boolean useHierarchicalCrossCounter = !node.getPortSideView(side).isEmpty() && nestedGraph != null;
             if (useHierarchicalCrossCounter) {
                 LNode[][] innerGraph = nestedGraph.toNodeArray();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -128,11 +128,11 @@ public class LayerSweepCrossingMinimizer
     private Consumer<GraphInfoHolder> chooseMinimizingMethod(final List<GraphInfoHolder> graphsToSweepOn) {
         GraphInfoHolder parent = graphsToSweepOn.get(0);
         if (!parent.crossMinDeterministic()) {
-            return g -> compareDifferentRandomizedLayouts(g);
+            return this::compareDifferentRandomizedLayouts;
         } else if (parent.crossMinAlwaysImproves()) {
-            return g -> minimizeCrossingsNoCounter(g);
+            return this::minimizeCrossingsNoCounter;
         } else {
-            return g -> minimizeCrossingsWithCounter(g);
+            return this::minimizeCrossingsWithCounter;
         }
     }
 
@@ -262,7 +262,7 @@ public class LayerSweepCrossingMinimizer
             final boolean isFirstSweep) {
         boolean improved = false;
         for (LNode node : layer) {
-            if (hasNestedGraph(node) && !graphInfoHolders.get(nestedGraphOf(node).id).dontSweepInto()) {
+            if (hasNestedGraph(node) && !graphInfoHolders.get(node.getNestedGraph().id).dontSweepInto()) {
                 improved |= sweepInHierarchicalNode(isForwardSweep, node, isFirstSweep);
             }
         }
@@ -271,7 +271,7 @@ public class LayerSweepCrossingMinimizer
 
     private boolean sweepInHierarchicalNode(final boolean isForwardSweep, final LNode node,
             final boolean isFirstSweep) {
-        LGraph nestedLGraph = nestedGraphOf(node);
+        LGraph nestedLGraph = node.getNestedGraph();
         GraphInfoHolder nestedGraph = graphInfoHolders.get(nestedLGraph.id);
         LNode[][] nestedGraphNodeOrder = nestedGraph.currentNodeOrder();
         int startIndex = firstIndex(isForwardSweep, nestedGraphNodeOrder.length);
@@ -359,12 +359,8 @@ public class LayerSweepCrossingMinimizer
         return isForwardSweep ? freeLayerIndex < length : freeLayerIndex >= 0;
     }
 
-    private LGraph nestedGraphOf(final LNode node) {
-        return node.getProperty(InternalProperties.NESTED_LGRAPH);
-    }
-
     private Boolean hasNestedGraph(final LNode node) {
-        return nestedGraphOf(node) != null;
+        return node.getNestedGraph() != null;
     }
 
     private PortSide sideOpposedSweepDirection(final boolean isForwardSweep) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/SweepCopy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/SweepCopy.java
@@ -86,7 +86,7 @@ class SweepCopy {
     /**
      * @param lGraph
      */
-    public void transferNodeAndPortOrdersToGraph(final LGraph lGraph, boolean setPortContstraints) {
+    public void transferNodeAndPortOrdersToGraph(final LGraph lGraph, final boolean setPortContstraints) {
         
         // the 'NORTH_OR_SOUTH_PORT' option allows the crossing minimizer to decide 
         // the side a corresponding dummy node is placed on in order to reduce the number of crossings

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/ICompactor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/ICompactor.java
@@ -25,6 +25,6 @@ public interface ICompactor {
      * 
      * @param bal One of the four layouts which shall be used in this step
      */
-    void horizontalCompaction(final BKAlignedLayout bal);
+    void horizontalCompaction(BKAlignedLayout bal);
     
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalEdgeRouter.java
@@ -23,7 +23,6 @@ import org.eclipse.elk.alg.layered.intermediate.IntermediateProcessorStrategy;
 import org.eclipse.elk.alg.layered.options.GraphProperties;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
-import org.eclipse.elk.alg.layered.options.Spacings;
 import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
@@ -222,7 +221,6 @@ public final class OrthogonalEdgeRouter implements ILayoutPhase<LayeredPhases, L
         monitor.begin("Orthogonal edge routing", 1);
         
         // Retrieve some generic values
-        Spacings spacings = layeredGraph.getProperty(InternalProperties.SPACINGS);
         double nodeNodeSpacing =
                 layeredGraph.getProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS).doubleValue();
         double edgeEdgeSpacing =

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalRoutingGenerator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalRoutingGenerator.java
@@ -152,18 +152,18 @@ public final class OrthogonalRoutingGenerator {
                 double sourcey = port.getAbsoluteAnchor().y;
 
                 for (LEdge edge : port.getOutgoingEdges()) {
-                    if(!edge.isSelfLoop()) {
-                    LPort target = edge.getTarget();
-                    double targety = target.getAbsoluteAnchor().y;
-                    if (Math.abs(sourcey - targety) > TOLERANCE) {
-                        KVector point1 = new KVector(x, sourcey);
-                        edge.getBendPoints().add(point1);
-                        addJunctionPointIfNecessary(edge, hyperNode, point1, true);
-
-                        KVector point2 = new KVector(x, targety);
-                        edge.getBendPoints().add(point2);
-                        addJunctionPointIfNecessary(edge, hyperNode, point2, true);
-                    }
+                    if (!edge.isSelfLoop()) {
+                        LPort target = edge.getTarget();
+                        double targety = target.getAbsoluteAnchor().y;
+                        if (Math.abs(sourcey - targety) > TOLERANCE) {
+                            KVector point1 = new KVector(x, sourcey);
+                            edge.getBendPoints().add(point1);
+                            addJunctionPointIfNecessary(edge, hyperNode, point1, true);
+    
+                            KVector point2 = new KVector(x, targety);
+                            edge.getBendPoints().add(point2);
+                            addJunctionPointIfNecessary(edge, hyperNode, point2, true);
+                        }
                     }
                 }
             }
@@ -209,18 +209,19 @@ public final class OrthogonalRoutingGenerator {
                 double sourcex = port.getAbsoluteAnchor().x;
 
                 for (LEdge edge : port.getOutgoingEdges()) {
-                    if(!edge.isSelfLoop()) {
-                    LPort target = edge.getTarget();
-                    double targetx = target.getAbsoluteAnchor().x;
-                    if (Math.abs(sourcex - targetx) > TOLERANCE) {
-                        KVector point1 = new KVector(sourcex, y);
-                        edge.getBendPoints().add(point1);
-                        addJunctionPointIfNecessary(edge, hyperNode, point1, false);
-
-                        KVector point2 = new KVector(targetx, y);
-                        edge.getBendPoints().add(point2);
-                        addJunctionPointIfNecessary(edge, hyperNode, point2, false);
-                    }}
+                    if (!edge.isSelfLoop()) {
+                        LPort target = edge.getTarget();
+                        double targetx = target.getAbsoluteAnchor().x;
+                        if (Math.abs(sourcex - targetx) > TOLERANCE) {
+                            KVector point1 = new KVector(sourcex, y);
+                            edge.getBendPoints().add(point1);
+                            addJunctionPointIfNecessary(edge, hyperNode, point1, false);
+    
+                            KVector point2 = new KVector(targetx, y);
+                            edge.getBendPoints().add(point2);
+                            addJunctionPointIfNecessary(edge, hyperNode, point2, false);
+                        }
+                    }
                 }
             }
         }
@@ -266,19 +267,20 @@ public final class OrthogonalRoutingGenerator {
 
                 for (LEdge edge : port.getOutgoingEdges()) {
 
-                    if(!edge.isSelfLoop()) {
-                    LPort target = edge.getTarget();
-                    double targetx = target.getAbsoluteAnchor().x;
-                    if (Math.abs(sourcex - targetx) > TOLERANCE) {
-                        KVector point1 = new KVector(sourcex, y);
-                        edge.getBendPoints().add(point1);
-                        addJunctionPointIfNecessary(edge, hyperNode, point1, false);
-
-                        KVector point2 = new KVector(targetx, y);
-                        edge.getBendPoints().add(point2);
-                        addJunctionPointIfNecessary(edge, hyperNode, point2, false);
+                    if (!edge.isSelfLoop()) {
+                        LPort target = edge.getTarget();
+                        double targetx = target.getAbsoluteAnchor().x;
+                        if (Math.abs(sourcex - targetx) > TOLERANCE) {
+                            KVector point1 = new KVector(sourcex, y);
+                            edge.getBendPoints().add(point1);
+                            addJunctionPointIfNecessary(edge, hyperNode, point1, false);
+    
+                            KVector point2 = new KVector(targetx, y);
+                            edge.getBendPoints().add(point2);
+                            addJunctionPointIfNecessary(edge, hyperNode, point2, false);
+                        }
                     }
-                }}
+                }
             }
         }
     }
@@ -375,7 +377,7 @@ public final class OrthogonalRoutingGenerator {
             Iterator<LPort> portIter = ports.iterator();
             while (portIter.hasNext()) {
                 LPort port = portIter.next();
-                String name = port.getNode().getName();
+                String name = port.getNode().getDesignation();
                 if (name == null) {
                     name = "n" + port.getNode().getIndex();
                 }


### PR DESCRIPTION
 * Replaced `NESTED_LGRAPH` and `PARENT_LNODE` properties with direct references.
 * Added `toNodeArray(..)`, `toEdgeArray(..)`,` toPortArray(..)` utilities.
 * Added `getDesignation()` to LGraphElement, removed `getName()` from LNode.
 * Changed the `toString()` output of graph elements so it’s more useful while debugging.
 * Removed two lines of duplicate code in CompoundGraphPreprocessor.
 * Use method references instead of trivial lambda expressions in LayerSweepCrossingMinimizer.
 * Eliminated compiler and CheckStyle warnings.