### PR TITLE
Fixed problems with rect packing algorithm

### DIFF
--- a/plugins/org.eclipse.elk.alg.packing.rectangles/src/org/eclipse/elk/alg/packing/rectangles/RectPacking.melk
+++ b/plugins/org.eclipse.elk.alg.packing.rectangles/src/org/eclipse/elk/alg/packing/rectangles/RectPacking.melk
@@ -23,7 +23,7 @@ bundle {
 
 //ALGORITHM
 algorithm rectPacking (RectPackingLayoutProvider) {
-    label "Rectangle Layout."
+    label "Rectangle Packing"
     description "Algorithm for packing of unconnected boxes, i.e. graphs without edges. The given order of the boxes
         is always preserved and the main reading direction of the boxes is left to right. The algorithm is divided into
         two phases. One phase approximates the width in which the rectangles can be placed. The next phase places the rectangles

--- a/plugins/org.eclipse.elk.alg.packing.rectangles/src/org/eclipse/elk/alg/packing/rectangles/seconditeration/Compaction.java
+++ b/plugins/org.eclipse.elk.alg.packing.rectangles/src/org/eclipse/elk/alg/packing/rectangles/seconditeration/Compaction.java
@@ -336,9 +336,17 @@ public final class Compaction {
         
         // Check height of next block.
         double nextBlockHeight = nextBlock.getHeightForTargetWidth(targetWidthOfNextBlock);
-        if (nextBlockHeight <= row.getHeight()) {
-            block.getStack().placeRectsIn(currentBlockMinWidth);
-            block.setFixed(true);
+        if (rows.get(nextRowIndex).getChildren().size() == 1 ||
+                nextBlockHeight <= row.getHeight()) {
+            if (rows.get(nextRowIndex).getChildren().size() == 1) {
+                block.setHeight(nextBlockHeight);
+                
+                block.placeRectsIn(block.getWidthForTargetHeight(nextBlockHeight));
+            } else {
+                block.getStack().placeRectsIn(currentBlockMinWidth);
+                block.setFixed(true);
+                
+            }
             
             // Place next block in remaining width.
             nextBlock.placeRectsIn(boundingWidth - (block.getX() + block.getWidth()));

--- a/plugins/org.eclipse.elk.alg.packing.rectangles/src/org/eclipse/elk/alg/packing/rectangles/seconditeration/Compaction.java
+++ b/plugins/org.eclipse.elk.alg.packing.rectangles/src/org/eclipse/elk/alg/packing/rectangles/seconditeration/Compaction.java
@@ -336,16 +336,13 @@ public final class Compaction {
         
         // Check height of next block.
         double nextBlockHeight = nextBlock.getHeightForTargetWidth(targetWidthOfNextBlock);
-        if (rows.get(nextRowIndex).getChildren().size() == 1 ||
-                nextBlockHeight <= row.getHeight()) {
+        if (rows.get(nextRowIndex).getChildren().size() == 1 || nextBlockHeight <= row.getHeight()) {
             if (rows.get(nextRowIndex).getChildren().size() == 1) {
                 block.setHeight(nextBlockHeight);
-                
                 block.placeRectsIn(block.getWidthForTargetHeight(nextBlockHeight));
             } else {
                 block.getStack().placeRectsIn(currentBlockMinWidth);
                 block.setFixed(true);
-                
             }
             
             // Place next block in remaining width.


### PR DESCRIPTION
The parent node is correctly resized.
The algorithm logs intermediate graphs.
Compaction was optimized. If a row is emptied this is taken into account.