### PR TITLE
Don’t create self-loop edges for edges that are not self-loops

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SelfLoopPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SelfLoopPlacer.java
@@ -119,10 +119,11 @@ public final class SelfLoopPlacer implements ILayoutProcessor<LGraph> {
 
         case FIXED_ORDER:
         case FIXED_POS:
+        case FIXED_RATIO:
             return new FixedOrderSelfLoopPortPositioner();
 
         default:
-            return null;
+            throw new AssertionError("Unknown port constraint: " + constraint);
         }
 
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SelfLoopPreProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SelfLoopPreProcessor.java
@@ -96,7 +96,7 @@ public final class SelfLoopPreProcessor implements ILayoutProcessor<LGraph> {
         for (SelfLoopComponent component : slNode.getSelfLoopComponents()) {
             // Retrieve all labels attached to edges that belong to this component
             List<LLabel> labels = component.getConnectedEdges().stream()
-                .filter(edge -> edge.getEdge().getSource().getNode().equals(edge.getEdge().getTarget().getNode()))
+                .filter(edge -> edge.getEdge().isSelfLoop())
                 .flatMap(edge -> edge.getEdge().getLabels().stream())
                 .sorted(new Comparator<LLabel>() {
                     @Override
@@ -149,7 +149,7 @@ public final class SelfLoopPreProcessor implements ILayoutProcessor<LGraph> {
      * Collect and remove ports that are only self-loop ports.
      */
     private void hidePorts(final LNode node) {
-        List<LPort> selfLoopPorts = new ArrayList<LPort>();
+        List<LPort> selfLoopPorts = new ArrayList<LPort>(node.getPorts().size());
 
         // check each port if has to be hidden
         for (LPort port : node.getPorts()) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopComponent.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopComponent.java
@@ -30,13 +30,13 @@ import org.eclipse.elk.core.options.PortSide;
 public class SelfLoopComponent {
 
     /** The ports of the self loop component. They are all connected by at least one edge. */
-    private List<SelfLoopPort> ports = new ArrayList<>();
+    private final List<SelfLoopPort> ports;
     /** All center edge labels that occur at the component edges, if any. */
     private SelfLoopLabel selfLoopLabel;
     /** The components that the self loop component depends on. */
-    private Map<SelfLoopNodeSide, List<SelfLoopComponent>> dependencyComponents = new HashMap<>();
+    private final Map<SelfLoopNodeSide, List<SelfLoopComponent>> dependencyComponents = new HashMap<>();
     /** Any edges the component depends on. */
-    private Map<PortSide, List<SelfLoopEdge>> edgeDependencies = new HashMap<>();
+    private final Map<PortSide, List<SelfLoopEdge>> edgeDependencies = new HashMap<>();
 
     
     /**
@@ -46,6 +46,7 @@ public class SelfLoopComponent {
      *            Ports of the connected self loop component.
      */
     public SelfLoopComponent(final List<LPort> ports) {
+        this.ports = new ArrayList<>(ports.size());
         addAllPorts(ports);
         calculateConnectedEdges();
     }
@@ -113,7 +114,7 @@ public class SelfLoopComponent {
     /**
      * Adds a {@link SelfLoopPort} to the component that represents the given regular port.
      */
-    public void addPort(final LPort port) {
+    private void addPort(final LPort port) {
         ports.add(new SelfLoopPort(port, this));
     }
 
@@ -224,9 +225,9 @@ public class SelfLoopComponent {
         for (SelfLoopPort port : ports) {
             for (LEdge edge : port.getLPort().getOutgoingEdges()) {
                 SelfLoopPort targetPort = findPort(edge.getTarget());
-                SelfLoopEdge selfLoopEdge = new SelfLoopEdge(this, port, targetPort, edge);
-                port.getConnectedEdges().add(selfLoopEdge);
                 if (targetPort != null) {
+                    SelfLoopEdge selfLoopEdge = new SelfLoopEdge(this, port, targetPort, edge);
+                    port.getConnectedEdges().add(selfLoopEdge);
                     targetPort.getConnectedEdges().add(selfLoopEdge);
                 }
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopEdge.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopEdge.java
@@ -29,9 +29,9 @@ public class SelfLoopEdge {
     /** The component the self loop belongs to. */
     private final SelfLoopComponent component;
     /** Other self loops this self loop depends on. */
-    private Map<PortSide, List<SelfLoopEdge>> dependencyEdges = new HashMap<>();
+    private final Map<PortSide, List<SelfLoopEdge>> dependencyEdges = new HashMap<>();
     /** TODO Document. */
-    private Map<PortSide, Integer> edgeOrders = new HashMap<>();
+    private final Map<PortSide, Integer> edgeOrders = new HashMap<>();
 
     /**
      * Create a new self loop.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopLabel.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopLabel.java
@@ -18,13 +18,13 @@ import org.eclipse.elk.alg.layered.graph.LLabel;
 public class SelfLoopLabel {
 
     /** The list of labels this self loop label consists of. */
-    private List<LLabel> labels = new ArrayList<>();
+    private final List<LLabel> labels = new ArrayList<>();
     /** The combined height of all labels. */
     private double height;
     /** The maximum width over all labels. */
     private double width;
     /** The candidate positions for this label. */
-    private List<SelfLoopLabelPosition> candidatePositions = new ArrayList<>();
+    private final List<SelfLoopLabelPosition> candidatePositions = new ArrayList<>();
     /** The position chosen for this label. */
     private SelfLoopLabelPosition labelPosition;
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopNode.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopNode.java
@@ -24,9 +24,9 @@ public class SelfLoopNode {
     /** The original node this class represents. */
     private final LNode node;
     /** A map from all four port sides to their respective node side objects. */
-    private EnumMap<PortSide, SelfLoopNodeSide> nodeSides = new EnumMap<>(PortSide.class);
+    private final EnumMap<PortSide, SelfLoopNodeSide> nodeSides = new EnumMap<>(PortSide.class);
     /** List of self loop components this node has. */
-    private List<SelfLoopComponent> selfLoopComponents = new ArrayList<>();
+    private final List<SelfLoopComponent> selfLoopComponents = new ArrayList<>();
 
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopNodeSide.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopNodeSide.java
@@ -24,7 +24,7 @@ public class SelfLoopNodeSide {
     /** The actual side information. */
     private final PortSide side;
     /** The ports which are placed on this node side. */
-    private List<SelfLoopPort> ports = new ArrayList<>();
+    private final List<SelfLoopPort> ports = new ArrayList<>();
     /** The maximum level a port on this side has. */
     private int maximumPortLevel;
     /** The maximum level a segment on this side has. */
@@ -32,9 +32,9 @@ public class SelfLoopNodeSide {
     /** The maximum offset which has to be considered when calculating the margin of the node. */
     private double maximumLabelOffset;
     /** The segments which belong to an opposing self loop (space has to be reserved for them). */
-    private Map<SelfLoopEdge, SelfLoopOpposingSegment> opposingSegments = new HashMap<>();
+    private final Map<SelfLoopEdge, SelfLoopOpposingSegment> opposingSegments = new HashMap<>();
     /** The roots of the component dependency graph. They hold the outermost components of the node side. */
-    private Set<SelfLoopComponent> componentDependencies = new HashSet<>();
+    private final Set<SelfLoopComponent> componentDependencies = new HashSet<>();
 
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopPort.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/SelfLoopPort.java
@@ -30,11 +30,11 @@ public class SelfLoopPort {
     /** The level of the edge segment. */
     private int maximumLevel = 0;
     /** Map about the different level for the different edges connected to this port. */
-    private Map<LEdge, Integer> edgeToLevelMap = new HashMap<>();
+    private final Map<LEdge, Integer> edgeToLevelMap = new HashMap<>();
     /** The SelfLoopComponent the port belongs to. */
     private SelfLoopComponent component;
     /** Self loops connected to this port. */
-    private List<SelfLoopEdge> connectedEdges = new ArrayList<>();
+    private final List<SelfLoopEdge> connectedEdges = new ArrayList<>();
     /** The port is connected to an edge connecting it to another node. */
     private boolean isNonLoopPort = false;
     /** The original index of the port before using the linear node representation or altering the port order. */

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/calculators/SelfLoopComponentDependencyGraphCalculator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/loops/calculators/SelfLoopComponentDependencyGraphCalculator.java
@@ -196,7 +196,7 @@ public final class SelfLoopComponentDependencyGraphCalculator {
                 List<SelfLoopPort> sidePorts = component.getPortsOfSide(currentSide);
                 
                 // filter non-loop components
-                if (component.getPorts().size() > 1) {
+                if (ports.size() > 1) {
                     List<SelfLoopEdge> dependencies = calculateEdgeOrder(
                             ports, sidePorts, new HashSet<SelfLoopEdge>(), currentSide, false);
                     component.getEdgeDependencies().put(currentSide, dependencies);


### PR DESCRIPTION
Fixes #417. Includes some code cleanup.

The relevant change is in `SelfLoopComponent#calculateConnectedEdges()`. If the target port of an outgoing edge belongs to a different node, the SelfLoopEdge creation is skipped. Without this change, a SelfLoopEdge with `null` target was created.