### PR TITLE
Bug/automatically select loaded file

### DIFF
--- a/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LayoutGraphView.java
+++ b/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LayoutGraphView.java
@@ -32,6 +32,9 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.custom.StackLayout;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.FileTransfer;
+import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 
@@ -177,6 +180,10 @@ public class LayoutGraphView extends AbstractLayoutDebugView {
     @Override
     protected void customizeTreeViewer(TreeViewer treeViewer) {
         treeViewer.setLabelProvider(new DelegatingStyledCellLabelProvider(new GraphTreeLabelProvider()));
+        // Add drop support for file
+        int ops = DND.DROP_COPY | DND.DROP_MOVE;
+        Transfer[] transfers = new Transfer[] {FileTransfer.getInstance()};
+        treeViewer.addDropSupport(ops, transfers, new LayoutGraphViewDropAdapter(this, treeViewer));
     }
     
     @Override

--- a/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LayoutGraphView.java
+++ b/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LayoutGraphView.java
@@ -45,7 +45,7 @@ public class LayoutGraphView extends AbstractLayoutDebugView {
     
     // Actions
     private final LayoutUponLoadSettingAction layoutUponLoadSettingAction = new LayoutUponLoadSettingAction();
-    private final LoadGraphAction loadGraphAction = new LoadGraphAction();
+    private final LoadGraphAction loadGraphAction = new LoadGraphAction(this);
     private final ReloadFromFileAction reloadFromFileAction = new ReloadFromFileAction(this);
     private final ImageExportAction saveImageAction = new ImageExportAction(this);
     

--- a/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LayoutGraphViewDropAdapter.java
+++ b/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LayoutGraphViewDropAdapter.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Obeo and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.elk.core.debug.views.graph;
+
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerDropAdapter;
+import org.eclipse.swt.dnd.FileTransfer;
+import org.eclipse.swt.dnd.TransferData;
+
+/**
+ * This adapter provides a drop support for the tree viewer of the Layout Graph view.
+ */
+public class LayoutGraphViewDropAdapter extends ViewerDropAdapter {
+    /**
+     * The Layout Graph view containing the viewer to which this drop support has been added.
+     */
+    private LayoutGraphView layoutGraphView;
+    
+    /**
+     * Creates a new drop adapter for the given viewer.
+     *
+     * @param layoutGraphView the Layout Graph view containing the viewer
+     * @param viewer the viewer
+     */
+    public LayoutGraphViewDropAdapter(final LayoutGraphView layoutGraphView, final Viewer viewer) {
+        super(viewer);
+        this.layoutGraphView = layoutGraphView;
+    }
+    
+    public boolean validateDrop(final Object target, final int operation, final TransferData transferType) {
+        return FileTransfer.getInstance().isSupportedType(transferType);
+    }
+    
+    @Override
+    public boolean performDrop(final Object data) {
+        boolean result = true;
+        String[] filePathsToDrop = (String[])data;
+        if (filePathsToDrop.length == 0) {
+            result = false;
+        }
+        for (String filePathToDrop : filePathsToDrop) {
+            LoadGraphAction.run(filePathToDrop, layoutGraphView);
+        }
+        return result;
+    }
+}

--- a/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LoadGraphAction.java
+++ b/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LoadGraphAction.java
@@ -72,14 +72,24 @@ public class LoadGraphAction extends Action {
 
         // Open the file dialog and wait for file name
         String fileName = fileDialog.open();
-
-        if (fileName != null) {
-            prefStore.setValue(LAST_FILE_NAME_PREF, fileName);
+        run(fileName, view);
+    }
+    
+    /**
+     * Load an ELK graph file and performing layout on it.
+     * 
+     * @param fullFilePath The full path of the file to load.
+     * @param layoutGraphView The Layout Graph view
+     */
+    public static void run(final String fullFilePath, final LayoutGraphView layoutGraphView) {
+        IPreferenceStore prefStore = ElkDebugPlugin.getDefault().getPreferenceStore();
+        if (fullFilePath != null) {
+            prefStore.setValue(LAST_FILE_NAME_PREF, fullFilePath);
 
             // Load the file content
             try {
-                ElkNode content = loadFromFile(fileName);
-                ExecutionInfo info = layout(fileName, content);
+                ElkNode content = loadFromFile(fullFilePath);
+                ExecutionInfo info = layout(fullFilePath, content);
                 ElkDebugPlugin.getDefault().getModel().addExecution(info);
                 // Select the new loaded element (made in async to let the view refresh before)
                 layoutGraphView.getSite().getShell().getDisplay().asyncExec(new Runnable() {

--- a/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LoadGraphAction.java
+++ b/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/LoadGraphAction.java
@@ -33,6 +33,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 
+import com.google.common.collect.Lists;
+
 /**
  * An action for loading an ELK graph file and performing layout on it.
  */
@@ -46,11 +48,16 @@ public class LoadGraphAction extends Action {
     /** preference identifier for the last used file name. */
     private static final String LAST_FILE_NAME_PREF = "loadGraphAction.lastGraphFile";
 
-    public LoadGraphAction() {
+    /** The layout graph view associated with this action. */
+    private LayoutGraphView view;
+    
+    public LoadGraphAction(final LayoutGraphView theview) {
         setId(ACTION_ID);
         setText("Load Graph");
         setToolTipText("Load, layout, and display a saved ELK graph.");
         setImageDescriptor(ElkDebugPlugin.imageDescriptorFromPlugin(ElkDebugPlugin.PLUGIN_ID, ICON_PATH));
+        
+        this.view = theview;
     }
 
     @Override
@@ -74,6 +81,13 @@ public class LoadGraphAction extends Action {
                 ElkNode content = loadFromFile(fileName);
                 ExecutionInfo info = layout(fileName, content);
                 ElkDebugPlugin.getDefault().getModel().addExecution(info);
+                // Select the new loaded element (made in async to let the view refresh before)
+                layoutGraphView.getSite().getShell().getDisplay().asyncExec(new Runnable() {
+                    @Override
+                    public void run() {
+                        layoutGraphView.setSelectedExecutionInfos(Lists.newArrayList(info));
+                    }
+                });
             } catch (IOException exception) {
                 throw new WrappedException(exception);
             }

--- a/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/ReloadFromFileAction.java
+++ b/plugins/org.eclipse.elk.core.debug/src/org/eclipse/elk/core/debug/views/graph/ReloadFromFileAction.java
@@ -68,7 +68,13 @@ public class ReloadFromFileAction extends Action {
             ElkNode graph = LoadGraphAction.loadFromFile(oldInfo.getFileName());
             ExecutionInfo newInfo = LoadGraphAction.layout(oldInfo.getFileName(), oldInfo.isLaidOutAfterLoad(), graph);
             ElkDebugPlugin.getDefault().getModel().replaceExecution(oldInfo, newInfo);
-            view.setSelectedExecutionInfos(Lists.newArrayList(newInfo));
+            // We change selection in async to let the view refresh before
+            view.getSite().getShell().getDisplay().asyncExec(new Runnable() {
+                @Override
+                public void run() {
+                    view.setSelectedExecutionInfos(Lists.newArrayList(newInfo));
+                }
+            });
             
         } catch (IOException e) {
             throw new WrappedException(e);


### PR DESCRIPTION
I've made several changes in the Layout Graph view:

- Automatically view the result of a reload file
- Directly see the result of a load file
- Allowing the drag'n'drop of a file instead of using loading action