### PR TITLE
discodebug: Fix build properties to include icons

### DIFF
--- a/plugins/org.eclipse.elk.alg.disco.debug/build.properties
+++ b/plugins/org.eclipse.elk.alg.disco.debug/build.properties
@@ -3,5 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               icons,\
+               icons/,\
                about.html


### PR DESCRIPTION
The disco.debug-plugin does not correctly include the icons folder in the binary file. Since icons is a folder a slash has to be added.

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>