### PR TITLE
Added null guards for IPropertyValueProxy processing

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/LayoutOptionValidator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/LayoutOptionValidator.java
@@ -36,14 +36,17 @@ public class LayoutOptionValidator implements IValidatingGraphElementVisitor {
     @Override
     public void visit(final ElkGraphElement element) {
         for (Map.Entry<IProperty<?>, Object> entry : element.getProperties()) {
-            Object value = entry.getValue();
-            if (value instanceof IPropertyValueProxy) {
-                value = ((IPropertyValueProxy) value).resolveValue(entry.getKey());
-                if (value != null) {
-                    entry.setValue(value);
+            IProperty<?> property = entry.getKey();
+            if (property != null) {
+                Object value = entry.getValue();
+                if (value instanceof IPropertyValueProxy) {
+                    value = ((IPropertyValueProxy) value).resolveValue(property);
+                    if (value != null) {
+                        entry.setValue(value);
+                    }
                 }
+                issues.addAll(checkProperty((IProperty<Object>) property, value, element));
             }
-            issues.addAll(checkProperty((IProperty<Object>) entry.getKey(), value, element));
         }
     }
     

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/EMapPropertyHolderImpl.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/EMapPropertyHolderImpl.java
@@ -178,7 +178,7 @@ public abstract class EMapPropertyHolderImpl extends MinimalEObjectImpl.Containe
         
         // check for unresolved properties
         for (Map.Entry<IProperty<?>, Object> entry : props) {
-            if (entry.getValue() instanceof IPropertyValueProxy) {
+            if (entry.getValue() instanceof IPropertyValueProxy && entry.getKey() != null) {
                 IPropertyValueProxy proxy = (IPropertyValueProxy) entry.getValue();
                 
                 // Try to resolve the proxy's value, maybe the layout option was 


### PR DESCRIPTION
Without these guards, NullPointerExceptions can fly around when you try to process a graph with references to unknown properties, e.g. after loading it from an `elkt` file.