### PR TITLE
Create SelfLoopLabels only for edges that are actually self-loops

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SelfLoopPreProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SelfLoopPreProcessor.java
@@ -96,6 +96,7 @@ public final class SelfLoopPreProcessor implements ILayoutProcessor<LGraph> {
         for (SelfLoopComponent component : slNode.getSelfLoopComponents()) {
             // Retrieve all labels attached to edges that belong to this component
             List<LLabel> labels = component.getConnectedEdges().stream()
+                .filter(edge -> edge.getEdge().getSource().getNode().equals(edge.getEdge().getTarget().getNode()))
                 .flatMap(edge -> edge.getEdge().getLabels().stream())
                 .sorted(new Comparator<LLabel>() {
                     @Override


### PR DESCRIPTION
 * Fixes #407 by creating SelfLoopLabels only for edges that are actually self-loops.
 * Simplified the code of `SelfLoopComponent.createSelfLoopComponents(SelfLoopNode)`.