### PR TITLE
alg.disco.debug: The View icon is not displaying properly

### DIFF
--- a/plugins/org.eclipse.elk.alg.disco.debug/build.properties
+++ b/plugins/org.eclipse.elk.alg.disco.debug/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
+               icons,\
                about.html


### PR DESCRIPTION
- Added the icons folder into the build.properties

Signed-off-by: Quentin Le Menez <quentin.lemenez@cea.fr>