### PR TITLE
Switch unit tests to using elkg instead of elkt for ptolemy models

### DIFF
--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessorTest.java
@@ -48,7 +48,7 @@ public class InLayerConstraintProcessorTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessorTest.java
@@ -48,7 +48,7 @@ public class InvertedPortProcessorTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemoverTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemoverTest.java
@@ -41,7 +41,7 @@ public class LabelDummyRemoverTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelectorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelectorTest.java
@@ -50,7 +50,7 @@ public class LabelSideSelectorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LayerSizeAndGraphHeigthCalculatorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LayerSizeAndGraphHeigthCalculatorTest.java
@@ -40,7 +40,7 @@ public class LayerSizeAndGraphHeigthCalculatorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoinerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoinerTest.java
@@ -41,7 +41,7 @@ public class LongEdgeJoinerTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeSplitterTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeSplitterTest.java
@@ -40,7 +40,7 @@ public class LongEdgeSplitterTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodeMarginCalculatorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodeMarginCalculatorTest.java
@@ -44,7 +44,7 @@ public class NodeMarginCalculatorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodePromotionTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodePromotionTest.java
@@ -44,7 +44,7 @@ public class NodePromotionTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortListSorterTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortListSorterTest.java
@@ -72,7 +72,7 @@ public class PortListSorterTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortSideProcessorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortSideProcessorTest.java
@@ -42,7 +42,7 @@ public class PortSideProcessorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorerTest.java
@@ -43,7 +43,7 @@ public class ReversedEdgeRestorerTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
@@ -53,7 +53,7 @@ public class BasicCycleBreakerTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p2layers/BasicLayerAssignmentTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p2layers/BasicLayerAssignmentTest.java
@@ -54,7 +54,7 @@ public class BasicLayerAssignmentTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p4nodes/BasicNodePlacementTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p4nodes/BasicNodePlacementTest.java
@@ -53,7 +53,7 @@ public class BasicNodePlacementTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")),
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")),
                 new ModelResourcePath("tests/layered/node_placement/**/"));
     }
     

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p5edges/BasicEdgeRouterTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p5edges/BasicEdgeRouterTest.java
@@ -51,7 +51,7 @@ public class BasicEdgeRouterTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkt")));
+                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.test/src/org/eclipse/elk/alg/test/framework/graph/GraphFromFile.java
+++ b/test/org.eclipse.elk.alg.test/src/org/eclipse/elk/alg/test/framework/graph/GraphFromFile.java
@@ -84,8 +84,9 @@ public final class GraphFromFile extends TestGraph {
             }
         }
 
-        // Set proper file filters
-        resourcePaths.stream().forEach(path -> path.setFilter(GRAPH_FILE_FILTER));
+        // Set a default graph file filter in case no explicit filter has been specified
+        resourcePaths.stream().filter(path -> path.getFilter() == null)
+                .forEach(path -> path.setFilter(GRAPH_FILE_FILTER));
 
         // Turn the abstract paths into absolute paths
         return resourcePaths.stream().flatMap(path -> path.listResources().stream())


### PR DESCRIPTION
The elkg are identical to the elkt (graph-wise). The idea behind checking in the elkg as well is to significantly reduce the execution time of ELK's unit tests. Parsing the xtext-based elkt files takes very long, especially for larger models.