### PR TITLE
first draft of enabling 'CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE' for outside port labels

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/PortContext.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/PortContext.java
@@ -74,4 +74,7 @@ public final class PortContext {
     }
     
     
+    public boolean hasExternalConnections() {
+        return port.getIncomingEdges().iterator().hasNext() || port.getOutgoingEdges().iterator().hasNext();
+    }
 }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
@@ -218,4 +218,8 @@ public final class NodeLabelAndSizeUtilities {
         }
     }
     
+    public static boolean mayHaveFirstOutsideLabelNextToPort(final PortContext portContext) {
+        return !portContext.hasExternalConnections()
+            && portContext.parentNodeContext.node.getProperty(CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE);
+    }
 }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.common.nodespacing.internal.algorithm;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.AtomicCell;
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.HorizontalLabelAlignment;
@@ -27,6 +28,7 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.options.SizeConstraint;
 import org.eclipse.elk.core.options.SizeOptions;
+import org.eclipse.elk.core.util.adapters.GraphAdapters.LabelAdapter;
 
 /**
  * Knows how to place port labels.
@@ -355,10 +357,15 @@ public final class PortLabelPlacementCalculator {
             portLabelCellRect.width = portLabelCell.getMinimumWidth();
             portLabelCellRect.height = portLabelCell.getMinimumHeight();
             
+            Iterator<LabelAdapter<?>> labels = portContext.port.getLabels().iterator();
+            
             // Calculate the position of the port's label space
             switch (portSide) {
             case NORTH:
-                if (portWithSpecialNeeds) {
+                if (labels.hasNext() && NodeLabelAndSizeUtilities.mayHaveFirstOutsideLabelNextToPort(portContext)) {
+                    portLabelCellRect.x = (portSize.x - /* portLabelCellRect.width */ labels.next().getSize().x) / 2;
+                    portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
+                } else if (portWithSpecialNeeds) {
                     portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacing;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 } else {
@@ -370,7 +377,10 @@ public final class PortLabelPlacementCalculator {
                 break;
                 
             case SOUTH:
-                if (portWithSpecialNeeds) {
+                if (labels.hasNext() && NodeLabelAndSizeUtilities.mayHaveFirstOutsideLabelNextToPort(portContext)) {
+                    portLabelCellRect.x = (portSize.x - /* portLabelCellRect.width */ labels.next().getSize().x) / 2;
+                    portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
+                } else if (portWithSpecialNeeds) {
                     portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacing;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 } else {
@@ -383,7 +393,10 @@ public final class PortLabelPlacementCalculator {
                 
             case EAST:
                 portLabelCellRect.x = portSize.x + nodeContext.portLabelSpacing;
-                if (portWithSpecialNeeds) {
+                if (labels.hasNext() && NodeLabelAndSizeUtilities.mayHaveFirstOutsideLabelNextToPort(portContext)) {
+                    portLabelCellRect.y = (portSize.y - /* portLabelCellRect.height */ labels.next().getSize().y) / 2;
+                    portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
+                } else if (portWithSpecialNeeds) {
                     portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacing;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
                 } else {
@@ -396,7 +409,10 @@ public final class PortLabelPlacementCalculator {
                 
             case WEST:
                 portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacing;
-                if (portWithSpecialNeeds) {
+                if (labels.hasNext() && NodeLabelAndSizeUtilities.mayHaveFirstOutsideLabelNextToPort(portContext)) {
+                    portLabelCellRect.y = (portSize.y - /* portLabelCellRect.height */ labels.next().getSize().y) / 2;
+                    portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
+                } else if (portWithSpecialNeeds) {
                     portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacing;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
                 } else {


### PR DESCRIPTION
This PR provides a draft on enabling the port label arrangement as demanded in #491.

However, I surrendered while trying to adapt the node size and margin calculations, esp. for the external port dummy nodes. This seems to be extremely distributed among the various components of the layered layout algorithm and the included generic parts.