### PR TITLE
Rectpacking: Handle too big position constraints.

### DIFF
--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPackingLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPackingLayoutProvider.java
@@ -96,6 +96,7 @@ public class RectPackingLayoutProvider extends AbstractLayoutProvider {
             });
             for (ElkNode elkNode : fixedNodes) {
                 int position = elkNode.getProperty(RectPackingOptions.DESIRED_POSITION);
+                position = Math.min(position, rectangles.size());
                 rectangles.add(position, elkNode);
             }
 


### PR DESCRIPTION
If a position constraint is set that is bigger than the number of nodes the node is added to the end of the list.

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>