### PR TITLE
[PR] Test: added hierarchical test cases

### DIFF
--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessorTest.java
@@ -48,7 +48,7 @@ public class InLayerConstraintProcessorTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessorTest.java
@@ -48,7 +48,7 @@ public class InvertedPortProcessorTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemoverTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemoverTest.java
@@ -41,7 +41,7 @@ public class LabelDummyRemoverTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LayerSizeAndGraphHeigthCalculatorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LayerSizeAndGraphHeigthCalculatorTest.java
@@ -40,7 +40,7 @@ public class LayerSizeAndGraphHeigthCalculatorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoinerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoinerTest.java
@@ -41,7 +41,7 @@ public class LongEdgeJoinerTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeSplitterTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeSplitterTest.java
@@ -40,7 +40,7 @@ public class LongEdgeSplitterTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodeMarginCalculatorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodeMarginCalculatorTest.java
@@ -44,7 +44,7 @@ public class NodeMarginCalculatorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodePromotionTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodePromotionTest.java
@@ -44,7 +44,7 @@ public class NodePromotionTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortListSorterTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortListSorterTest.java
@@ -72,7 +72,7 @@ public class PortListSorterTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortSideProcessorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PortSideProcessorTest.java
@@ -42,7 +42,7 @@ public class PortSideProcessorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorerTest.java
@@ -43,7 +43,7 @@ public class ReversedEdgeRestorerTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
@@ -53,7 +53,7 @@ public class BasicCycleBreakerTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")),
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")),
                 new ModelResourcePath("tickets/layered/600_outgoingEdgeInLastSeparateNode.elkt"));
     }
     

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p2layers/BasicLayerAssignmentTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p2layers/BasicLayerAssignmentTest.java
@@ -54,7 +54,7 @@ public class BasicLayerAssignmentTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p4nodes/BasicNodePlacementTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p4nodes/BasicNodePlacementTest.java
@@ -53,7 +53,7 @@ public class BasicNodePlacementTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")),
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")),
                 new ModelResourcePath("tests/layered/node_placement/**/"));
     }
     

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p5edges/BasicEdgeRouterTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p5edges/BasicEdgeRouterTest.java
@@ -51,7 +51,7 @@ public class BasicEdgeRouterTest extends TestGraphCreator {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("realworld/ptolemy/flattened/**/").withFilter(new FileExtensionFilter("elkg")));
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
     }
     
 


### PR DESCRIPTION
The build is going to be failing, I'll use this PR to track the issues. 

### 1
```
2020-04-21T16:35:59.0873424Z Running org.eclipse.elk.alg.layered.intermediate.NodeMarginCalculatorTest
2020-04-21T16:36:03.7706361Z Tests run: 550, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 4.689 s <<< FAILURE! - in org.eclipse.elk.alg.layered.intermediate.NodeMarginCalculatorTest
```
In both cases `assertTrue(node.getMargin().bottom >= 0);` fails. 

The issue is in both cases due to double imprecision:
```
-1.4210854715202004E-14
-1.4210854715202004E-14
```

### 2
```
2020-04-21T16:36:08.6396228Z Running org.eclipse.elk.alg.layered.intermediate.LabelSideSelectorTest
2020-04-21T16:36:14.2256751Z Tests run: 550, Failures: 29, Errors: 0, Skipped: 0, Time elapsed: 5.591 s <<< FAILURE! - in org.eclipse.elk.alg.layered.intermediate.LabelSideSelectorTest
```
All fail due to 
```
// At this stage, the port list should be sorted (once this line stops compiling with newer Guava versions,
        // use the Comparators class instead of Ordering, which is scheduled to be deleted sometime > Guava 21)
        assert Ordering.from(PortListSorter.CMP_COMBINED).isOrdered(node.getPorts());
```

### 3
```
2020-04-21T16:36:42.3810319Z Running org.eclipse.elk.alg.layered.p1cycles.BasicCycleBreakerTest
2020-04-21T16:36:59.2377219Z Tests run: 1650, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 16.835 s <<< FAILURE! - in org.eclipse.elk.alg.layered.p1cycles.BasicCycleBreakerTest
```

```
        // Otherwise, the source node is expected to be in the LAST layer
        assert sourceNode.getProperty(LayeredOptions.LAYERING_LAYER_CONSTRAINT) == LayerConstraint.LAST;
```