### PR TITLE
Change how layout algorithms are resolved

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutAlgorithmResolver.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutAlgorithmResolver.java
@@ -30,28 +30,66 @@ public class LayoutAlgorithmResolver implements IGraphElementVisitor {
     }
     
     /**
-     * Resolve the layout algorithm to apply to the content of the given node.
+     * Resolve the layout algorithm to apply to the content of the given node. If no algorithm is configured for the
+     * given node but should be, we try to resolve the {@link #getDefaultLayoutAlgorithmID() default algorithm}. If the
+     * algorithm configured for the node does not exist, an exception is thrown instead.
+     * 
+     * @param node
+     *            the node to resolve the layout algorithm for.
+     * @throws UnsupportedConfigurationException
+     *             if a non-existent layout algorithm was configured for the node.
      */
     protected void resolveAlgorithm(final ElkNode node) {
         String algorithmId = node.getProperty(CoreOptions.ALGORITHM);
-        LayoutAlgorithmData data = LayoutMetaDataService.getInstance().getAlgorithmDataBySuffixOrDefault(
-                algorithmId, getDefaultLayoutAlgorithmID());
-        if (data != null) {
-            // Assign the algorithm meta data to this node
-            node.setProperty(CoreOptions.RESOLVED_ALGORITHM, data);
-        } else if (mustResolve(node)) {
-            // We must resolve the algorithm for this node, but failed to do so
-            if (algorithmId == null || algorithmId.isEmpty()) {
-                StringBuilder message = new StringBuilder("No layout algorithm has been specified for ");
-                ElkUtil.printElementPath(node, message);
-                throw new UnsupportedConfigurationException(message.toString());
-            } else {
-                StringBuilder message = new StringBuilder("Layout algorithm '");
-                message.append(algorithmId);
-                message.append("' not found for ");
-                ElkUtil.printElementPath(node, message);
-                throw new UnsupportedConfigurationException(message.toString());
-            }
+        
+        // Stage 1: Try to resolve the intended algorithm
+        if (resolveAndSetAlgorithm(algorithmId, node)) {
+            return;
+        }
+        
+        // Stage 2: If we must resolve a layout algorithm, try to fall back on the default if none was specified
+        if (mustResolve(node)) {
+             if (algorithmId == null || algorithmId.trim().isEmpty()) {
+                 // No algorithm was specified, load the default one
+                 String defaultAlgorithmId = getDefaultLayoutAlgorithmID();
+                 
+                 if (!resolveAndSetAlgorithm(getDefaultLayoutAlgorithmID(), node)) {
+                     StringBuilder message = new StringBuilder("Unable to load default layout algorithm ")
+                             .append(defaultAlgorithmId)
+                             .append(" for unconfigured node ");
+                     ElkUtil.printElementPath(node, message);
+                     throw new UnsupportedConfigurationException(message.toString());
+                 }
+             
+             } else {
+                 // An algorithm was specified, but not found. Fail!
+                 StringBuilder message = new StringBuilder("Layout algorithm '")
+                         .append(algorithmId)
+                         .append("' not found for ");
+                 ElkUtil.printElementPath(node, message);
+                 throw new UnsupportedConfigurationException(message.toString());
+             }
+        }
+    }
+    
+    /**
+     * Tries to resolve the layout algorithm with the given ID. If one is found, the node's
+     * {@link CoreOptions#RESOLVED_ALGORITHM} is set accordingly.
+     * 
+     * @param algorithmId
+     *            the algorithm to resolve.
+     * @param node
+     *            the node to resolve it for.
+     * @return {@code true} if the algorithm was resolved and stored.
+     */
+    protected boolean resolveAndSetAlgorithm(final String algorithmId, final ElkNode node) {
+        LayoutAlgorithmData algorithmData = LayoutMetaDataService.getInstance().getAlgorithmDataBySuffix(algorithmId);
+        
+        if (algorithmData != null) {
+            node.setProperty(CoreOptions.RESOLVED_ALGORITHM, algorithmData);
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/RecursiveGraphLayoutEngineTest.java
+++ b/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/RecursiveGraphLayoutEngineTest.java
@@ -11,6 +11,7 @@ package org.eclipse.elk.core;
 
 import static org.junit.Assert.*;
 
+import org.eclipse.elk.alg.test.PlainJavaInitialization;
 import org.eclipse.elk.core.RecursiveGraphLayoutEngine;
 import org.eclipse.elk.core.UnsupportedConfigurationException;
 import org.eclipse.elk.core.data.LayoutAlgorithmData;
@@ -19,6 +20,7 @@ import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.util.BasicProgressMonitor;
 import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -26,16 +28,9 @@ import org.junit.Test;
  */
 public class RecursiveGraphLayoutEngineTest {
     
-    @Test
-    public void testResolvedGraph() {
-        Graph graph = new Graph();
-        LayoutAlgorithmData algorithmData = LayoutMetaDataService.getInstance().getAlgorithmData("org.eclipse.elk.box");
-        graph.root.setProperty(CoreOptions.RESOLVED_ALGORITHM, algorithmData);
-        RecursiveGraphLayoutEngine engine = new RecursiveGraphLayoutEngine();
-        engine.layout(graph.root, new BasicProgressMonitor());
-        
-        assertTrue(graph.root.getWidth() > 0);
-        assertTrue(graph.root.getHeight() > 0);
+    @BeforeClass
+    public static void initPlainJavaLayout() {
+        PlainJavaInitialization.initializePlainJavaLayout();
     }
     
     @Test
@@ -49,21 +44,33 @@ public class RecursiveGraphLayoutEngineTest {
         assertTrue(graph.root.getHeight() > 0);
     }
     
-    @Test//(expected = UnsupportedConfigurationException.class)
-    public void testUnknownAlgorithm() {
+    @Test
+    public void testResolvedGraph() {
+        Graph graph = new Graph();
+        LayoutAlgorithmData algorithmData = LayoutMetaDataService.getInstance().getAlgorithmData("org.eclipse.elk.box");
+        graph.root.setProperty(CoreOptions.RESOLVED_ALGORITHM, algorithmData);
+        RecursiveGraphLayoutEngine engine = new RecursiveGraphLayoutEngine();
+        engine.layout(graph.root, new BasicProgressMonitor());
+        
+        assertTrue(graph.root.getWidth() > 0);
+        assertTrue(graph.root.getHeight() > 0);
+    }
+    
+    @Test(expected = UnsupportedConfigurationException.class)
+    public void testUnknownAlgorithmId() {
         Graph graph = new Graph();
         graph.root.setProperty(CoreOptions.ALGORITHM, "foo.Bar");
         RecursiveGraphLayoutEngine engine = new RecursiveGraphLayoutEngine();
+        engine.layout(graph.root, new BasicProgressMonitor());
+    }
+    
+    @Test
+    public void testEmptyAlgorithmId() {
+        Graph graph = new Graph();
+        RecursiveGraphLayoutEngine engine = new RecursiveGraphLayoutEngine();
+        engine.layout(graph.root, new BasicProgressMonitor());
         
-        // We expect the layout call to throw an exception
-        try {
-            engine.layout(graph.root, new BasicProgressMonitor());
-        } catch (UnsupportedConfigurationException e) {
-            return;
-        }
-        
-        // If we reach this line, something has failed
-        fail("Layout algorithm foo.Bar resolved to " + graph.root.getProperty(CoreOptions.RESOLVED_ALGORITHM));
+        assertEquals("org.eclipse.elk.layered", graph.root.getProperty(CoreOptions.RESOLVED_ALGORITHM).getId());
     }
     
     private class Graph {

--- a/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/RecursiveGraphLayoutEngineTest.java
+++ b/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/RecursiveGraphLayoutEngineTest.java
@@ -49,12 +49,21 @@ public class RecursiveGraphLayoutEngineTest {
         assertTrue(graph.root.getHeight() > 0);
     }
     
-    @Test(expected = UnsupportedConfigurationException.class)
+    @Test//(expected = UnsupportedConfigurationException.class)
     public void testUnknownAlgorithm() {
         Graph graph = new Graph();
         graph.root.setProperty(CoreOptions.ALGORITHM, "foo.Bar");
         RecursiveGraphLayoutEngine engine = new RecursiveGraphLayoutEngine();
-        engine.layout(graph.root, new BasicProgressMonitor());
+        
+        // We expect the layout call to throw an exception
+        try {
+            engine.layout(graph.root, new BasicProgressMonitor());
+        } catch (UnsupportedConfigurationException e) {
+            return;
+        }
+        
+        // If we reach this line, something has failed
+        fail("Layout algorithm foo.Bar resolved to " + graph.root.getProperty(CoreOptions.RESOLVED_ALGORITHM));
     }
     
     private class Graph {


### PR DESCRIPTION
This pull request changes the way `LayoutAlgorithmResolver` handles the case when layout algorithm resolution fails. It tries the default algorithm only if no algorithm was specified. If an algorithm was specified, but fails to resolve, this is now treated as an error since that is most certainly not what the user wanted.