### PR TITLE
Fix #579 (formatting melk)

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/Polyomino.melk
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/Polyomino.melk
@@ -14,37 +14,38 @@ bundle {
     metadataClass options.PolyominoOptions
     idPrefix org.eclipse.elk
 }
- 
+
 group polyomino {
-    
+
     option traversalStrategy: TraversalStrategy {
         label "Polyomino Traversal Strategy"
-        description 
+        description
             "Traversal strategy for trying different candidate positions for polyominoes."
         default = TraversalStrategy.QUADRANTS_LINE_BY_LINE
         targets parents
     }
-    
+
     option lowLevelSort: LowLevelSortingCriterion {
         label "Polyomino Secondary Sorting Criterion"
-        description 
+        description
             "Possible secondary sorting criteria for the processing order of polyominoes. 
              They are used when polyominoes are equal according to the primary 
              sorting criterion HighLevelSortingCriterion."
         default = LowLevelSortingCriterion.BY_SIZE_AND_SHAPE
         targets parents
     }
-    
-     option highLevelSort: HighLevelSortingCriterion {
+
+    option highLevelSort: HighLevelSortingCriterion {
         label "Polyomino Primary Sorting Criterion"
-        description "Possible primary sorting criteria for the processing order of polyominoes."
+        description
+            "Possible primary sorting criteria for the processing order of polyominoes."
         default = HighLevelSortingCriterion.NUM_OF_EXTERNAL_SIDES_THAN_NUM_OF_EXTENSIONS_LAST
         targets parents
     }
-    
+
     option fill: boolean {
         label "Fill Polyominoes"
-        description 
+        description
             "Use the Profile Fill algorithm to fill polyominoes to prevent small polyominoes
              from being placed inside of big polyominoes with large holes. Might increase packing area."
         default = true

--- a/plugins/org.eclipse.elk.alg.disco/src/org/eclipse/elk/alg/disco/Disco.melk
+++ b/plugins/org.eclipse.elk.alg.disco/src/org/eclipse/elk/alg/disco/Disco.melk
@@ -15,10 +15,10 @@ bundle {
     metadataClass options.DisCoMetaDataProvider
     idPrefix org.eclipse.elk.disco
 }
- 
+
 algorithm disco(DisCoLayoutProvider) {
     label "ELK DisCo"
-    description 
+    description
         "Layouter for arranging unconnected subgraphs. The subgraphs themselves are, by default, not laid out."
     metadataClass options.DisCoOptions
     preview images/disco_layout.png
@@ -37,15 +37,16 @@ algorithm disco(DisCoLayoutProvider) {
 }
 
 group componentCompaction {
+
     option strategy : CompactionStrategy {
         label "Connected Components Compaction Strategy"
-        description 
+        description
             "Strategy for packing different connected components in order to save space 
              and enhance readability of a graph."
         default = CompactionStrategy.POLYOMINO
         targets parents
     }
-    
+
     option componentLayoutAlgorithm: String {
         label "Connected Components Layout Algorithm"
         description
@@ -53,20 +54,25 @@ group componentCompaction {
              before the components themselves are compacted. If unspecified, 
              the positions of the components' nodes are not altered. "
         targets parents
-    }  
+    }
+
 }
 
 group debug {
+
     programmatic option discoGraph: Object {
         label "DCGraph"
-        description "Access to the DCGraph is intended for the debug view,"
+        description
+            "Access to the DCGraph is intended for the debug view,"
         targets parents
     }
-    
+
     programmatic option discoPolys: Object {
         label "List of Polyominoes"
-        description "Access to the polyominoes is intended for the debug view,"
+        description
+            "Access to the polyominoes is intended for the debug view,"
         targets parents
     }
+
 }
 

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/Force.melk
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/Force.melk
@@ -33,8 +33,7 @@ algorithm force(ForceLayoutProvider) {
     features multi_edges, edge_labels
     preview images/force_layout.png
     supports org.eclipse.elk.priority = 1
-	   documentation 
-	       "Priorities set on nodes determine the order in which connected components are placed:
+    documentation "Priorities set on nodes determine the order in which connected components are placed:
             components with a higher sum of node priorities will end up
             before components with a lower sum.
             Priorities set on edges usually directly influence the attractive force of a connection,
@@ -56,14 +55,16 @@ algorithm force(ForceLayoutProvider) {
 
 option model: ForceModelStrategy {
     label "Force Model"
-    description "Determines the model for force calculation."
+    description
+        "Determines the model for force calculation."
     default = ForceModelStrategy.FRUCHTERMAN_REINGOLD
     targets parents
 }
 
 option iterations: int {
     label "Iterations"
-    description "The number of iterations on the force model."
+    description
+        "The number of iterations on the force model."
     default = 300
     lowerBound = 1
     targets parents
@@ -81,7 +82,8 @@ option repulsivePower: int {
 
 option temperature: double {
     label "FR Temperature"
-    description "The temperature is used as a scaling factor for particle displacements."
+    description
+        "The temperature is used as a scaling factor for particle displacements."
     default = 0.001
     lowerBound = ExclusiveBounds.greaterThan(0)
     targets parents
@@ -90,7 +92,8 @@ option temperature: double {
 
 option repulsion: double {
     label "Eades Repulsion"
-    description "Factor for repulsive forces in Eades' model."
+    description
+        "Factor for repulsive forces in Eades' model."
     default = 5.0
     lowerBound = ExclusiveBounds.greaterThan(0)
     targets parents

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/stress/Stress.melk
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/stress/Stress.melk
@@ -41,14 +41,15 @@ algorithm stress(StressLayoutProvider) {
 
 option fixed: boolean {
     label "Fixed Position"
-    description "Prevent that the node is moved by the layout algorithm."
+    description
+        "Prevent that the node is moved by the layout algorithm."
     default = false
     targets nodes
 }
 
 option desiredEdgeLength: double {
     label "Desired Edge Length"
-    description 
+    description
         "Either specified for parent nodes or for individual edges, 
         where the latter takes higher precedence."
     default = 100.0
@@ -57,21 +58,23 @@ option desiredEdgeLength: double {
 
 option dimension: Dimension {
     label "Layout Dimension"
-    description "Dimensions that are permitted to be altered during layout."
+    description
+        "Dimensions that are permitted to be altered during layout."
     default = Dimension.XY
     targets parents
 }
 
 option epsilon: double {
     label "Stress Epsilon"
-    description "Termination criterion for the iterative process."
+    description
+        "Termination criterion for the iterative process."
     default = 10e-4
     targets parents
-} 
+}
 
 option iterationLimit: int {
     label "Iteration Limit"
-    description 
+    description
         "Maximum number of performed iterations. Takes higher
         precedence than 'epsilon'."
     default = Integer.MAX_VALUE

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/Graphviz.melk
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/Graphviz.melk
@@ -11,236 +11,240 @@ package org.eclipse.elk.alg.graphviz
 
 import org.eclipse.elk.alg.graphviz.dot.transform.NeatoModel
 import org.eclipse.elk.alg.graphviz.dot.transform.OverlapMode
+import org.eclipse.elk.core.math.ElkPadding
 import org.eclipse.elk.core.options.Direction
 import org.eclipse.elk.core.options.EdgeRouting
 import org.eclipse.elk.core.util.ExclusiveBounds
-import org.eclipse.elk.core.math.ElkPadding
 
 bundle {
-	label "Graphviz"
-	metadataClass layouter.GraphvizMetaDataProvider
-	idPrefix org.eclipse.elk.graphviz
+    label "Graphviz"
+    metadataClass layouter.GraphvizMetaDataProvider
+    idPrefix org.eclipse.elk.graphviz
 }
 
 algorithm dot(GraphvizLayoutProvider#DOT) {
-	label "Dot"
-	description
-		"Layered drawings of directed graphs. The algorithm aims edges in the same direction (top
+    label "Dot"
+    description
+        "Layered drawings of directed graphs. The algorithm aims edges in the same direction (top
 		to bottom, or left to right) and then attempts to avoid edge crossings and reduce edge
 		length. Edges are routed as spline curves and are thus drawn very smoothly. This algorithm
 		is very suitable for state machine and activity diagrams, where the direction of edges has
 		an important role."
-	metadataClass layouter.DotOptions
-	category org.eclipse.elk.layered
-	features self_loops, multi_edges, edge_labels, compound, clusters
-	preview images/dot_layout.png
+    metadataClass layouter.DotOptions
+    category org.eclipse.elk.layered
+    features self_loops, multi_edges, edge_labels, compound, clusters
+    preview images/dot_layout.png
 	supports org.eclipse.elk.padding = new ElkPadding(10)
-	supports org.eclipse.elk.direction = Direction.DOWN
-	supports org.eclipse.elk.spacing.nodeNode = 20
-	supports org.eclipse.elk.spacing.edgeLabel
-	supports org.eclipse.elk.nodeSize.constraints
-	supports org.eclipse.elk.nodeSize.options
-	supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
-	supports org.eclipse.elk.debugMode
-	supports org.eclipse.elk.hierarchyHandling
-	documentation 
-        "If activated, the whole hierarchical graph is passed to dot as a whole.
+    supports org.eclipse.elk.direction = Direction.DOWN
+    supports org.eclipse.elk.spacing.nodeNode = 20
+    supports org.eclipse.elk.spacing.edgeLabel
+    supports org.eclipse.elk.nodeSize.constraints
+    supports org.eclipse.elk.nodeSize.options
+    supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
+    supports org.eclipse.elk.debugMode
+    supports org.eclipse.elk.hierarchyHandling
+    documentation "If activated, the whole hierarchical graph is passed to dot as a whole.
          Note however that dot performs a 'compound' layout where it somewhat flattens 
          the hierarchy and performs a layout on the flattened graph. 
          As a consequence, padding information of hierarchical child nodes is discarded."
-	supports iterationsFactor = 1
-	supports concentrate
-	supports labelDistance
-	supports labelAngle
-	supports layerSpacingFactor
-	supports adaptPortPositions
+    supports iterationsFactor = 1
+    supports concentrate
+    supports labelDistance
+    supports labelAngle
+    supports layerSpacingFactor
+    supports adaptPortPositions
 }
 
 algorithm neato(GraphvizLayoutProvider#NEATO) {
-	label "Neato"
-	description
-		"Spring model layouts. Neato attempts to minimize a global energy function, which is
+    label "Neato"
+    description
+        "Spring model layouts. Neato attempts to minimize a global energy function, which is
 		equivalent to statistical multi-dimensional scaling. The solution is achieved using
 		stress majorization, though the older Kamada-Kawai algorithm, using steepest descent, is
 		also available."
     metadataClass layouter.NeatoOptions
-	category org.eclipse.elk.force
-	features self_loops, multi_edges, edge_labels
-	preview  images/neato_layout.png
+    category org.eclipse.elk.force
+    features self_loops, multi_edges, edge_labels
+    preview images/neato_layout.png
 	supports org.eclipse.elk.padding = new ElkPadding(10)
-	supports org.eclipse.elk.spacing.nodeNode = 40
-	supports org.eclipse.elk.spacing.edgeLabel
-	supports org.eclipse.elk.nodeSize.constraints
-	supports org.eclipse.elk.nodeSize.options
-	supports org.eclipse.elk.randomSeed = 1
-	supports org.eclipse.elk.interactive
-	supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
-	supports org.eclipse.elk.debugMode
-	supports org.eclipse.elk.separateConnectedComponents = false
-	supports concentrate
-	supports epsilon = 0.0001f
-	supports labelDistance
-	supports labelAngle
-	supports maxiter = 200
-	supports neatoModel
-	supports overlapMode
-	supports adaptPortPositions
+    supports org.eclipse.elk.spacing.nodeNode = 40
+    supports org.eclipse.elk.spacing.edgeLabel
+    supports org.eclipse.elk.nodeSize.constraints
+    supports org.eclipse.elk.nodeSize.options
+    supports org.eclipse.elk.randomSeed = 1
+    supports org.eclipse.elk.interactive
+    supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
+    supports org.eclipse.elk.debugMode
+    supports org.eclipse.elk.separateConnectedComponents = false
+    supports concentrate
+    supports epsilon = 0.0001f
+    supports labelDistance
+    supports labelAngle
+    supports maxiter = 200
+    supports neatoModel
+    supports overlapMode
+    supports adaptPortPositions
 }
 
 algorithm fdp(GraphvizLayoutProvider#FDP) {
-	label "FDP"
-	description
-		"Spring model layouts similar to those of Neato, but does this by reducing forces rather
+    label "FDP"
+    description
+        "Spring model layouts similar to those of Neato, but does this by reducing forces rather
 		 than working with energy. Fdp implements the Fruchterman-Reingold heuristic including a
 		 multigrid solver that handles larger graphs and clustered undirected graphs."
     metadataClass layouter.FdpOptions
-	category org.eclipse.elk.force
-	features self_loops, multi_edges, edge_labels, clusters
-	preview  images/fdp_layout.png
+    category org.eclipse.elk.force
+    features self_loops, multi_edges, edge_labels, clusters
+    preview images/fdp_layout.png
 	supports org.eclipse.elk.padding = new ElkPadding(10)
-	supports org.eclipse.elk.spacing.nodeNode = 40
-	supports org.eclipse.elk.spacing.edgeLabel
-	supports org.eclipse.elk.nodeSize.constraints
-	supports org.eclipse.elk.nodeSize.options
-	supports org.eclipse.elk.interactive
-	supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
-	supports org.eclipse.elk.debugMode
-	supports org.eclipse.elk.separateConnectedComponents = false
-	supports concentrate
-	supports labelDistance
-	supports labelAngle
-	supports maxiter = 600
-	supports overlapMode
-	supports adaptPortPositions
+    supports org.eclipse.elk.spacing.nodeNode = 40
+    supports org.eclipse.elk.spacing.edgeLabel
+    supports org.eclipse.elk.nodeSize.constraints
+    supports org.eclipse.elk.nodeSize.options
+    supports org.eclipse.elk.interactive
+    supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
+    supports org.eclipse.elk.debugMode
+    supports org.eclipse.elk.separateConnectedComponents = false
+    supports concentrate
+    supports labelDistance
+    supports labelAngle
+    supports maxiter = 600
+    supports overlapMode
+    supports adaptPortPositions
 }
 
 algorithm twopi(GraphvizLayoutProvider#TWOPI) {
-	label "Twopi"
-	description
-		"Radial layouts, after Wills '97. The nodes are placed on concentric circles depending on
+    label "Twopi"
+    description
+        "Radial layouts, after Wills '97. The nodes are placed on concentric circles depending on
 		 their distance from a given root node. The algorithm is designed to handle not only small
 		 graphs, but also very large ones."
     metadataClass layouter.TwopiOptions
-	category org.eclipse.elk.radial
-	features self_loops, multi_edges, edge_labels
-	preview  images/twopi_layout.png
+    category org.eclipse.elk.radial
+    features self_loops, multi_edges, edge_labels
+    preview images/twopi_layout.png
 	supports org.eclipse.elk.padding = new ElkPadding(10)
-	supports org.eclipse.elk.spacing.nodeNode = 60
-	supports org.eclipse.elk.spacing.edgeLabel
-	supports org.eclipse.elk.nodeSize.constraints
-	supports org.eclipse.elk.nodeSize.options
-	supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
-	supports org.eclipse.elk.debugMode
-	supports concentrate
-	supports labelDistance
-	supports labelAngle
-	supports overlapMode
-	supports adaptPortPositions
+    supports org.eclipse.elk.spacing.nodeNode = 60
+    supports org.eclipse.elk.spacing.edgeLabel
+    supports org.eclipse.elk.nodeSize.constraints
+    supports org.eclipse.elk.nodeSize.options
+    supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
+    supports org.eclipse.elk.debugMode
+    supports concentrate
+    supports labelDistance
+    supports labelAngle
+    supports overlapMode
+    supports adaptPortPositions
 }
 
 algorithm circo(GraphvizLayoutProvider#CIRCO) {
-	label "Circo"
-	description
-		"Circular layout, after Six and Tollis '99, Kaufmann and Wiese '02. The algorithm finds
+    label "Circo"
+    description
+        "Circular layout, after Six and Tollis '99, Kaufmann and Wiese '02. The algorithm finds
 		biconnected components and arranges each component in a circle, trying to minimize the
 		number of crossings inside the circle. This is suitable for certain diagrams of multiple
 		cyclic structures such as certain telecommunications networks."
     metadataClass layouter.CircoOptions
-	category org.eclipse.elk.circle
-	features self_loops, multi_edges, edge_labels
-	preview  images/circo_layout.png
+    category org.eclipse.elk.circle
+    features self_loops, multi_edges, edge_labels
+    preview images/circo_layout.png
 	supports org.eclipse.elk.padding = new ElkPadding(10)
-	supports org.eclipse.elk.spacing.nodeNode = 40
-	supports org.eclipse.elk.spacing.edgeLabel
-	supports org.eclipse.elk.nodeSize.constraints
-	supports org.eclipse.elk.nodeSize.options
-	supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
-	supports org.eclipse.elk.debugMode
-	supports org.eclipse.elk.separateConnectedComponents = false
-	supports concentrate
-	supports labelDistance
-	supports labelAngle
-	supports overlapMode
-	supports adaptPortPositions
+    supports org.eclipse.elk.spacing.nodeNode = 40
+    supports org.eclipse.elk.spacing.edgeLabel
+    supports org.eclipse.elk.nodeSize.constraints
+    supports org.eclipse.elk.nodeSize.options
+    supports org.eclipse.elk.edgeRouting = EdgeRouting.SPLINES
+    supports org.eclipse.elk.debugMode
+    supports org.eclipse.elk.separateConnectedComponents = false
+    supports concentrate
+    supports labelDistance
+    supports labelAngle
+    supports overlapMode
+    supports adaptPortPositions
 }
 
-
 //------- LAYOUT OPTIONS
-
 advanced option adaptPortPositions: boolean {
-	label "Adapt Port Positions"
-	description "Whether ports should be moved to the point where edges cross the node's bounds."
-	default = true
-	targets parents
+    label "Adapt Port Positions"
+    description
+        "Whether ports should be moved to the point where edges cross the node's bounds."
+    default = true
+    targets parents
 }
 
 advanced option concentrate: boolean {
-	label "Concentrate Edges"
-	description
-		"Merges multiedges into a single edge and causes partially parallel edges to share part of
+    label "Concentrate Edges"
+    description
+        "Merges multiedges into a single edge and causes partially parallel edges to share part of
 		their paths."
-	default = false
-	targets parents
+    default = false
+    targets parents
 }
 
 option epsilon: double {
-	label "Epsilon"
-	description
-		"Terminating condition. If the length squared of all energy gradients are less than
+    label "Epsilon"
+    description
+        "Terminating condition. If the length squared of all energy gradients are less than
 		epsilon, the algorithm stops."
     lowerBound = ExclusiveBounds.greaterThan(0)
-	targets parents
+    targets parents
 }
 
 advanced option iterationsFactor: double {
-	label "Iterations Factor"
-	description
-		"Multiplicative scale factor for the maximal number of iterations used during crossing
+    label "Iterations Factor"
+    description
+        "Multiplicative scale factor for the maximal number of iterations used during crossing
 		minimization, node ranking, and node positioning."
     lowerBound = ExclusiveBounds.greaterThan(0)
-	targets parents
+    targets parents
 }
 
 option labelAngle: double {
-	label "Label Angle"
-	description "Angle between head / tail positioned edge labels and the corresponding edge."
-	default = -25
-	targets edges
+    label "Label Angle"
+    description
+        "Angle between head / tail positioned edge labels and the corresponding edge."
+    default = -25
+    targets edges
 }
 
 option labelDistance: double {
-	label "Label Distance"
-	description "Distance of head / tail positioned edge labels to the source or target node."
-	default = 1
+    label "Label Distance"
+    description
+        "Distance of head / tail positioned edge labels to the source or target node."
+    default = 1
     lowerBound = 0.0
-	targets edges
+    targets edges
 }
 
 option layerSpacingFactor: double {
-	label "Layer Spacing Factor"
-	description "Factor for the spacing of different layers (ranks)."
-	default = 1
+    label "Layer Spacing Factor"
+    description
+        "Factor for the spacing of different layers (ranks)."
+    default = 1
     lowerBound = ExclusiveBounds.greaterThan(0)
-	targets parents
+    targets parents
 }
 
 advanced option maxiter: int {
-	label "Max. Iterations"
-	description "The maximum number of iterations."
+    label "Max. Iterations"
+    description
+        "The maximum number of iterations."
     lowerBound = 1
-	targets parents
+    targets parents
 }
 
 advanced option neatoModel: NeatoModel {
-	label "Distance Model"
-	description "Specifies how the distance matrix is computed for the input graph."
-	default = NeatoModel.SHORTPATH
-	targets parents
+    label "Distance Model"
+    description
+        "Specifies how the distance matrix is computed for the input graph."
+    default = NeatoModel.SHORTPATH
+    targets parents
 }
 
 option overlapMode: OverlapMode {
-	label "Overlap Removal"
-	description "Determines if and how node overlaps should be removed."
-	default = OverlapMode.PRISM
-	targets parents
+    label "Overlap Removal"
+    description
+        "Determines if and how node overlaps should be removed."
+    default = OverlapMode.PRISM
+    targets parents
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered
 
-import java.util.EnumSet
 import java.util.List
 import org.eclipse.elk.alg.layered.LayeredLayoutProvider
 import org.eclipse.elk.core.math.ElkPadding
@@ -23,9 +22,9 @@ import org.eclipse.elk.core.util.ExclusiveBounds
  * Declarations for the ELK Layered layout algorithm.
  */
 bundle {
-    metadataClass options.LayeredMetaDataProvider
-    idPrefix org.eclipse.elk.layered  
-} 
+	metadataClass options.LayeredMetaDataProvider
+	idPrefix org.eclipse.elk.layered  
+}
 
 algorithm layered(LayeredLayoutProvider) {
 	label "ELK Layered"
@@ -53,87 +52,86 @@ algorithm layered(LayeredLayoutProvider) {
 	supports org.eclipse.elk.spacing.nodeSelfLoop
 	supports org.eclipse.elk.spacing.portPort
 	supports org.eclipse.elk.spacing.individualOverride
-	   documentation "Most parts of the algorithm do not support this yet."
+	documentation "Most parts of the algorithm do not support this yet."
 	// layer-based spacings
-    supports org.eclipse.elk.alg.layered.spacing.edgeEdgeBetweenLayers
-    supports org.eclipse.elk.alg.layered.spacing.edgeNodeBetweenLayers
-    supports org.eclipse.elk.alg.layered.spacing.nodeNodeBetweenLayers
-    // layer-based priorities
-    supports org.eclipse.elk.priority = 0
-	   documentation 
-	       "Used by the 'simple row graph placer' to decide which connected components to place first.
+	supports org.eclipse.elk.alg.layered.spacing.edgeEdgeBetweenLayers
+	supports org.eclipse.elk.alg.layered.spacing.edgeNodeBetweenLayers
+	supports org.eclipse.elk.alg.layered.spacing.nodeNodeBetweenLayers
+	// layer-based priorities
+	supports org.eclipse.elk.priority = 0
+	documentation "Used by the 'simple row graph placer' to decide which connected components to place first.
             A component's priority is the sum of the node priorities,
             and components with higher priorities will be placed
             before components with lower priorities."
-    supports priority.direction
-    supports priority.shortness
-        documentation "Currently only supported by the network simplex layerer."
-    supports priority.straightness
-    // wrapping related
-    supports wrapping.strategy
-    supports wrapping.additionalEdgeSpacing
-    supports wrapping.correctionFactor
-    supports wrapping.cutting.strategy
-    supports wrapping.cutting.cuts
-    supports wrapping.cutting.msd.freedom
-    supports wrapping.validify.strategy
-    supports wrapping.validify.forbiddenIndices
-    supports wrapping.multiEdge.improveCuts
-    supports wrapping.multiEdge.distancePenalty
-    supports wrapping.multiEdge.improveWrappedEdges
-    // flexible nodes during node placement
-    supports nodePlacement.networkSimplex.nodeFlexibility
-    supports nodePlacement.networkSimplex.nodeFlexibility.^default
-    // splines
-    supports edgeRouting.splines.mode
-    supports edgeRouting.splines.sloppy.layerSpacingFactor
-    // other options
-    supports org.eclipse.elk.padding = new ElkPadding(12)
-    supports org.eclipse.elk.edgeRouting = EdgeRouting.ORTHOGONAL
-    supports org.eclipse.elk.port.borderOffset = 0
-    supports org.eclipse.elk.randomSeed = 1
-    supports org.eclipse.elk.aspectRatio = 1.6f
-    supports org.eclipse.elk.noLayout
-    supports org.eclipse.elk.portConstraints
-    supports org.eclipse.elk.port.side
-    supports org.eclipse.elk.debugMode
-    supports org.eclipse.elk.alignment
-    supports org.eclipse.elk.hierarchyHandling
-    supports org.eclipse.elk.separateConnectedComponents = true
-    supports org.eclipse.elk.insideSelfLoops.activate
-    supports org.eclipse.elk.insideSelfLoops.yo
-    supports org.eclipse.elk.nodeSize.constraints
-    supports org.eclipse.elk.nodeSize.options
-    supports org.eclipse.elk.direction = Direction.UNDEFINED
-    supports org.eclipse.elk.nodeLabels.placement
-    supports org.eclipse.elk.nodeLabels.padding
-    supports org.eclipse.elk.portLabels.placement
-    supports org.eclipse.elk.portLabels.nextToPortIfPossible
-    supports org.eclipse.elk.portLabels.treatAsGroup
-    supports org.eclipse.elk.portAlignment.^default = PortAlignment.JUSTIFIED
-    supports org.eclipse.elk.portAlignment.north
-    supports org.eclipse.elk.portAlignment.south
-    supports org.eclipse.elk.portAlignment.west
-    supports org.eclipse.elk.portAlignment.east
-    supports unnecessaryBendpoints
-    supports org.eclipse.elk.alg.layered.layering.strategy
-    supports org.eclipse.elk.alg.layered.layering.nodePromotion.strategy
-    supports thoroughness
-    supports org.eclipse.elk.alg.layered.layering.layerConstraint
-    supports org.eclipse.elk.alg.layered.cycleBreaking.strategy
-    supports org.eclipse.elk.alg.layered.crossingMinimization.strategy
-    supports org.eclipse.elk.alg.layered.crossingMinimization.greedySwitch.activationThreshold
-    supports org.eclipse.elk.alg.layered.crossingMinimization.greedySwitch.type
-    supports org.eclipse.elk.alg.layered.crossingMinimization.semiInteractive
-    supports mergeEdges
-    supports mergeHierarchyEdges
-    supports interactiveReferencePoint
-    supports org.eclipse.elk.alg.layered.nodePlacement.strategy
-    supports org.eclipse.elk.alg.layered.nodePlacement.bk.fixedAlignment
-    supports feedbackEdges
-    supports org.eclipse.elk.alg.layered.nodePlacement.linearSegments.deflectionDampening
-    supports org.eclipse.elk.alg.layered.edgeRouting.selfLoopDistribution
-    supports org.eclipse.elk.alg.layered.edgeRouting.selfLoopOrdering
+	supports priority.direction
+	supports priority.shortness
+	documentation "Currently only supported by the network simplex layerer."
+	supports priority.straightness
+	// wrapping related
+	supports wrapping.strategy
+	supports wrapping.additionalEdgeSpacing
+	supports wrapping.correctionFactor
+	supports wrapping.cutting.strategy
+	supports wrapping.cutting.cuts
+	supports wrapping.cutting.msd.freedom
+	supports wrapping.validify.strategy
+	supports wrapping.validify.forbiddenIndices
+	supports wrapping.multiEdge.improveCuts
+	supports wrapping.multiEdge.distancePenalty
+	supports wrapping.multiEdge.improveWrappedEdges
+	// flexible nodes during node placement
+	supports nodePlacement.networkSimplex.nodeFlexibility
+	supports nodePlacement.networkSimplex.nodeFlexibility.^default
+	// splines
+	supports edgeRouting.splines.mode
+	supports edgeRouting.splines.sloppy.layerSpacingFactor
+	// other options
+	supports org.eclipse.elk.padding = new ElkPadding(12)
+	supports org.eclipse.elk.edgeRouting = EdgeRouting.ORTHOGONAL
+	supports org.eclipse.elk.port.borderOffset = 0
+	supports org.eclipse.elk.randomSeed = 1
+	supports org.eclipse.elk.aspectRatio = 1.6f
+	supports org.eclipse.elk.noLayout
+	supports org.eclipse.elk.portConstraints
+	supports org.eclipse.elk.port.side
+	supports org.eclipse.elk.debugMode
+	supports org.eclipse.elk.alignment
+	supports org.eclipse.elk.hierarchyHandling
+	supports org.eclipse.elk.separateConnectedComponents = true
+	supports org.eclipse.elk.insideSelfLoops.activate
+	supports org.eclipse.elk.insideSelfLoops.yo
+	supports org.eclipse.elk.nodeSize.constraints
+	supports org.eclipse.elk.nodeSize.options
+	supports org.eclipse.elk.direction = Direction.UNDEFINED
+	supports org.eclipse.elk.nodeLabels.placement
+	supports org.eclipse.elk.nodeLabels.padding
+	supports org.eclipse.elk.portLabels.placement
+	supports org.eclipse.elk.portLabels.nextToPortIfPossible
+	supports org.eclipse.elk.portLabels.treatAsGroup
+	supports org.eclipse.elk.portAlignment.^default = PortAlignment.JUSTIFIED
+	supports org.eclipse.elk.portAlignment.north
+	supports org.eclipse.elk.portAlignment.south
+	supports org.eclipse.elk.portAlignment.west
+	supports org.eclipse.elk.portAlignment.east
+	supports unnecessaryBendpoints
+	supports org.eclipse.elk.alg.layered.layering.strategy
+	supports org.eclipse.elk.alg.layered.layering.nodePromotion.strategy
+	supports thoroughness
+	supports org.eclipse.elk.alg.layered.layering.layerConstraint
+	supports org.eclipse.elk.alg.layered.cycleBreaking.strategy
+	supports org.eclipse.elk.alg.layered.crossingMinimization.strategy
+	supports org.eclipse.elk.alg.layered.crossingMinimization.greedySwitch.activationThreshold
+	supports org.eclipse.elk.alg.layered.crossingMinimization.greedySwitch.type
+	supports org.eclipse.elk.alg.layered.crossingMinimization.semiInteractive
+	supports mergeEdges
+	supports mergeHierarchyEdges
+	supports interactiveReferencePoint
+	supports org.eclipse.elk.alg.layered.nodePlacement.strategy
+	supports org.eclipse.elk.alg.layered.nodePlacement.bk.fixedAlignment
+	supports feedbackEdges
+	supports org.eclipse.elk.alg.layered.nodePlacement.linearSegments.deflectionDampening
+	supports org.eclipse.elk.alg.layered.edgeRouting.selfLoopDistribution
+	supports org.eclipse.elk.alg.layered.edgeRouting.selfLoopOrdering
 	supports org.eclipse.elk.contentAlignment
 	supports org.eclipse.elk.alg.layered.nodePlacement.bk.edgeStraightening
 	supports org.eclipse.elk.alg.layered.compaction.postCompaction.strategy
@@ -147,699 +145,741 @@ algorithm layered(LayeredLayoutProvider) {
 	supports org.eclipse.elk.edge.thickness
 	supports org.eclipse.elk.edgeLabels.placement
 	supports org.eclipse.elk.edgeLabels.inline
-    supports org.eclipse.elk.alg.layered.crossingMinimization.hierarchicalSweepiness
-    supports org.eclipse.elk.port.index
-    supports org.eclipse.elk.commentBox
-    supports org.eclipse.elk.hypernode
-    supports org.eclipse.elk.port.anchor
-    supports org.eclipse.elk.partitioning.activate
-    supports org.eclipse.elk.partitioning.partition
-    supports org.eclipse.elk.alg.layered.layering.minWidth.upperBoundOnWidth
-    supports org.eclipse.elk.alg.layered.layering.minWidth.upperLayerEstimationScalingFactor
-    supports org.eclipse.elk.position
-    supports northOrSouthPort
-    supports org.eclipse.elk.alg.layered.layering.nodePromotion.maxIterations
-    supports edgeLabels.sideSelection
-    supports edgeLabels.centerLabelPlacementStrategy
-    supports org.eclipse.elk.margins
-    supports layering.coffmanGraham.layerBound
-    supports nodePlacement.favorStraightEdges
-    supports org.eclipse.elk.spacing.portsSurrounding
-    supports directionCongruency
-    supports portSortingStrategy
-    supports edgeRouting.polyline.slopedEdgeZoneWidth
-    supports layering.layerChoiceConstraint
-    supports crossingMinimization.positionChoiceConstraint
-    supports org.eclipse.elk.interactiveLayout
-    supports layering.layerID
-    supports crossingMinimization.positionID
+	supports org.eclipse.elk.alg.layered.crossingMinimization.hierarchicalSweepiness
+	supports org.eclipse.elk.port.index
+	supports org.eclipse.elk.commentBox
+	supports org.eclipse.elk.hypernode
+	supports org.eclipse.elk.port.anchor
+	supports org.eclipse.elk.partitioning.activate
+	supports org.eclipse.elk.partitioning.partition
+	supports org.eclipse.elk.alg.layered.layering.minWidth.upperBoundOnWidth
+	supports org.eclipse.elk.alg.layered.layering.minWidth.upperLayerEstimationScalingFactor
+	supports org.eclipse.elk.position
+	supports northOrSouthPort
+	supports org.eclipse.elk.alg.layered.layering.nodePromotion.maxIterations
+	supports edgeLabels.sideSelection
+	supports edgeLabels.centerLabelPlacementStrategy
+	supports org.eclipse.elk.margins
+	supports layering.coffmanGraham.layerBound
+	supports nodePlacement.favorStraightEdges
+	supports org.eclipse.elk.spacing.portsSurrounding
+	supports directionCongruency
+	supports portSortingStrategy
+	supports edgeRouting.polyline.slopedEdgeZoneWidth
+	supports layering.layerChoiceConstraint
+	supports crossingMinimization.positionChoiceConstraint
+	supports org.eclipse.elk.interactiveLayout
+	supports layering.layerID
+	supports crossingMinimization.positionID
 }
-
 
 /* ------------------------
  *    phase 1
  * ------------------------*/
 group cycleBreaking {
-    
-    option strategy: CycleBreakingStrategy {
-        label "Cycle Breaking Strategy"
-        description
-            "Strategy for cycle breaking. Cycle breaking looks for cycles in the graph and determines
+
+	option strategy: CycleBreakingStrategy {
+		label "Cycle Breaking Strategy"
+		description
+			"Strategy for cycle breaking. Cycle breaking looks for cycles in the graph and determines
             which edges to reverse to break the cycles. Reversed edges will end up pointing to the
             opposite direction of regular edges (that is, reversed edges will point left if edges
             usually point right)."
-        default = CycleBreakingStrategy.GREEDY
-        targets parents
+		default = CycleBreakingStrategy.GREEDY
+		targets parents
     }
-    
-}
 
+}
 
 /* ------------------------
  *    phase 2
  * ------------------------*/
 group layering {
-    
-    option strategy: LayeringStrategy {
-        label "Node Layering Strategy"
-        description "Strategy for node layering."
-        default = LayeringStrategy.NETWORK_SIMPLEX
-        targets parents
-    }
-    
-    advanced option layerConstraint: LayerConstraint {
-        label "Layer Constraint"
-        description "Determines a constraint on the placement of the node regarding the layering."
-        default = LayerConstraint.NONE
-        targets nodes
+
+	option strategy: LayeringStrategy {
+		label "Node Layering Strategy"
+		description
+			"Strategy for node layering."
+		default = LayeringStrategy.NETWORK_SIMPLEX
+		targets parents
     }
 
-    advanced option layerChoiceConstraint: int {
-        label "Layer Choice Constraint"
-        description "Allows to set a constraint regarding the layer placement of a node. 
+	advanced option layerConstraint: LayerConstraint {
+		label "Layer Constraint"
+		description
+			"Determines a constraint on the placement of the node regarding the layering."
+		default = LayerConstraint.NONE
+		targets nodes
+    }
+
+	advanced option layerChoiceConstraint: int {
+		label "Layer Choice Constraint"
+		description
+			"Allows to set a constraint regarding the layer placement of a node. 
                      Let i be the value of teh constraint. Assumed the drawing has n layers and i < n.
                      If set to i, it expresses that the node should be placed in i-th layer.
                      Should i>=n be true then the node is placed in the last layer of the drawing."
-        default = -1
-        lowerBound = -1
-        targets nodes
+		default = -1
+		lowerBound = -1
+		targets nodes
     }
 
-    output option layerID: int {
-        label "Layer ID"
-        description "Layer identifier that was calculated by ELK Layered for a node"
-        default = -1
-        lowerBound = -1
-        targets nodes
+	output option layerID: int {
+		label "Layer ID"
+		description
+			"Layer identifier that was calculated by ELK Layered for a node"
+		default = -1
+		lowerBound = -1
+		targets nodes
     }
 
-    group minWidth {
-        
-        advanced option upperBoundOnWidth: int {
-            label "Upper Bound On Width [MinWidth Layerer]"
-            description 
-                "Defines a loose upper bound on the width of the MinWidth layerer.
+	group minWidth {
+
+		advanced option upperBoundOnWidth: int {
+			label "Upper Bound On Width [MinWidth Layerer]"
+			description
+				"Defines a loose upper bound on the width of the MinWidth layerer.
                  If set to '-1' multiple values are tested and the best result is selected."
-            default = 4
-            lowerBound = -1
-            targets parents
+			default = 4
+			lowerBound = -1
+			targets parents
             requires org.eclipse.elk.alg.layered.layering.strategy == LayeringStrategy.MIN_WIDTH
-        }
-        
-        advanced option upperLayerEstimationScalingFactor: int {
-            label "Upper Layer Estimation Scaling Factor [MinWidth Layerer]"
-            description
-                "Multiplied with Upper Bound On Width for defining an upper bound on the width of layers which
+		}
+
+		advanced option upperLayerEstimationScalingFactor: int {
+			label "Upper Layer Estimation Scaling Factor [MinWidth Layerer]"
+			description
+				"Multiplied with Upper Bound On Width for defining an upper bound on the width of layers which
                 haven't been determined yet, but whose maximum width had been (roughly) estimated by the MinWidth
                 algorithm. Compensates for too high estimations.
                 If set to '-1' multiple values are tested and the best result is selected."
-            default = 2
-            lowerBound = -1
-            targets parents
+			default = 2
+			lowerBound = -1
+			targets parents
             requires org.eclipse.elk.alg.layered.layering.strategy == LayeringStrategy.MIN_WIDTH
+		}
+
+	}
+
+	group nodePromotion {
+
+		advanced option strategy: NodePromotionStrategy {
+			label "Node Promotion Strategy"
+			description
+				"Reduces number of dummy nodes after layering phase (if possible)."
+			default = NodePromotionStrategy.NONE
+			targets parents
         }
-        
-    }
-    
-    group nodePromotion {
-        
-        advanced option strategy: NodePromotionStrategy {
-            label "Node Promotion Strategy"
-            description "Reduces number of dummy nodes after layering phase (if possible)."
-            default = NodePromotionStrategy.NONE
-            targets parents
-        }
-        
-        advanced option maxIterations: int {
-            label "Max Node Promotion Iterations"
-            description "Limits the number of iterations for node promotion."
-            default = 0
-            lowerBound = 0
-            targets parents
+
+		advanced option maxIterations: int {
+			label "Max Node Promotion Iterations"
+			description
+				"Limits the number of iterations for node promotion."
+			default = 0
+			lowerBound = 0
+			targets parents
             requires org.eclipse.elk.alg.layered.layering.nodePromotion.strategy
-        }
+		}
 
-    }
-    
-    group coffmanGraham {
-        
-        advanced option layerBound: int {
-            label "Layer Bound"
-            description "The maximum number of nodes allowed per layer."
-            default = Integer.MAX_VALUE
-            targets parents
+	}
+
+	group coffmanGraham {
+
+		advanced option layerBound: int {
+			label "Layer Bound"
+			description
+				"The maximum number of nodes allowed per layer."
+			default = Integer.MAX_VALUE
+			targets parents
             requires org.eclipse.elk.alg.layered.layering.strategy == LayeringStrategy.COFFMAN_GRAHAM
-        }
-        
-    }
-}
+		}
 
+	}
+
+}
 
 /* ------------------------
  *    phase 3
  * ------------------------*/
 group crossingMinimization {
-    
-    option strategy: CrossingMinimizationStrategy {
-        label "Crossing Minimization Strategy"
-        description "Strategy for crossing minimization."
-        default = CrossingMinimizationStrategy.LAYER_SWEEP
-        targets parents
+
+	option strategy: CrossingMinimizationStrategy {
+		label "Crossing Minimization Strategy"
+		description
+			"Strategy for crossing minimization."
+		default = CrossingMinimizationStrategy.LAYER_SWEEP
+		targets parents
     }
-    
-    advanced option hierarchicalSweepiness: double {
-        label "Hierarchical Sweepiness"
-        description "How likely it is to use cross-hierarchy (1) vs bottom-up (-1)."
-        default = 0.1
-        targets parents
+
+	advanced option hierarchicalSweepiness: double {
+		label "Hierarchical Sweepiness"
+		description
+			"How likely it is to use cross-hierarchy (1) vs bottom-up (-1)."
+		default = 0.1
+		targets parents
         requires org.eclipse.elk.hierarchyHandling == HierarchyHandling.INCLUDE_CHILDREN
-    }
-    
-    group greedySwitch {
-        
-        advanced option activationThreshold: int {
-            label "Greedy Switch Activation Threshold"
-            description 
-                "By default it is decided automatically if the greedy switch is activated or not. 
+	}
+
+	group greedySwitch {
+
+		advanced option activationThreshold: int {
+			label "Greedy Switch Activation Threshold"
+			description
+				"By default it is decided automatically if the greedy switch is activated or not. 
                  The decision is based on whether the size of the input graph (without dummy nodes) 
                  is smaller than the value of this option. A '0' enforces the activation."
-            default = 40
-            targets parents
-            lowerBound = 0
+			default = 40
+			targets parents
+			lowerBound = 0
         }
-        
-        advanced option type: GreedySwitchType {
-            label "Greedy Switch Crossing Minimization"
-            description 
-                "Greedy Switch strategy for crossing minimization. The greedy switch heuristic is executed 
+
+		advanced option type: GreedySwitchType {
+			label "Greedy Switch Crossing Minimization"
+			description
+				"Greedy Switch strategy for crossing minimization. The greedy switch heuristic is executed 
                  after the regular layer sweep as a post-processor."
-            default = GreedySwitchType.TWO_SIDED
-            targets parents
+			default = GreedySwitchType.TWO_SIDED
+			targets parents
         }
-    }
-    
-    advanced option semiInteractive: boolean {
-    	label "Semi-Interactive Crossing Minimization"
-    	description 
-            "Preserves the order of nodes within a layer but still minimizes crossings between edges connecting 
+
+	}
+
+	advanced option semiInteractive: boolean {
+		label "Semi-Interactive Crossing Minimization"
+		description
+			"Preserves the order of nodes within a layer but still minimizes crossings between edges connecting 
              long edge dummies. Derives the desired order from positions specified by the 'org.eclipse.elk.position' 
              layout option. Requires a crossing minimization strategy that is able to process 'in-layer' constraints."
 		default = false
 		targets parents
 		requires crossingMinimization.strategy == CrossingMinimizationStrategy.LAYER_SWEEP
-    }
+	}
 
-    advanced option positionChoiceConstraint: int {
-        label "Position Choice Constraint"
-        description "Allows to set a constraint regarding the position placement of a node in a layer. 
+	advanced option positionChoiceConstraint: int {
+		label "Position Choice Constraint"
+		description
+			"Allows to set a constraint regarding the position placement of a node in a layer. 
                      Assumed the layer in which the node placed includes n other nodes and i < n.
                      If set to i, it expresses that the node should be placed at the i-th position.
                      Should i>=n be true then the node is placed at the last position in the layer.
                     "
-        default = -1
-        lowerBound = -1
-        targets nodes
+		default = -1
+		lowerBound = -1
+		targets nodes
     }
 
-    output option positionID: int {
-        label "Position ID"
-        description "Position within a layer that was determined by ELK Layered for a node."
-        default = -1
-        lowerBound = -1
-        targets nodes
+	output option positionID: int {
+		label "Position ID"
+		description
+			"Position within a layer that was determined by ELK Layered for a node."
+		default = -1
+		lowerBound = -1
+		targets nodes
     }
+
 }
-
 
 /* ------------------------
  *    phase 4
  * ------------------------*/
 group nodePlacement {
 
-    option strategy: NodePlacementStrategy {
-        label "Node Placement Strategy"
-        description "Strategy for node placement."
-        default = NodePlacementStrategy.BRANDES_KOEPF
-        targets parents
+	option strategy: NodePlacementStrategy {
+		label "Node Placement Strategy"
+		description
+			"Strategy for node placement."
+		default = NodePlacementStrategy.BRANDES_KOEPF
+		targets parents
     }
-    
-    option favorStraightEdges: boolean {
-        label "Favor Straight Edges Over Balancing"
-        description 
-            "Favor straight edges over a balanced node placement.
+
+	option favorStraightEdges: boolean {
+		label "Favor Straight Edges Over Balancing"
+		description
+			"Favor straight edges over a balanced node placement.
              The default behavior is determined automatically based on the used 'edgeRouting'.
              For an orthogonal style it is set to true, for all other styles to false."
-        // no default, see description
-        targets parents
+		// no default, see description
+		targets parents
         requires strategy == NodePlacementStrategy.NETWORK_SIMPLEX
-        requires strategy == NodePlacementStrategy.BRANDES_KOEPF
-    }
-    
-    group bk {
-        
-        advanced option edgeStraightening: EdgeStraighteningStrategy {
-        	label "BK Edge Straightening"
-        	description
-        	    "Specifies whether the Brandes Koepf node placer tries to increase the number of straight edges
+		requires strategy == NodePlacementStrategy.BRANDES_KOEPF
+	}
+
+	group bk {
+
+		advanced option edgeStraightening: EdgeStraighteningStrategy {
+			label "BK Edge Straightening"
+			description
+				"Specifies whether the Brandes Koepf node placer tries to increase the number of straight edges
                  at the expense of diagram size.
                  There is a subtle difference to the 'favorStraightEdges' option, which decides whether 
                  a balanced placement of the nodes is desired, or not. In bk terms this means combining the four 
                  alignments into a single balanced one, or not. This option on the other hand tries to straighten 
                  additional edges during the creation of each of the four alignments."
-        	default = EdgeStraighteningStrategy.IMPROVE_STRAIGHTNESS
-        	targets parents
+			default = EdgeStraighteningStrategy.IMPROVE_STRAIGHTNESS
+			targets parents
         	requires org.eclipse.elk.alg.layered.nodePlacement.strategy == NodePlacementStrategy.BRANDES_KOEPF
-        }
-        
-        advanced option fixedAlignment: FixedAlignment {
-            label "BK Fixed Alignment"
-            description
-                "Tells the BK node placer to use a certain alignment (out of its four) instead of the 
+		}
+
+		advanced option fixedAlignment: FixedAlignment {
+			label "BK Fixed Alignment"
+			description
+				"Tells the BK node placer to use a certain alignment (out of its four) instead of the 
                  one producing the smallest height, or the combination of all four."
-            default = FixedAlignment.NONE
-            targets parents
+			default = FixedAlignment.NONE
+			targets parents
             requires org.eclipse.elk.alg.layered.nodePlacement.strategy == NodePlacementStrategy.BRANDES_KOEPF
-        }
-        
-    }
-    
-    group linearSegments {
-        
-        advanced option deflectionDampening: double {
-            label "Linear Segments Deflection Dampening"
-            description "Dampens the movement of nodes to keep the diagram from getting too large."
-            default = 0.3
-            lowerBound = ExclusiveBounds.greaterThan(0)
-            targets parents
+		}
+
+	}
+
+	group linearSegments {
+
+		advanced option deflectionDampening: double {
+			label "Linear Segments Deflection Dampening"
+			description
+				"Dampens the movement of nodes to keep the diagram from getting too large."
+			default = 0.3
+			lowerBound = ExclusiveBounds.greaterThan(0)
+			targets parents
             requires org.eclipse.elk.alg.layered.nodePlacement.strategy == NodePlacementStrategy.LINEAR_SEGMENTS
-        }
-        
-    }
-    
-    group networkSimplex {
-        
-        advanced option nodeFlexibility: NodeFlexibility {
-            label "Node Flexibility"
-            description 
-                "Aims at shorter and straighter edges. Two configurations are possible: 
+		}
+
+	}
+
+	group networkSimplex {
+
+		advanced option nodeFlexibility: NodeFlexibility {
+			label "Node Flexibility"
+			description
+				"Aims at shorter and straighter edges. Two configurations are possible: 
                  (a) allow ports to move freely on the side they are assigned to (the order is always defined beforehand),
                  (b) additionally allow to enlarge a node wherever it helps. 
                  If this option is not configured for a node, the 'nodeFlexibility.default' value is used, 
                  which is specified for the node's parent."
-            targets nodes
+			targets nodes
             requires nodePlacement.strategy == NodePlacementStrategy.NETWORK_SIMPLEX
-        }
-        
-        group nodeFlexibility {
-            advanced option ^default: NodeFlexibility {
-                label "Node Flexibility Default"
-                description "Default value of the 'nodeFlexibility' option for the children of a hierarchical node."
-                default = NodeFlexibility.NONE
-                targets parents   
-                requires nodePlacement.strategy == NodePlacementStrategy.NETWORK_SIMPLEX
-            }
-        }
-    }
-}
+		}
 
+		group nodeFlexibility {
+
+			advanced option ^default: NodeFlexibility {
+				label "Node Flexibility Default"
+				description
+					"Default value of the 'nodeFlexibility' option for the children of a hierarchical node."
+				default = NodeFlexibility.NONE
+				targets parents   
+                requires nodePlacement.strategy == NodePlacementStrategy.NETWORK_SIMPLEX
+			}
+
+		}
+
+	}
+
+}
 
 /* ------------------------
  *    phase 5
  * ------------------------*/
 group edgeRouting {
-    
-    group splines {
-        option mode: SplineRoutingMode {
-            label "Spline Routing Mode"
-            description 
-                "Specifies the way control points are assembled for each individual edge.
+
+	group splines {
+
+		option mode: SplineRoutingMode {
+			label "Spline Routing Mode"
+			description
+				"Specifies the way control points are assembled for each individual edge.
                  CONSERVATIVE ensures that edges are properly routed around the nodes 
                  but feels rather orthogonal at times.  
                  SLOPPY uses fewer control points to obtain curvier edge routes but may result in 
                  edges overlapping nodes. "
-            default = SplineRoutingMode.SLOPPY
-            targets parents
+			default = SplineRoutingMode.SLOPPY
+			targets parents
             requires org.eclipse.elk.edgeRouting == EdgeRouting.SPLINES
-        }
-        
-        group sloppy {
-            option layerSpacingFactor: double {
-                label "Sloppy Spline Layer Spacing Factor"
-                description "Spacing factor for routing area between layers when using sloppy spline routing."
-                default = 0.2
-                targets parents
+		}
+
+		group sloppy {
+
+			option layerSpacingFactor: double {
+				label "Sloppy Spline Layer Spacing Factor"
+				description
+					"Spacing factor for routing area between layers when using sloppy spline routing."
+				default = 0.2
+				targets parents
                 requires org.eclipse.elk.edgeRouting == EdgeRouting.SPLINES // TODO this should be an AND
-                requires splines.mode == SplineRoutingMode.SLOPPY
-            }            
-        }
-        
-    }
-    
-    group polyline {
-        advanced option slopedEdgeZoneWidth: double {
-            label "Sloped Edge Zone Width"
-            description "Width of the strip to the left and to the right of each layer where the polyline edge router
+				requires splines.mode == SplineRoutingMode.SLOPPY
+			}
+
+		}
+
+	}
+
+	group polyline {
+
+		advanced option slopedEdgeZoneWidth: double {
+			label "Sloped Edge Zone Width"
+			description
+				"Width of the strip to the left and to the right of each layer where the polyline edge router
                     is allowed to refrain from ensuring that edges are routed horizontally. This prevents awkward
                     bend points for nodes that extent almost to the edge of their layer."
-            documentation "@slopedEdgeZoneWidth.md"
-            default = 2.0
-            targets parents
+			documentation "@slopedEdgeZoneWidth.md"
+			default = 2.0
+			targets parents
             requires org.eclipse.elk.edgeRouting == EdgeRouting.POLYLINE
-        }
+		}
+
+	}
+
+	option selfLoopDistribution: SelfLoopDistributionStrategy {
+		label "Self-Loop Distribution"
+		description
+			"Alter the distribution of the loops around the node. It only takes effect for PortConstraints.FREE."
+		default = SelfLoopDistributionStrategy.NORTH
+		targets nodes
     }
 
-    option selfLoopDistribution: SelfLoopDistributionStrategy {
-        label "Self-Loop Distribution"
-        description 
-            "Alter the distribution of the loops around the node. It only takes effect for PortConstraints.FREE."
-        default = SelfLoopDistributionStrategy.NORTH
-        targets nodes
-    }
-    
-    option selfLoopOrdering: SelfLoopOrderingStrategy {
-        label "Self-Loop Ordering"
-         description "Alter the ordering of the loops they can either be stacked or sequenced.
+	option selfLoopOrdering: SelfLoopOrderingStrategy {
+		label "Self-Loop Ordering"
+		description
+			"Alter the ordering of the loops they can either be stacked or sequenced.
                 It only takes effect for PortConstraints.FREE."
-        default = SelfLoopOrderingStrategy.STACKED
-        targets nodes
+		default = SelfLoopOrderingStrategy.STACKED
+		targets nodes
     }
 
 }
-
 
 /* ------------------------
  *    spacing
  * ------------------------*/
 group spacing {
 
-    option edgeNodeBetweenLayers: double {
-        label "Edge Node Between Layers Spacing"
-        description 
-            "The spacing to be preserved between nodes and edges that are routed next to the node's layer. 
+	option edgeNodeBetweenLayers: double {
+		label "Edge Node Between Layers Spacing"
+		description
+			"The spacing to be preserved between nodes and edges that are routed next to the node's layer. 
              For the spacing between nodes and edges that cross the node's layer 'spacing.edgeNode' is used."
-        default = 10
-        lowerBound = 0.0
-        targets parents
-    }
-    
-    option edgeEdgeBetweenLayers: double {
-        label "Edge Edge Between Layer Spacing"
-        description 
-            "Spacing to be preserved between pairs of edges that are routed between the same pair of layers. 
-             Note that 'spacing.edgeEdge' is used for the spacing between pairs of edges crossing the same layer."
-        default = 10
-        lowerBound = 0.0
-        targets parents
+		default = 10
+		lowerBound = 0.0
+		targets parents
     }
 
-    option nodeNodeBetweenLayers: double {
-        label "Node Node Between Layers Spacing"
-        description 
-            "The spacing to be preserved between any pair of nodes of two adjacent layers. 
-             Note that 'spacing.nodeNode' is used for the spacing between nodes within the layer itself."
-        default = 20
-        lowerBound = 0.0
-        targets parents
+	option edgeEdgeBetweenLayers: double {
+		label "Edge Edge Between Layer Spacing"
+		description
+			"Spacing to be preserved between pairs of edges that are routed between the same pair of layers. 
+             Note that 'spacing.edgeEdge' is used for the spacing between pairs of edges crossing the same layer."
+		default = 10
+		lowerBound = 0.0
+		targets parents
     }
-    
+
+	option nodeNodeBetweenLayers: double {
+		label "Node Node Between Layers Spacing"
+		description
+			"The spacing to be preserved between any pair of nodes of two adjacent layers. 
+             Note that 'spacing.nodeNode' is used for the spacing between nodes within the layer itself."
+		default = 20
+		lowerBound = 0.0
+		targets parents
+    }
+
 }
 
 /* ------------------------
  *    priority
  * ------------------------*/
 group priority {
-    
-    advanced option direction: int {
-        label "Direction Priority"
-        description 
-            "Defines how important it is to have a certain edge point into the direction of the overall layout.
+
+	advanced option direction: int {
+		label "Direction Priority"
+		description
+			"Defines how important it is to have a certain edge point into the direction of the overall layout.
              This option is evaluated during the cycle breaking phase."
-        default = 0
-        lowerBound = 0
-        targets edges
+		default = 0
+		lowerBound = 0
+		targets edges
     }
-    
-    advanced option shortness: int {
-        label "Shortness Priority"
-        description 
-            "Defines how important it is to keep an edge as short as possible.
+
+	advanced option shortness: int {
+		label "Shortness Priority"
+		description
+			"Defines how important it is to keep an edge as short as possible.
              This option is evaluated during the layering phase."
-        default = 0
-        lowerBound = 0
-        targets edges
+		default = 0
+		lowerBound = 0
+		targets edges
     }
-    
-    advanced option straightness: int {
-        label "Straightness Priority"
-        description 
-            "Defines how important it is to keep an edge straight, i.e. aligned with one of the two axes.
+
+	advanced option straightness: int {
+		label "Straightness Priority"
+		description
+			"Defines how important it is to keep an edge straight, i.e. aligned with one of the two axes.
              This option is evaluated during node placement."
-        default = 0
-        lowerBound = 0
-        targets edges
+		default = 0
+		lowerBound = 0
+		targets edges
     }
-    
+
 }
 
 /* ------------------------
  *    compaction
  * ------------------------*/
 group compaction {
-    
-    group postCompaction {
-        
-        advanced option strategy: GraphCompactionStrategy {
-            label "Post Compaction Strategy"
-            description "Specifies whether and how post-process compaction is applied."
-            default = GraphCompactionStrategy.NONE
-            targets parents
-        }
-        
-        advanced option constraints: ConstraintCalculationStrategy {
-            label "Post Compaction Constraint Calculation"
-            description "Specifies whether and how post-process compaction is applied."
-            default = ConstraintCalculationStrategy.SCANLINE
-            targets parents
-        }
-        
-    }
-    
-    advanced option connectedComponents: boolean {
-        label "Connected Components Compaction"
-        description "Tries to further compact components (disconnected sub-graphs)."
-        default = false
-        targets parents
-        requires org.eclipse.elk.separateConnectedComponents == true
-    }
-    
-}
 
+	group postCompaction {
+
+		advanced option strategy: GraphCompactionStrategy {
+			label "Post Compaction Strategy"
+			description
+				"Specifies whether and how post-process compaction is applied."
+			default = GraphCompactionStrategy.NONE
+			targets parents
+        }
+
+		advanced option constraints: ConstraintCalculationStrategy {
+			label "Post Compaction Constraint Calculation"
+			description
+				"Specifies whether and how post-process compaction is applied."
+			default = ConstraintCalculationStrategy.SCANLINE
+			targets parents
+        }
+
+	}
+
+	advanced option connectedComponents: boolean {
+		label "Connected Components Compaction"
+		description
+			"Tries to further compact components (disconnected sub-graphs)."
+		default = false
+		targets parents
+        requires org.eclipse.elk.separateConnectedComponents == true
+	}
+
+}
 
 /* ------------------------
  *    high degree nodes
  * ------------------------*/
 group highDegreeNodes {
-    
-    advanced option treatment: boolean {
-        label "High Degree Node Treatment"
-        description "Makes room around high degree nodes to place leafs and trees."
-        default = false
-        targets parents
+
+	advanced option treatment: boolean {
+		label "High Degree Node Treatment"
+		description
+			"Makes room around high degree nodes to place leafs and trees."
+		default = false
+		targets parents
     }
-    
-    advanced option threshold: int {
-        label "High Degree Node Threshold"
-        description "Whether a node is considered to have a high degree."
-        default = 16
-        lowerBound = 0
-        targets parents
+
+	advanced option threshold: int {
+		label "High Degree Node Threshold"
+		description
+			"Whether a node is considered to have a high degree."
+		default = 16
+		lowerBound = 0
+		targets parents
         requires org.eclipse.elk.alg.layered.highDegreeNodes.treatment == true
-    }
-    
-    advanced option treeHeight: int {
-        label "High Degree Node Maximum Tree Height"
-        description "Maximum height of a subtree connected to a high degree node to be moved to separate layers."
-        default = 5
-        lowerBound = 0
-        targets parents
+	}
+
+	advanced option treeHeight: int {
+		label "High Degree Node Maximum Tree Height"
+		description
+			"Maximum height of a subtree connected to a high degree node to be moved to separate layers."
+		default = 5
+		lowerBound = 0
+		targets parents
         requires org.eclipse.elk.alg.layered.highDegreeNodes.treatment == true
-    }
+	}
 
 }
 
 /* ------------------------
-  *    wrapping
-  * ------------------------*/
+ *    wrapping
+ * ------------------------*/
 group wrapping {
-      
-    advanced option strategy: WrappingStrategy {
-        label "Graph Wrapping Strategy"
-        description 
-            "For certain graphs and certain prescribed drawing areas it may be desirable to 
+
+	advanced option strategy: WrappingStrategy {
+		label "Graph Wrapping Strategy"
+		description
+			"For certain graphs and certain prescribed drawing areas it may be desirable to 
              split the laid out graph into chunks that are placed side by side. 
              The edges that connect different chunks are 'wrapped' around from the end of 
              one chunk to the start of the other chunk.
              The points between the chunks are referred to as 'cuts'."
-        targets parents
-        default = WrappingStrategy.OFF
+		targets parents
+		default = WrappingStrategy.OFF
     }
- 
-    advanced option additionalEdgeSpacing: double {
-        label "Additional Wrapped Edges Spacing"
-        description 
-            "To visually separate edges that are wrapped from regularly routed edges an additional spacing value 
+
+	advanced option additionalEdgeSpacing: double {
+		label "Additional Wrapped Edges Spacing"
+		description
+			"To visually separate edges that are wrapped from regularly routed edges an additional spacing value 
              can be specified in form of this layout option. The spacing is added to the regular edgeNode spacing."
-        default = 10
-        targets parents
+		default = 10
+		targets parents
         requires wrapping.strategy == WrappingStrategy.SINGLE_EDGE
-        requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
-    }
-    
-    advanced option correctionFactor: double {
-        label "Correction Factor for Wrapping"
-        description 
-            "At times and for certain types of graphs the executed wrapping may produce results that 
+		requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
+	}
+
+	advanced option correctionFactor: double {
+		label "Correction Factor for Wrapping"
+		description
+			"At times and for certain types of graphs the executed wrapping may produce results that 
              are consistently biased in the same fashion: either wrapping to often or to rarely. 
              This factor can be used to correct the bias. Internally, it is simply multiplied with 
              the 'aspect ratio' layout option."
-        default = 1.0
-        targets parents
+		default = 1.0
+		targets parents
         requires wrapping.strategy == WrappingStrategy.SINGLE_EDGE
-        requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
-    }
+		requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
+	}
 
-    group cutting {
+	group cutting {
 
-        advanced option strategy: CuttingStrategy {
-            label "Cutting Strategy"
-            description 
-                "The strategy by which the layer indexes are determined at which the layering crumbles into chunks."
-            default = CuttingStrategy.MSD
-            targets parents
+		advanced option strategy: CuttingStrategy {
+			label "Cutting Strategy"
+			description
+				"The strategy by which the layer indexes are determined at which the layering crumbles into chunks."
+			default = CuttingStrategy.MSD
+			targets parents
             requires wrapping.strategy == WrappingStrategy.SINGLE_EDGE
-            requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
-        }
+			requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
+		}
 
-        advanced option cuts: List<Integer> {
-            label "Manually Specified Cuts"
-            description "Allows the user to specify her own cuts for a certain graph."
-            targets parents 
+		advanced option cuts: List<Integer> {
+			label "Manually Specified Cuts"
+			description
+				"Allows the user to specify her own cuts for a certain graph."
+			targets parents 
             requires wrapping.cutting.strategy == CuttingStrategy.MANUAL
-        }
-     
-        group msd {
-            advanced option freedom: Integer {
-                label "MSD Freedom"
-                description 
-                    "The MSD cutting strategy starts with an initial guess on the number of chunks the graph 
+		}
+
+		group msd {
+
+			advanced option freedom: Integer {
+				label "MSD Freedom"
+				description
+					"The MSD cutting strategy starts with an initial guess on the number of chunks the graph 
                      should be split into. The freedom specifies how much the strategy may deviate from this guess.
                      E.g. if an initial number of 3 is computed, a freedom of 1 allows 2, 3, and 4 cuts."
-                default = 1
-                lowerBound = 0
-                targets parents
+				default = 1
+				lowerBound = 0
+				targets parents
                 requires wrapping.cutting.strategy == CuttingStrategy.MSD
-            }
-        }
-    }
- 
-    group validify {
-        
-        advanced option strategy: ValidifyStrategy {
-            label "Validification Strategy"
-            description 
-                "When wrapping graphs, one can specify indices that are not allowed as split points.  
+			}
+
+		}
+
+	}
+
+	group validify {
+
+		advanced option strategy: ValidifyStrategy {
+			label "Validification Strategy"
+			description
+				"When wrapping graphs, one can specify indices that are not allowed as split points.  
                  The validification strategy makes sure every computed split point is allowed."
-            default = ValidifyStrategy.GREEDY
-            targets parents
+			default = ValidifyStrategy.GREEDY
+			targets parents
             requires wrapping.strategy == WrappingStrategy.SINGLE_EDGE
-            requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
-        }
-        
-        advanced option forbiddenIndices: List<Integer> {
-            label "Valid Indices for Wrapping"
+			requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
+		}
+
+		advanced option forbiddenIndices: List<Integer> {
+			label "Valid Indices for Wrapping"
             targets parents 
             requires wrapping.strategy == WrappingStrategy.SINGLE_EDGE
             requires wrapping.strategy == WrappingStrategy.MULTI_EDGE
         }
-    }
-        
-    group singleEdge {
-    }
- 
-    group multiEdge {
-     
-        advanced option improveCuts: boolean {
-            label "Improve Cuts"
-            description 
-                "For general graphs it is important that not too many edges wrap backwards. 
+
+	}
+
+	group singleEdge {
+
+	}
+
+	group multiEdge {
+
+		advanced option improveCuts: boolean {
+			label "Improve Cuts"
+			description
+				"For general graphs it is important that not too many edges wrap backwards. 
                  Thus a compromise between evenly-distributed cuts and the total number of cut edges is sought."
-            default = true
-            targets parents
+			default = true
+			targets parents
             requires strategy == WrappingStrategy.MULTI_EDGE
-        }
- 
-        advanced option distancePenalty: double {
-            label "Distance Penalty When Improving Cuts "
+		}
+
+		advanced option distancePenalty: double {
+			label "Distance Penalty When Improving Cuts "
             default = 2.0
             targets parents
             requires strategy == WrappingStrategy.MULTI_EDGE
             requires improveCuts == true
         }
-     
-        advanced option improveWrappedEdges: boolean {
-            label "Improve Wrapped Edges"
-            description 
-                "The initial wrapping is performed in a very simple way. As a consequence, edges that wrap from 
+
+		advanced option improveWrappedEdges: boolean {
+			label "Improve Wrapped Edges"
+			description
+				"The initial wrapping is performed in a very simple way. As a consequence, edges that wrap from 
                  one chunk to another may be unnecessarily long. Activating this option tries to shorten such edges."
-            default = true
-            targets parents 
+			default = true
+			targets parents 
             requires strategy == WrappingStrategy.MULTI_EDGE
-         }
-    }
+		}
+
+	}
+
 }
 
 /* ------------------------
  *    edgeLabels
  * ------------------------*/
 group edgeLabels {
-    option sideSelection: EdgeLabelSideSelection {
-        label "Edge Label Side Selection"
-        description "Method to decide on edge label sides."
-        default = EdgeLabelSideSelection.SMART_DOWN
-        targets parents
+
+	option sideSelection: EdgeLabelSideSelection {
+		label "Edge Label Side Selection"
+		description
+			"Method to decide on edge label sides."
+		default = EdgeLabelSideSelection.SMART_DOWN
+		targets parents
     }
-    
-    advanced option centerLabelPlacementStrategy: CenterEdgeLabelPlacementStrategy {
-        label "Edge Center Label Placement Strategy"
-        description "Determines in which layer center labels of long edges should be placed."
-        default = CenterEdgeLabelPlacementStrategy.MEDIAN_LAYER
-        targets parents, labels
+
+	advanced option centerLabelPlacementStrategy: CenterEdgeLabelPlacementStrategy {
+		label "Edge Center Label Placement Strategy"
+		description
+			"Determines in which layer center labels of long edges should be placed."
+		default = CenterEdgeLabelPlacementStrategy.MEDIAN_LAYER
+		targets parents, labels
     }
+
 }
 
 /* ------------------------
  *    miscellaneous
  * ------------------------*/
 advanced option directionCongruency: DirectionCongruency {
-    label "Direction Congruency"
-    description
-        "Specifies how drawings of the same graph with different layout directions compare to each other: 
+	label "Direction Congruency"
+	description
+		"Specifies how drawings of the same graph with different layout directions compare to each other: 
          either a natural reading direction is preserved or the drawings are rotated versions of each other."
-    default = DirectionCongruency.READING_DIRECTION
-    targets parents
-    documentation "@transformation.md"
+	default = DirectionCongruency.READING_DIRECTION
+	targets parents
+	documentation "@transformation.md"
 }
 
 advanced option feedbackEdges: boolean {
 	label "Feedback Edges"
-	description "Whether feedback edges should be highlighted by routing around the nodes."
+	description
+		"Whether feedback edges should be highlighted by routing around the nodes."
 	default = false
 	targets parents
 }
 
 advanced option interactiveReferencePoint: InteractiveReferencePoint {
 	label "Interactive Reference Point"
-	description "Determines which point of a node is considered by interactive layout phases."
+	description
+		"Determines which point of a node is considered by interactive layout phases."
 	default = InteractiveReferencePoint.CENTER
 	targets parents
 	requires org.eclipse.elk.alg.layered.cycleBreaking.strategy == CycleBreakingStrategy.INTERACTIVE
@@ -870,28 +910,29 @@ advanced option mergeHierarchyEdges: boolean {
 }
 
 advanced option northOrSouthPort: boolean {
-    label "North or South Port"
-    description
-        "Specifies that this port can either be placed on the north side of a node or on the south
+	label "North or South Port"
+	description
+		"Specifies that this port can either be placed on the north side of a node or on the south
         side (if port constraints permit)"
-    default = false
-    targets ports
+	default = false
+	targets ports
 }
 
 advanced option portSortingStrategy: PortSortingStrategy {
-    label "Port Sorting Strategy"
-    description 
-        "Only relevant for nodes with FIXED_SIDE port constraints. Determines the way a node's ports are 
+	label "Port Sorting Strategy"
+	description
+		"Only relevant for nodes with FIXED_SIDE port constraints. Determines the way a node's ports are 
          distributed on the sides of a node if their order is not prescribed. The option is set on parent nodes."
-    default = PortSortingStrategy.INPUT_ORDER
-    targets parents
-} 
+	default = PortSortingStrategy.INPUT_ORDER
+	targets parents
+}
 
 advanced option thoroughness: int {
 	label "Thoroughness"
-	description "How much effort should be spent to produce a nice layout."
+	description
+		"How much effort should be spent to produce a nice layout."
 	default = 7
-    lowerBound = 1
+	lowerBound = 1
 	targets parents
 }
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
@@ -10,8 +10,6 @@
 package org.eclipse.elk.alg.mrtree
 
 import org.eclipse.elk.alg.mrtree.TreeLayoutProvider
-import org.eclipse.elk.alg.mrtree.options.OrderWeighting
-import org.eclipse.elk.alg.mrtree.options.TreeifyingOrder
 import org.eclipse.elk.core.math.ElkPadding
 
 /**
@@ -24,7 +22,7 @@ bundle {
 
 algorithm mrtree(TreeLayoutProvider) {
     label "ELK Mr. Tree"
-    description 
+    description
         "Tree-based algorithm provided by the Eclipse Layout Kernel. Computes a spanning tree of
         the input graph and arranges all nodes according to the resulting parent-children
         hierarchy. I pity the fool who doesn't use Mr. Tree Layout."
@@ -36,11 +34,10 @@ algorithm mrtree(TreeLayoutProvider) {
     supports org.eclipse.elk.spacing.nodeNode = 20
     supports org.eclipse.elk.aspectRatio = 1.6f
     supports org.eclipse.elk.priority = 1
-	   documentation 
-	       "Priorities set on nodes determine the order in which connected components are placed:
+    documentation "Priorities set on nodes determine the order in which connected components are placed:
             components with a higher sum of node priorities will end up
             before components with a lower sum."
-    supports org.eclipse.elk.separateConnectedComponents = true 
+    supports org.eclipse.elk.separateConnectedComponents = true
     supports org.eclipse.elk.debugMode
     supports weighting
     supports searchOrder
@@ -48,14 +45,16 @@ algorithm mrtree(TreeLayoutProvider) {
 
 option weighting: OrderWeighting {
     label "Weighting of Nodes"
-    description "Which weighting to use when computing a node order."
+    description
+        "Which weighting to use when computing a node order."
     default = OrderWeighting.DESCENDANTS
     targets parents
 }
 
 option searchOrder: TreeifyingOrder {
     label "Search Order"
-    description "Which search order to use when computing a spanning tree."
+    description
+        "Which search order to use when computing a spanning tree."
     default = TreeifyingOrder.DFS
     targets parents
 }

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/Radial.melk
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/Radial.melk
@@ -10,10 +10,6 @@
 package org.eclipse.elk.alg.radial
 
 import org.eclipse.elk.alg.radial.RadialLayoutProvider
-import org.eclipse.elk.alg.radial.options.AnnulusWedgeCriteria
-import org.eclipse.elk.alg.radial.options.CompactionStrategy
-import org.eclipse.elk.alg.radial.options.RadialTranslationStrategy
-import org.eclipse.elk.alg.radial.options.SortingStrategy
 
 bundle {
     metadataClass options.RadialMetaDataProvider
@@ -23,7 +19,7 @@ bundle {
 algorithm radial(RadialLayoutProvider) {
     label "ELK Radial"
     metadataClass options.RadialOptions
-    description 
+    description
         "A radial layout provider which is based on the algorithm of Peter Eades published in \"Drawing free trees.\", 
          published by International Institute for Advanced Study of Social Information Science, Fujitsu Limited in 1991. 
          The radial layouter takes a tree and places the nodes in radial order around the root. The nodes of the same 
@@ -43,10 +39,9 @@ algorithm radial(RadialLayoutProvider) {
 }
 
 /////////////////////////////////Options///////////////////////////////
-
 option orderId: int {
     label "Order ID "
-    description 
+    description
         "The id can be used to define an order for nodes of one radius. This can be used to sort them in the 
          layer accordingly."
     default = 0
@@ -55,24 +50,25 @@ option orderId: int {
 
 option radius: double {
     label "Radius"
-    description "The radius option can be used to set the initial radius for the radial layouter."
+    description
+        "The radius option can be used to set the initial radius for the radial layouter."
     default = 0.0
     targets parents
-}  
+}
 
 //Compaction
 option compactor: CompactionStrategy {
     label "Compaction"
-    description 
+    description
         "With the compacter option it can be determined how compaction on the graph is done. 
          It can be chosen between none, the radial compaction or the compaction of wedges separately."
     targets parents
     default = CompactionStrategy.NONE
-} 
+}
 
 option compactionStepSize: int {
     label "Compaction Step Size"
-    description 
+    description
         "Determine the size of steps with which the compaction is done. 
          Step size 1 correlates to a compaction of 1 pixel per Iteration."
     lowerBound = 0
@@ -83,7 +79,7 @@ option compactionStepSize: int {
 
 option sorter: SortingStrategy {
     label "Sorter"
-    description 
+    description
         "Sort the nodes per radius according to the sorting algorithm. The strategies are none, by the given order id, 
          or sorting them by polar coordinates."
     targets parents
@@ -92,7 +88,7 @@ option sorter: SortingStrategy {
 
 option wedgeCriteria: AnnulusWedgeCriteria {
     label "Annulus Wedge Criteria"
-    description 
+    description
         "Determine how the wedge for the node placement is calculated. 
          It can be chosen between wedge determination by the number of leaves or by the maximum sum of diagonals."
     targets parents
@@ -101,7 +97,7 @@ option wedgeCriteria: AnnulusWedgeCriteria {
 
 option optimizationCriteria: RadialTranslationStrategy {
     label "Translation Optimization"
-    description 
+    description
         "Find the optimal translation of the nodes of the first radii according to this criteria. 
          For example edge crossings can be minimized."
     default = RadialTranslationStrategy.NONE

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPacking.melk
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPacking.melk
@@ -8,24 +8,23 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/ 
 package org.eclipse.elk.alg.rectpacking
- 
-/* Metadata file for rectangle packing algorithms. Enables support for options and specifies auto-generated files.
- */
+
 import org.eclipse.elk.alg.rectpacking.RectPackingLayoutProvider
-import org.eclipse.elk.core.math.ElkPadding
 import org.eclipse.elk.alg.rectpacking.util.OptimizationGoal
+import org.eclipse.elk.core.math.ElkPadding
 import org.eclipse.elk.core.options.ContentAlignment
 
-//BUNDLE
+// BUNDLE
 bundle {
     metadataClass options.RectPackingMetaDataProvider
     idPrefix org.eclipse.elk.rectpacking
 }
 
-//ALGORITHM
-algorithm rectpacking (RectPackingLayoutProvider) {
+// ALGORITHM
+algorithm rectpacking(RectPackingLayoutProvider) {
     label "Rectangle Packing"
-    description "Algorithm for packing of unconnected boxes, i.e. graphs without edges. The given order of the boxes
+    description
+        "Algorithm for packing of unconnected boxes, i.e. graphs without edges. The given order of the boxes
         is always preserved and the main reading direction of the boxes is left to right. The algorithm is divided into
         two phases. One phase approximates the width in which the rectangles can be placed. The next phase places the rectangles
         in rows using the previously calculated width as bounding width and bundles rectangles with a similar height in blocks.
@@ -49,10 +48,11 @@ algorithm rectpacking (RectPackingLayoutProvider) {
     supports currentPosition
 }
 
-//OPTIONS
+// OPTIONS
 advanced option optimizationGoal: OptimizationGoal {
     label "Optimization Goal"
-    description "Optimization goal for approximation of the bounding box given by the first iteration. Determines whether layout is 
+    description
+        "Optimization goal for approximation of the bounding box given by the first iteration. Determines whether layout is 
          sorted by the maximum scaling, aspect ratio, or area. Depending on the strategy the aspect ratio might be nearly ignored."
     documentation "@packingstrategy.md"
     targets nodes
@@ -61,7 +61,8 @@ advanced option optimizationGoal: OptimizationGoal {
 
 programmatic option lastPlaceShift: boolean {
     label "Shift Last Placed."
-    description "When placing a rectangle behind or below the last placed rectangle in the first iteration, it is sometimes 
+    description
+        "When placing a rectangle behind or below the last placed rectangle in the first iteration, it is sometimes 
          possible to shift the rectangle further to the left or right, resulting in less whitespace. True (default) 
          enables the shift and false disables it. Disabling the shift produces a greater approximated area by the first 
          iteration and a layout, when using ONLY the first iteration (default not the case), where it is sometimes 
@@ -73,7 +74,8 @@ programmatic option lastPlaceShift: boolean {
 
 output option currentPosition: int {
     label "Current position of a node in the order of nodes"
-    description "The rectangles are ordered. Normally according to their definition the the model.
+    description
+        "The rectangles are ordered. Normally according to their definition the the model.
                  This option specifies the current position of a node."
     default = -1
     lowerBound = -1
@@ -82,7 +84,8 @@ output option currentPosition: int {
 
 advanced option desiredPosition: int {
     label "Desired index of node"
-    description "The rectangles are ordered. Normally according to their definition the the model.
+    description
+        "The rectangles are ordered. Normally according to their definition the the model.
                  This option allows to specify a desired position that has preference over the
                  original position."
     default = -1
@@ -92,7 +95,8 @@ advanced option desiredPosition: int {
 
 programmatic option onlyFirstIteration: boolean {
     label "Only Area Approximation"
-    description "If enabled only the width approximation step is executed and the nodes are placed accordingly.
+    description
+        "If enabled only the width approximation step is executed and the nodes are placed accordingly.
         The nodes are layouted according to the packingStrategy.
         If set to true not expansion of nodes is taking place."
     targets nodes
@@ -101,7 +105,8 @@ programmatic option onlyFirstIteration: boolean {
 
 programmatic option rowCompaction: boolean {
     label "Compact Rows"
-    description "Enables compaction. Compacts blocks if they do not use the full height of the row.
+    description
+        "Enables compaction. Compacts blocks if they do not use the full height of the row.
         This option allows to have a smaller drawing.
         If this option is disabled all nodes are placed next to each other in rows."
     targets nodes
@@ -110,7 +115,8 @@ programmatic option rowCompaction: boolean {
 
 advanced option expandToAspectRatio: boolean {
     label "Fit Aspect Ratio"
-    description "Expands nodes if expandNodes is true to fit the aspect ratio instead of only in their bounds.
+    description
+        "Expands nodes if expandNodes is true to fit the aspect ratio instead of only in their bounds.
             The option is only useful if the used packingStrategy is ASPECT_RATIO_DRIVEN, otherwise this may result
             in unreasonable ndoe expansion."
     targets nodes

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/SPOrE.melk
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/SPOrE.melk
@@ -11,11 +11,6 @@ package org.eclipse.elk.alg.spore
 
 import org.eclipse.elk.alg.spore.OverlapRemovalLayoutProvider
 import org.eclipse.elk.alg.spore.ShrinkTreeLayoutProvider
-import org.eclipse.elk.alg.spore.options.CompactionStrategy
-import org.eclipse.elk.alg.spore.options.RootSelection
-import org.eclipse.elk.alg.spore.options.SpanningTreeCostFunction
-import org.eclipse.elk.alg.spore.options.StructureExtractionStrategy
-import org.eclipse.elk.alg.spore.options.TreeConstructionStrategy
 import org.eclipse.elk.core.math.ElkPadding
 
 bundle {
@@ -26,7 +21,7 @@ bundle {
 algorithm sporeOverlap(OverlapRemovalLayoutProvider) {
     label "ELK SPOrE Overlap Removal"
     metadataClass options.SporeOverlapRemovalOptions
-    description 
+    description
         "A node overlap removal algorithm proposed by Nachmanson et al. in \"Node overlap removal 
          by growing a tree\"."
     preview images/overlap-removal.png
@@ -42,7 +37,7 @@ algorithm sporeOverlap(OverlapRemovalLayoutProvider) {
 algorithm sporeCompaction(ShrinkTreeLayoutProvider) {
     label "ELK SPOrE Compaction"
     metadataClass options.SporeCompactionOptions
-    description 
+    description
         "ShrinkTree is a compaction algorithm that maintains the topology of a layout. 
          The relocation of diagram elements is based on contracting a spanning tree."
     preview images/compaction-example.png
@@ -68,71 +63,90 @@ option underlyingLayoutAlgorithm: String {
          compacted. If this is null, nothing is applied before compaction."
     targets parents
 }
-    
+
 group structure {
-     advanced option structureExtractionStrategy: StructureExtractionStrategy {
+
+    advanced option structureExtractionStrategy: StructureExtractionStrategy {
         label "Structure Extraction Strategy"
-        description "This option defines what kind of triangulation or other partitioning of the plane 
+        description
+            "This option defines what kind of triangulation or other partitioning of the plane 
                     is applied to the vertices."
         targets parents
         default = StructureExtractionStrategy.DELAUNAY_TRIANGULATION
     }
+
 }
 
 group processingOrder {
+
     advanced option treeConstruction: TreeConstructionStrategy {
         label "Tree Construction Strategy"
-        description "Whether a minimum spanning tree or a maximum spanning tree should be constructed."
+        description
+            "Whether a minimum spanning tree or a maximum spanning tree should be constructed."
         targets parents
         default = TreeConstructionStrategy.MINIMUM_SPANNING_TREE
     }
-    
+
     option spanningTreeCostFunction: SpanningTreeCostFunction {
         label "Cost Function for Spanning Tree"
-        description "The cost function is used in the creation of the spanning tree."
+        description
+            "The cost function is used in the creation of the spanning tree."
         targets parents
         default = SpanningTreeCostFunction.CIRCLE_UNDERLAP
     }
+
     advanced option preferredRoot: String {
         label "Root node for spanning tree construction"
-        description "The identifier of the node that is preferred as the root of the spanning tree. 
+        description
+            "The identifier of the node that is preferred as the root of the spanning tree. 
                      If this is null, the first node is chosen."
         targets parents
         default = null
         requires rootSelection == RootSelection.FIXED
     }
+
     advanced option rootSelection: RootSelection {
         label "Root selection for spanning tree"
-        description "This sets the method used to select a root node for the construction of a spanning tree"
+        description
+            "This sets the method used to select a root node for the construction of a spanning tree"
         targets parents
         default = RootSelection.CENTER_NODE
     }
+
 }
 
 group compaction {
+
     advanced option compactionStrategy: CompactionStrategy {
         label "Compaction Strategy"
-        description "This option defines how the compaction is applied."
+        description
+            "This option defines how the compaction is applied."
         targets parents
         default = CompactionStrategy.DEPTH_FIRST
     }
+
     advanced option orthogonal: boolean {
         label "Orthogonal Compaction"
-        description "Restricts the translation of nodes to orthogonal directions in the compaction phase."
+        description
+            "Restricts the translation of nodes to orthogonal directions in the compaction phase."
         targets parents
         default = false
     }
+
 }
 
 group overlapRemoval {
+
     option maxIterations: int {
         label "Upper limit for iterations of overlap removal"
         targets parents
         default = 64
     }
+
     advanced option runScanline: boolean {
         label "Whether to run a supplementary scanline overlap check."
         targets parents
         default = true
     }
+
 }

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/layouter/Gmf.melk
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/layouter/Gmf.melk
@@ -9,28 +9,28 @@
  *******************************************************************************/
 package org.eclipse.elk.conn.gmf.layouter
 
-import org.eclipse.elk.core.options.Direction
 import org.eclipse.elk.core.math.ElkPadding
+import org.eclipse.elk.core.options.Direction
 
 /**
  * Layout algorithms contributed by GMF / GEF.
  */
 bundle {
-	label "GMF"
-	metadataClass GmfMetaDataProvider
+    label "GMF"
+    metadataClass GmfMetaDataProvider
 }
 
 algorithm Draw2D(Draw2DLayoutProvider) {
-	label "Draw2D Layout"
-	description
-		"'Directed Graph Layout' provided by the Draw2D framework. This is the same algorithm that
+    label "Draw2D Layout"
+    description
+        "'Directed Graph Layout' provided by the Draw2D framework. This is the same algorithm that
 		is used by the standard layout button of GMF diagrams."
     metadataClass Draw2DOptions
-	category org.eclipse.elk.layered
-	features multi_edges
-	preview images/draw2d.png
+    category org.eclipse.elk.layered
+    features multi_edges
+    preview images/draw2d.png
 	supports org.eclipse.elk.spacing.nodeNode = 16
-	supports org.eclipse.elk.padding = new ElkPadding(16)
-	supports org.eclipse.elk.direction = Direction.RIGHT
-	supports org.eclipse.elk.nodeSize.constraints
+    supports org.eclipse.elk.padding = new ElkPadding(16)
+    supports org.eclipse.elk.direction = Direction.RIGHT
+    supports org.eclipse.elk.nodeSize.constraints
 }

--- a/plugins/org.eclipse.elk.core.meta/src/org/eclipse/elk/core/meta/formatting2/MetaDataFormatter.xtend
+++ b/plugins/org.eclipse.elk.core.meta/src/org/eclipse/elk/core/meta/formatting2/MetaDataFormatter.xtend
@@ -27,9 +27,11 @@ import org.eclipse.elk.core.meta.metaData.MdGroupOrOption
 
 class MetaDataFormatter extends AbstractFormatter2 {
 
+    static val Procedure1<? super IHiddenRegionFormatter> no_space = [noSpace]
     static val Procedure1<? super IHiddenRegionFormatter> one_space = [oneSpace]
     static val Procedure1<? super IHiddenRegionFormatter> new_line = [newLine]
     static val Procedure1<? super IHiddenRegionFormatter> indention = [indent]
+    static val Procedure1<? super IHiddenRegionFormatter> new_line_twice = [setNewLines(2, 2, 2)]
 
     @Inject extension MetaDataGrammarAccess
 
@@ -54,7 +56,7 @@ class MetaDataFormatter extends AbstractFormatter2 {
     def dispatch void format(MdBundle bundle, extension IFormattableDocument document) {
         bundle.regionFor.keyword(mdBundleAccess.bundleKeyword_1_0).append(one_space)
         interior(
-            bundle.regionFor.keyword(mdBundleAccess.leftCurlyBracketKeyword_1_1).prepend(one_space).append(new_line),
+            bundle.regionFor.keyword(mdBundleAccess.leftCurlyBracketKeyword_1_1).prepend(one_space),
             bundle.regionFor.keyword(mdBundleAccess.rightCurlyBracketKeyword_1_3),
             indention
         )
@@ -65,22 +67,22 @@ class MetaDataFormatter extends AbstractFormatter2 {
         bundle.regionFor.keyword(mdBundleAccess.idPrefixKeyword_1_2_3_0).prepend(new_line).append(one_space)
 
         for (member : bundle.members) {
-            member.append(new_line).format
+            member.prepend(new_line_twice).format
         }
     }
 
     def dispatch void format(MdGroup group, extension IFormattableDocument document) {
         group.regionFor.keyword(mdGroupAccess.groupKeyword_0).append(one_space)
         interior(
-            group.regionFor.keyword(mdGroupAccess.leftCurlyBracketKeyword_2).prepend(one_space).append(new_line),
-            group.regionFor.keyword(mdGroupAccess.rightCurlyBracketKeyword_5),
+            group.regionFor.keyword(mdGroupAccess.leftCurlyBracketKeyword_2).prepend(one_space),
+            group.regionFor.keyword(mdGroupAccess.rightCurlyBracketKeyword_5).prepend(new_line_twice),
             indention
         )
 
         group.regionFor.keyword(mdGroupAccess.documentationKeyword_3_0).append(one_space)
 
         for (child : group.children) {
-            child.append(new_line).format
+            child.prepend(new_line_twice).format
         }
     }
 
@@ -96,10 +98,15 @@ class MetaDataFormatter extends AbstractFormatter2 {
             option.regionFor.keyword(mdOptionAccess.leftCurlyBracketKeyword_5).prepend(one_space).append(new_line),
             option.regionFor.keyword(mdOptionAccess.rightCurlyBracketKeyword_8),
             indention
-        )
+        ) 
 
         option.regionFor.keyword(mdOptionAccess.labelKeyword_6_0_0).prepend(new_line).append(one_space)
-        option.regionFor.keyword(mdOptionAccess.descriptionKeyword_6_1_0).prepend(new_line).append(one_space)
+        option.regionFor.keyword(mdOptionAccess.descriptionKeyword_6_1_0).prepend(new_line).append(new_line)
+        interior(
+            option.regionFor.keyword(mdOptionAccess.descriptionKeyword_6_1_0),
+            option.regionFor.assignment(mdOptionAccess.descriptionAssignment_6_1_1).nextSemanticRegion,
+            indention
+        )
         option.regionFor.keyword(mdOptionAccess.documentationKeyword_6_2_0).prepend(new_line).append(one_space)
         option.regionFor.keyword(mdOptionAccess.defaultKeyword_6_3_0).prepend(new_line).append(one_space)
         option.regionFor.keyword(mdOptionAccess.equalsSignKeyword_6_3_1).append(one_space)
@@ -108,9 +115,9 @@ class MetaDataFormatter extends AbstractFormatter2 {
         option.regionFor.keyword(mdOptionAccess.upperBoundKeyword_6_5_0).prepend(new_line).append(one_space)
         option.regionFor.keyword(mdOptionAccess.equalsSignKeyword_6_5_1).append(one_space)
         option.regionFor.keyword(mdOptionAccess.targetsKeyword_6_6_0).prepend(new_line).append(one_space)
-        option.regionFor.keyword(mdOptionAccess.commaKeyword_6_6_2_0).prepend(one_space).append(one_space)
+        option.regionFor.keyword(mdOptionAccess.commaKeyword_6_6_2_0).prepend(no_space).append(one_space)
         option.regionFor.keyword(mdOptionAccess.legacyIdsKeyword_6_7_0).prepend(new_line).append(one_space)
-        option.regionFor.keyword(mdOptionAccess.commaKeyword_6_7_2_0).prepend(one_space).append(one_space)
+        option.regionFor.keyword(mdOptionAccess.commaKeyword_6_7_2_0).prepend(no_space).append(one_space)
 
         for (dependencies : option.dependencies) {
             dependencies.append(new_line)
@@ -127,7 +134,7 @@ class MetaDataFormatter extends AbstractFormatter2 {
         algorithm.regionFor.keyword(mdAlgorithmAccess.deprecatedDeprecatedKeyword_0_0).append(one_space)
 
         algorithm.regionFor.keyword(mdAlgorithmAccess.algorithmKeyword_1).append(one_space)
-        algorithm.regionFor.keyword(mdAlgorithmAccess.leftParenthesisKeyword_3).prepend(one_space)
+        algorithm.regionFor.keyword(mdAlgorithmAccess.leftParenthesisKeyword_3).prepend(no_space)
         interior(
             algorithm.regionFor.keyword(mdAlgorithmAccess.leftCurlyBracketKeyword_7).prepend(one_space).append(
                 new_line),
@@ -137,7 +144,12 @@ class MetaDataFormatter extends AbstractFormatter2 {
 
         algorithm.regionFor.keyword(mdAlgorithmAccess.labelKeyword_8_0_0).prepend(new_line).append(one_space)
         algorithm.regionFor.keyword(mdAlgorithmAccess.metadataClassKeyword_8_1_0).prepend(new_line).append(one_space)
-        algorithm.regionFor.keyword(mdAlgorithmAccess.descriptionKeyword_8_2_0).prepend(new_line).append(one_space)
+        algorithm.regionFor.keyword(mdAlgorithmAccess.descriptionKeyword_8_2_0).prepend(new_line).append(new_line)
+        interior(
+            algorithm.regionFor.keyword(mdAlgorithmAccess.descriptionKeyword_8_2_0),
+            algorithm.regionFor.assignment(mdAlgorithmAccess.descriptionAssignment_8_2_1).nextSemanticRegion,
+            indention
+        )
         algorithm.regionFor.keyword(mdAlgorithmAccess.documentationKeyword_8_3_0).prepend(new_line).append(one_space)
         algorithm.regionFor.keyword(mdAlgorithmAccess.categoryKeyword_8_4_0).prepend(new_line).append(one_space)
         algorithm.regionFor.keyword(mdAlgorithmAccess.previewKeyword_8_5_0).prepend(new_line).append(one_space)
@@ -160,7 +172,12 @@ class MetaDataFormatter extends AbstractFormatter2 {
         )
 
         category.regionFor.keyword(mdCategoryAccess.labelKeyword_4_0_0).prepend(new_line).append(one_space)
-        category.regionFor.keyword(mdCategoryAccess.descriptionKeyword_4_1_0).prepend(new_line).append(one_space)
+        category.regionFor.keyword(mdCategoryAccess.descriptionKeyword_4_1_0).prepend(new_line).append(new_line)
+        interior(
+            category.regionFor.keyword(mdCategoryAccess.descriptionKeyword_4_1_0),
+            category.regionFor.assignment(mdCategoryAccess.descriptionAssignment_4_1_1).nextSemanticRegion,
+            indention
+        )
         category.regionFor.keyword(mdCategoryAccess.documentationKeyword_4_2_0).prepend(new_line).append(one_space)
     }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -37,15 +37,18 @@ bundle {
 
 category layered {
     label "Layered"
-    description "The layer-based method was introduced by Sugiyama, Tagawa and Toda in 1981. It emphasizes
+    description
+        "The layer-based method was introduced by Sugiyama, Tagawa and Toda in 1981. It emphasizes
         the direction of edges by pointing as many edges as possible into the same direction.
         The nodes are arranged in layers, which are sometimes called \"hierarchies\", and then
         reordered such that the number of edge crossings is minimized. Afterwards, concrete
         coordinates are computed for the nodes and edge bend points."
 }
+
 category orthogonal {
     label "Orthogonal"
-    description "Orthogonal methods that follow the \"topology-shape-metrics\" approach by Batini,
+    description
+        "Orthogonal methods that follow the \"topology-shape-metrics\" approach by Batini,
         Nardelli and Tamassia '86. The first phase determines the topology of the drawing by
         applying a planarization technique, which results in a planar representation of the graph.
         The orthogonal shape is computed in the second phase, which aims at minimizing the number
@@ -53,35 +56,47 @@ category orthogonal {
         coordinates for nodes and edge bend points by applying a compaction method, thus defining
         the metrics."
 }
+
 category force {
     label "Force"
-    description "Layout algorithms that follow physical analogies by simulating a system of attractive and
+    description
+        "Layout algorithms that follow physical analogies by simulating a system of attractive and
         repulsive forces. The first successful method of this kind was proposed by Eades in 1984."
 }
+
 category circle {
     label "Circle"
-    description "Circular layout algorithms emphasize cycles or biconnected components of a graph by
+    description
+        "Circular layout algorithms emphasize cycles or biconnected components of a graph by
         arranging them in circles. This is useful if a drawing is desired where such components
         are clearly grouped, or where cycles are shown as prominent OPTIONS of the graph."
 }
+
 category tree {
     label "Tree"
-    description "Specialized layout methods for trees, i.e. acyclic graphs. The regular structure of graphs
+    description
+        "Specialized layout methods for trees, i.e. acyclic graphs. The regular structure of graphs
         that have no undirected cycles can be emphasized using an algorithm of this type."
 }
+
 category planar {
     label "Planar"
-    description "Algorithms that require a planar or upward planar graph. Most of these algorithms are 
+    description
+        "Algorithms that require a planar or upward planar graph. Most of these algorithms are 
         theoretically interesting, but not practically usable."
 }
+
 category radial {
     label "Radial"
-    description "Radial layout algorithms usually position the nodes of the graph on concentric circles."
+    description
+        "Radial layout algorithms usually position the nodes of the graph on concentric circles."
 }
+
 //------- UTILITY ALGORITHMS
-algorithm fixed (FixedLayoutProvider) {
+algorithm fixed(FixedLayoutProvider) {
     label "Fixed Layout"
-    description "Keeps the current layout as it is, without any automatic modification. Optional coordinates
+    description
+        "Keeps the current layout as it is, without any automatic modification. Optional coordinates
         can be given for nodes and edge bend points."
     metadataClass core.options.FixedLayouterOptions 
     supports padding = new ElkPadding(15)
@@ -91,9 +106,11 @@ algorithm fixed (FixedLayoutProvider) {
     supports nodeSize.minimum
     supports nodeSize.fixedGraphSize
 }
-algorithm box (BoxLayoutProvider) {
+
+algorithm box(BoxLayoutProvider) {
     label "Box Layout"
-    description "Algorithm for packing of unconnected boxes, i.e. graphs without edges."
+    description
+        "Algorithm for packing of unconnected boxes, i.e. graphs without edges."
     metadataClass core.options.BoxLayouterOptions
     preview images/box_layout.png
     supports padding = new ElkPadding(15)
@@ -112,20 +129,26 @@ algorithm box (BoxLayoutProvider) {
     supports box.packingMode
     supports contentAlignment = ContentAlignment.topCenter()
 }
+
 group box {
+
     option packingMode: PackingMode {
         label "Box Layout Mode"
-        description "Configures the packing mode used by the {@link BoxLayoutProvider}.
+        description
+            "Configures the packing mode used by the {@link BoxLayoutProvider}.
              If SIMPLE is not required (neither priorities are used nor the interactive mode),
              GROUP_DEC can improve the packing and decrease the area. 
              GROUP_MIXED and GROUP_INC may, in very specific scenarios, work better."
         default = BoxLayoutProvider.PackingMode.SIMPLE
         targets parents
     }
+
 }
-algorithm random (RandomLayoutProvider) {
+
+algorithm random(RandomLayoutProvider) {
     label "Randomizer"
-    description "Distributes the nodes randomly on the plane, leading to very obfuscating layouts. Can be
+    description
+        "Distributes the nodes randomly on the plane, leading to very obfuscating layouts. Can be
         useful to demonstrate the power of \"real\" layout algorithms."
     metadataClass core.options.RandomLayouterOptions
     preview images/random_layout.png
@@ -134,327 +157,427 @@ algorithm random (RandomLayoutProvider) {
     supports randomSeed = 0
     supports aspectRatio = 1.6f
 }
+
 //------- UI OPTIONS 
 option ^algorithm: String {
     label "Layout Algorithm"
-    description "Select a specific layout algorithm."
+    description
+        "Select a specific layout algorithm."
     targets parents
 }
+
 programmatic option resolvedAlgorithm: LayoutAlgorithmData {
     label "Resolved Layout Algorithm"
-    description "Meta data associated with the selected algorithm."
+    description
+        "Meta data associated with the selected algorithm."
     targets parents
 }
+
 advanced option alignment: Alignment {
     label "Alignment"
-    description "Alignment of the selected node relative to other nodes;
+    description
+        "Alignment of the selected node relative to other nodes;
         the exact meaning depends on the used algorithm."
     default = Alignment.AUTOMATIC
     targets nodes
 }
+
 advanced option aspectRatio: double {
     label "Aspect Ratio"
-    description "The desired aspect ratio of the drawing, that is the quotient of width by height."
+    description
+        "The desired aspect ratio of the drawing, that is the quotient of width by height."
     lowerBound = ExclusiveBounds.greaterThan(0)
     targets parents
 }
+
 programmatic option bendPoints: KVectorChain {
     label "Bend Points"
-    description "A fixed list of bend points for the edge. This is used by the 'Fixed Layout' algorithm to
+    description
+        "A fixed list of bend points for the edge. This is used by the 'Fixed Layout' algorithm to
         specify a pre-defined routing for an edge. The vector chain must include the source point,
         any bend points, and the target point, so it must have at least two points."
     targets edges
 }
+
 advanced option contentAlignment: EnumSet<ContentAlignment> {
     label "Content Alignment"
-    description "Specifies how the content of compound nodes is to be aligned, e.g. top-left."
+    description
+        "Specifies how the content of compound nodes is to be aligned, e.g. top-left."
     default = ContentAlignment.topLeft()
     targets parents
 }
+
 advanced option debugMode: boolean {
     label "Debug Mode"
-    description "Whether additional debug information shall be generated."
+    description
+        "Whether additional debug information shall be generated."
     default = false
     targets parents
 }
+
 option direction: Direction {
     label "Direction"
-    description "Overall direction of edges: horizontal (right / left) or
+    description
+        "Overall direction of edges: horizontal (right / left) or
         vertical (down / up)."
     default = Direction.UNDEFINED
     targets parents
 }
+
 option edgeRouting: EdgeRouting {
     label "Edge Routing"
-    description "What kind of edge routing style should be applied for the content of a parent node.
+    description
+        "What kind of edge routing style should be applied for the content of a parent node.
         Algorithms may also set this option to single edges in order to mark them as splines.
         The bend point list of edges with this option set to SPLINES must be interpreted as control
         points for a piecewise cubic spline."
     default = EdgeRouting.UNDEFINED
     targets parents
 }
+
 advanced option expandNodes: boolean {
     label "Expand Nodes"
     // TODO improve description, e.g. what is 'expand'
-    description "If active, nodes are expanded to fill the area of their parent."
+    description
+        "If active, nodes are expanded to fill the area of their parent."
     default = false
     targets parents
 }
+
 advanced option hierarchyHandling: HierarchyHandling {
     label "Hierarchy Handling"
-    description "If this option is set to SEPARATE_CHILDREN, each hierarchy level of the graph is processed independently, 
+    description
+        "If this option is set to SEPARATE_CHILDREN, each hierarchy level of the graph is processed independently, 
         possibly by different layout algorithms, beginning with the lowest level. 
         If it is set to INCLUDE_CHILDREN, the algorithm is responsible to process
         all hierarchy levels that are contained in the associated parent node.
         If the root node is set to inherit (or not set at all), the default behavior is SEPARATE_CHILDREN."
     default = HierarchyHandling.INHERIT
-    targets parents , nodes
+    targets parents, nodes
 }
+
 advanced option padding: ElkPadding {
     label "Padding"
-    description "The padding to be left to a parent element's border when placing child elements. This can
+    description
+        "The padding to be left to a parent element's border when placing child elements. This can
         also serve as an output option of a layout algorithm if node size calculation is setup
         appropriately."
     default = new ElkPadding(12)
-    targets parents , nodes
+    targets parents, nodes
 }
+
 advanced option interactive: boolean {
     label "Interactive"
-    description "Whether the algorithm should be run in interactive mode for the content of a parent node.
+    description
+        "Whether the algorithm should be run in interactive mode for the content of a parent node.
         What this means exactly depends on how the specific algorithm interprets this option.
         Usually in the interactive mode algorithms try to modify the current layout as little as
         possible."
     default = false
     targets parents
 }
+
 advanced option interactiveLayout: boolean {
     label "interactive Layout"
-    description "Whether the graph should be changeable interactively and by setting constraints"
+    description
+        "Whether the graph should be changeable interactively and by setting constraints"
     default = false
     targets parents
 }
+
 // --- SPACING
 group spacing {
+
     option componentComponent: double {
         label "Components Spacing"
-        description "Spacing to be preserved between pairs of connected components. 
+        description
+            "Spacing to be preserved between pairs of connected components. 
             This option is only relevant if 'separateConnectedComponents' is activated."
         default = 20f
         lowerBound = 0.0
         targets parents
     }
+
     option edgeEdge: double {
         label "Edge Spacing"
-        description "Spacing to be preserved between any two edges. Note that while this can somewhat easily be satisfied 
+        description
+            "Spacing to be preserved between any two edges. Note that while this can somewhat easily be satisfied 
             for the segments of orthogonally drawn edges, it is harder for general polylines or splines."
         default = 10
         lowerBound = 0.0
         targets parents
     }
+
     option edgeLabel: double {
         label "Edge Label Spacing"
-        description "The minimal distance to be preserved between a label and the edge it is associated with.
+        description
+            "The minimal distance to be preserved between a label and the edge it is associated with.
             Note that the placement of a label is influenced by the 'edgelabels.placement' option."
         default = 2
         lowerBound = 0.0
         targets parents
     }
+
     option edgeNode: double {
         label "Edge Node Spacing"
-        description "Spacing to be preserved between nodes and edges."
+        description
+            "Spacing to be preserved between nodes and edges."
         default = 10
         lowerBound = 0.0
         targets parents   
     }
+
     option labelLabel: double {
         label "Label Spacing"
-        description "Determines the amount of space to be left between two labels 
+        description
+            "Determines the amount of space to be left between two labels 
              of the same graph element."
         default = 0
         lowerBound = 0.0
         targets parents
     }
+
     option labelNode: double {
         label "Label Node Spacing"
-        description "Spacing to be preserved between labels and the border of node they are associated with. 
+        description
+            "Spacing to be preserved between labels and the border of node they are associated with. 
             Note that the placement of a label is influenced by the 'nodelabels.placement' option."
         default = 5
         lowerBound = 0.0
         targets parents
     }
+
     option labelPort: double {
         label "Label Port Spacing"
-        description "Spacing to be preserved between labels and the ports they are associated with. 
+        description
+            "Spacing to be preserved between labels and the ports they are associated with. 
             Note that the placement of a label is influenced by the 'portlabels.placement' option."
         default = 1
         lowerBound = 0.0
         targets parents
     }
+
     option nodeNode: double {
         label "Node Spacing"
-        description "The minimal distance to be preserved between each two nodes."
+        description
+            "The minimal distance to be preserved between each two nodes."
         default = 20
         lowerBound = 0.0
         targets parents
     }
+
     option nodeSelfLoop: double {
         label "Node Self Loop Spacing"
-        description "Spacing to be preserved between a node and its self loops."
+        description
+            "Spacing to be preserved between a node and its self loops."
         default = 10
         lowerBound = 0.0
         targets parents
     }
+
     option portPort: double {
         label "Port Spacing"
-        description "Spacing between pairs of ports of the same node."
+        description
+            "Spacing between pairs of ports of the same node."
         default = 10
         lowerBound = 0.0
-        targets parents , nodes
+        targets parents, nodes
     }
+
     advanced option individualOverride: IndividualSpacings {
         label "Individual Spacing Override"
-        description "In general spacing values apply to the children of the hierarchical node 
+        description
+            "In general spacing values apply to the children of the hierarchical node 
             (possibly the root node) for which the values are actually specified. Hereby,
             the children include ports, edges, and labels. "
-        targets nodes , edges, ports, labels
+        targets nodes, edges, ports, labels
     }
+
     advanced option portsSurrounding: ElkMargin {
         label "Additional Port Space"
-        description "Additional space around the sets of ports on each node side. For each side of a node,
+        description
+            "Additional space around the sets of ports on each node side. For each side of a node,
             this option can reserve additional space before and after the ports on each side. For
             example, a top spacing of 20 makes sure that the first port on the western and eastern
             side is 20 units away from the northern border."
         default = new ElkMargin(0)
         targets parents
     }
+
 }
+
 // --- PARTITIONING 
 group partitioning {
+
     advanced option partition: Integer {
         label "Layout Partition"
-        description "Partition to which the node belongs to. If 'layoutPartitions' is true,
+        description
+            "Partition to which the node belongs to. If 'layoutPartitions' is true,
              a pair of nodes with different partition indices is placed such that 
              the node with lower index is placed to the left of the other node (with left-to-right layout direction)."
-        targets parents , nodes
+        targets parents, nodes
     }
+
     advanced option activate: Boolean {
         label "Layout Partitioning"
-        description "Whether to activate partitioned layout."
+        description
+            "Whether to activate partitioned layout."
         default = false
         targets parents
     }
+
 }
+
 // --- NODE LABELS
 group nodeLabels {
+
     advanced option padding: ElkPadding {
         label "Node Label Padding"
-        description "Define padding for node labels that are placed inside of a node."
+        description
+            "Define padding for node labels that are placed inside of a node."
         default = new ElkPadding(5)
         targets nodes
     }
+
     option placement: EnumSet<NodeLabelPlacement> {
         label "Node Label Placement"
-        description "Hints for where node labels are to be placed; if empty, the node label's position is not
+        description
+            "Hints for where node labels are to be placed; if empty, the node label's position is not
             modified."
         default = NodeLabelPlacement.fixed
-        targets nodes , labels
+        targets nodes, labels
     }
+
 }
+
 // --- PORT ALIGNMENT
 group portAlignment {
+
     option ^default: PortAlignment {
         label "Port Alignment"
-        description "Defines the default port distribution for a node. May be overridden for each side individually."
+        description
+            "Defines the default port distribution for a node. May be overridden for each side individually."
         default = PortAlignment.DISTRIBUTED
         targets nodes
     }
+
     advanced option north: PortAlignment {
         label "Port Alignment (North)"
-        description "Defines how ports on the northern side are placed, overriding the node's general port alignment."
+        description
+            "Defines how ports on the northern side are placed, overriding the node's general port alignment."
         targets nodes
     }
+
     advanced option south: PortAlignment {
         label "Port Alignment (South)"
-        description "Defines how ports on the southern side are placed, overriding the node's general port alignment."
+        description
+            "Defines how ports on the southern side are placed, overriding the node's general port alignment."
         targets nodes
     }
+
     advanced option west: PortAlignment {
         label "Port Alignment (West)"
-        description "Defines how ports on the western side are placed, overriding the node's general port alignment."
+        description
+            "Defines how ports on the western side are placed, overriding the node's general port alignment."
         targets nodes
     }
+
     advanced option east: PortAlignment {
         label "Port Alignment (East)"
-        description "Defines how ports on the eastern side are placed, overriding the node's general port alignment."
+        description
+            "Defines how ports on the eastern side are placed, overriding the node's general port alignment."
         targets nodes
     }
+
 }
+
 option portConstraints: PortConstraints {
     label "Port Constraints"
-    description "Defines constraints of the position of the ports of a node."
+    description
+        "Defines constraints of the position of the ports of a node."
     default = PortConstraints.UNDEFINED
     targets nodes
 }
+
 advanced option position: KVector {
     label "Position"
-    description "The position of a node, port, or label. This is used by the 'Fixed Layout' algorithm to
+    description
+        "The position of a node, port, or label. This is used by the 'Fixed Layout' algorithm to
         specify a pre-defined position."
-    targets nodes , ports, labels
+    targets nodes, ports, labels
 }
+
 advanced option priority: int {
     label "Priority"
-    description "Defines the priority of an object; its meaning depends on the specific layout algorithm
+    description
+        "Defines the priority of an object; its meaning depends on the specific layout algorithm
         and the context where it is used."
-    targets nodes , edges
+    targets nodes, edges
 }
+
 advanced option randomSeed: int {
     label "Randomization Seed"
-    description "Seed used for pseudo-random number generators to control the layout algorithm. If the
+    description
+        "Seed used for pseudo-random number generators to control the layout algorithm. If the
         value is 0, the seed shall be determined pseudo-randomly (e.g. from the system time)."
     targets parents
 }
+
 option separateConnectedComponents: boolean {
     label "Separate Connected Components"
-    description "Whether each connected component should be processed separately."
+    description
+        "Whether each connected component should be processed separately."
     targets parents
 }
+
 // --- NODE SIZE
 group nodeSize {
+
     option constraints: EnumSet<SizeConstraint> {
         label "Node Size Constraints"
-        description "What should be taken into account when calculating a node's size. Empty size constraints
+        description
+            "What should be taken into account when calculating a node's size. Empty size constraints
             specify that a node's size is already fixed and should not be changed."
         documentation "@sizeconstraints.md"
         default = EnumSet.noneOf(SizeConstraint)
         targets nodes
     }
+
     option options: EnumSet<SizeOptions> {
         label "Node Size Options"
-        description "Options modifying the behavior of the size constraints set on a node. Each member of the
+        description
+            "Options modifying the behavior of the size constraints set on a node. Each member of the
             set specifies something that should be taken into account when calculating node sizes.
             The empty set corresponds to no further modifications."
         documentation "@sizeoptions.md"
         default = EnumSet.of(SizeOptions.DEFAULT_MINIMUM_SIZE)
         targets nodes
     }
+
     advanced option minimum: KVector {
         label "Node Size Minimum"
-        description "The minimal size to which a node can be reduced."
+        description
+            "The minimal size to which a node can be reduced."
         default = new KVector(0, 0)
         targets nodes
     }
+
     option fixedGraphSize: boolean {
         label "Fixed Graph Size"
-        description "By default, the fixed layout provider will enlarge a graph until it is large enough to contain
+        description
+            "By default, the fixed layout provider will enlarge a graph until it is large enough to contain
             its children. If this option is set, it won't do so."
         default = false
         targets parents
     }
+
 }
+
 //------- PROGRAMMATIC OPTIONS
 output option junctionPoints: KVectorChain {
     label "Junction Points"
-    description "This option is not used as option, but as output of the layout algorithms. It is
+    description
+        "This option is not used as option, but as output of the layout algorithms. It is
         attached to edges and determines the points where junction symbols should be drawn in
         order to represent hyperedges with orthogonal routing. Whether such points are computed
         depends on the chosen layout algorithm and edge routing style. The points are put into
@@ -462,101 +585,132 @@ output option junctionPoints: KVectorChain {
     targets edges
     default = new KVectorChain()
 }
+
 option commentBox: boolean {
     label "Comment Box"
-    description "Whether the node should be regarded as a comment box instead of a regular node. In that
+    description
+        "Whether the node should be regarded as a comment box instead of a regular node. In that
         case its placement should be similar to how labels are handled. Any edges incident to a
         comment box specify to which graph elements the comment is related."
     default = false
     targets nodes
 }
+
 // --- EDGE LABELS
 group edgeLabels {
+
     option placement: EdgeLabelPlacement {
         label "Edge Label Placement"
-        description "Gives a hint on where to put edge labels."
+        description
+            "Gives a hint on where to put edge labels."
         default = EdgeLabelPlacement.UNDEFINED
         targets labels
     }
+
     option inline: boolean {
         label "Inline Edge Labels"
-        description "If true, an edge label is placed directly on its edge. May only apply to center edge labels.
+        description
+            "If true, an edge label is placed directly on its edge. May only apply to center edge labels.
             This kind of label placement is only advisable if the label's rendering is such that it is not
             crossed by its edge and thus stays legible."
         default = false
         targets labels
     }
+
 }
+
 // --- FONT
 group font {
+
     programmatic option name: String {
         label "Font Name"
-        description "Font name used for a label."
+        description
+            "Font name used for a label."
         targets labels
     }
+
     programmatic option size: int {
         label "Font Size"
-        description "Font size used for a label."
+        description
+            "Font size used for a label."
         lowerBound = 1
         targets labels
     }
+
 }
+
 programmatic option hypernode: boolean {
     label "Hypernode"
-    description "Whether the node should be handled as a hypernode."
+    description
+        "Whether the node should be handled as a hypernode."
     default = false
     targets nodes
 }
+
 programmatic option labelManager: ILabelManager {
     label "Label Manager"
-    description "Label managers can shorten labels upon a layout algorithm's request."
-    targets parents , labels
+    description
+        "Label managers can shorten labels upon a layout algorithm's request."
+    targets parents, labels
 }
+
 option margins: ElkMargin {
     label "Margins"
-    description "Margins define additional space around the actual bounds of a graph element. For instance,
+    description
+        "Margins define additional space around the actual bounds of a graph element. For instance,
         ports or labels being placed on the outside of a node's border might introduce such a
         margin. The margin is used to guarantee non-overlap of other graph elements with those
         ports or labels."
     default = new ElkMargin()
     targets nodes
 }
+
 option noLayout: boolean {
     label "No Layout"
-    description "No layout is done for the associated element. This is used to mark parts of a diagram to
+    description
+        "No layout is done for the associated element. This is used to mark parts of a diagram to
         avoid their inclusion in the layout graph, or to mark parts of the layout graph to
         prevent layout engines from processing them. If you wish to exclude the contents of a
         compound node from automatic layout, while the node itself is still considered on its own
         layer, use the 'Fixed Layout' algorithm for that node."
     default = false
-    targets nodes , edges, ports, labels
+    targets nodes, edges, ports, labels
 }
+
 // --- PORT
 group port {
+
     option anchor: KVector {
         label "Port Anchor Offset"
-        description "The offset to the port position where connections shall be attached."
+        description
+            "The offset to the port position where connections shall be attached."
         targets ports
     }
+
     programmatic option index: int {
         label "Port Index"
-        description "The index of a port in the fixed order around a node. The order is assumed as clockwise,
+        description
+            "The index of a port in the fixed order around a node. The order is assumed as clockwise,
             starting with the leftmost port on the top side. This option must be set if 'Port
             Constraints' is set to FIXED_ORDER and no specific positions are given for the ports.
             Additionally, the option 'Port Side' must be defined in this case."
         targets ports
     }
+
     option side: PortSide {
         label "Port Side"
-        description "The side of a node on which a port is situated. This option must be set if 'Port
+        description
+            "The side of a node on which a port is situated. This option must be set if 'Port
             Constraints' is set to FIXED_SIDE or FIXED_ORDER and no specific positions are given
             for the ports."
         default = PortSide.UNDEFINED
         targets ports
     }
+
     option borderOffset: double {
         label "Port Border Offset"
-        description "The offset of ports on the node border. With a positive offset the port is moved outside
+        description
+            "The offset of ports on the node border. With a positive offset the port is moved outside
             of the node, while with a negative offset the port is moved towards the inside. An offset
             of 0 means that the port is placed directly on the node border, i.e.
             if the port side is north, the port's south border touches the nodes's north border;
@@ -565,18 +719,24 @@ group port {
             if the port side is west, the port's east border touches the node's west border."
         targets ports
     }
+
 }
+
 // --- PORT LABELS
 group portLabels {
+
     option placement: PortLabelPlacement {
         label "Port Label Placement"
-        description "Decides on a placement method for port labels."
+        description
+            "Decides on a placement method for port labels."
         default = PortLabelPlacement.OUTSIDE
         targets nodes
     }
+
     option nextToPortIfPossible: boolean {
         label "Port Labels Next to Port"
-        description "Usually, inside port labels of hierarchical nodes are placed not next to their port,
+        description
+            "Usually, inside port labels of hierarchical nodes are placed not next to their port,
            but with an offset to avoid edge-label crossings. The offset is not necessary if the
            port has no connections that would cross the label, but is usually applied anyway to
            keep things uniform. Setting this option to true places labels next to their ports if
@@ -584,19 +744,24 @@ group portLabels {
         default = false
         targets nodes
     }
+
     option treatAsGroup: boolean {
         label "Treat Port Labels as Group"
-        description "If this option is true (default), the labels of a port will be treated as a group when
+        description
+            "If this option is true (default), the labels of a port will be treated as a group when
            it comes to centering them next to their port. If this option is false, only the first label will
            be centered next to the port, with the others being placed below. This only applies to labels of
            eastern and western ports and will have no effect if labels are not placed next to their port."
         default = true
         targets nodes
     }
+
 }
+
 programmatic option scaleFactor: double {
     label "Scale Factor"
-    description "The scaling factor to be applied to the corresponding node in recursive layout. It causes
+    description
+        "The scaling factor to be applied to the corresponding node in recursive layout. It causes
         the corresponding node's size to be adjusted, and its ports and labels to be sized and
         placed accordingly after the layout of that node has been determined (and before the node
         itself and its siblings are arranged). The scaling is not reverted afterwards, so the
@@ -608,103 +773,134 @@ programmatic option scaleFactor: double {
     // TODO
 // requires hierarchyHandling != HierarchyHandling.INCLUDE_CHILDREN 
 }
+
 // --- INSIDE SELF LOOPS
 group insideSelfLoops {
+
     advanced option activate: boolean {
         label "Activate Inside Self Loops"
-        description "Whether this node allows to route self loops inside of it instead of around it. If set to true,
+        description
+            "Whether this node allows to route self loops inside of it instead of around it. If set to true,
             this will make the node a compound node if it isn't already, and will require the layout algorithm
             to support compound nodes with hierarchical ports."
         default = false
         targets nodes
     }
+
     advanced option yo: boolean {
         label "Inside Self Loop"
-        description "Whether a self loop should be routed inside a node instead of around that node."
+        description
+            "Whether a self loop should be routed inside a node instead of around that node."
         default = false
         targets edges
     }
+
 }
+
 // --- EDGE
 group edge {
+
     programmatic option thickness: double {
         label "Edge Thickness"
-        description "The thickness of an edge. This is a hint on the line width used to draw an edge, possibly
+        description
+            "The thickness of an edge. This is a hint on the line width used to draw an edge, possibly
             requiring more space to be reserved for it."
         default = 1
         targets edges
     }
+
     // TODO should this be moved to specific options of a layouter that actually supports different edge types?
     programmatic option type: EdgeType {
         label "Edge Type"
-        description "The type of an edge. This is usually used for UML class diagrams, where associations must
+        description
+            "The type of an edge. This is usually used for UML class diagrams, where associations must
             be handled differently from generalizations."
         default = EdgeType.NONE
         targets edges
     }
+
 }
+
 //------- GLOBAL OPTIONS
 global option animate: boolean {
     label "Animate"
-    description "Whether the shift from the old layout to the new computed layout shall be animated."
+    description
+        "Whether the shift from the old layout to the new computed layout shall be animated."
     default = true
     targets parents
 }
+
 global option animTimeFactor: int {
     label "Animation Time Factor"
-    description "Factor for computation of animation time. The higher the value, the longer the animation
+    description
+        "Factor for computation of animation time. The higher the value, the longer the animation
         time. If the value is 0, the resulting time is always equal to the minimum defined by
         'Minimal Animation Time'."
     default = 100
     lowerBound = 0
     targets parents
 }
+
 global option layoutAncestors: boolean {
     label "Layout Ancestors"
-    description "Whether the hierarchy levels on the path from the selected element to the root of the
+    description
+        "Whether the hierarchy levels on the path from the selected element to the root of the
         diagram shall be included in the layout process."
     default = false
     targets parents
 }
+
 global option maxAnimTime: int {
     label "Maximal Animation Time"
-    description "The maximal time for animations, in milliseconds."
+    description
+        "The maximal time for animations, in milliseconds."
     default = 4000
     lowerBound = 0
     targets parents
 }
+
 global option minAnimTime: int {
     label "Minimal Animation Time"
-    description "The minimal time for animations, in milliseconds."
+    description
+        "The minimal time for animations, in milliseconds."
     default = 400
     lowerBound = 0
     targets parents
 }
+
 global option progressBar: boolean {
     label "Progress Bar"
-    description "Whether a progress bar shall be displayed during layout computations."
+    description
+        "Whether a progress bar shall be displayed during layout computations."
     default = false
     targets parents
 }
+
 global option validateGraph: boolean {
     label "Validate Graph"
-    description "Whether the graph shall be validated before any layout algorithm is applied. If this
+    description
+        "Whether the graph shall be validated before any layout algorithm is applied. If this
         option is enabled and at least one error is found, the layout process is aborted and a message
         is shown to the user."
     default = false
     targets parents
 }
+
 global option validateOptions: boolean {
     label "Validate Options"
-    description "Whether layout options shall be validated before any layout algorithm is applied. If this
+    description
+        "Whether layout options shall be validated before any layout algorithm is applied. If this
         option is enabled and at least one error is found, the layout process is aborted and a message
         is shown to the user."
     default = true
     targets parents
 }
+
 global option zoomToFit: boolean {
     label "Zoom to Fit"
-    description "Whether the zoom level shall be set to view the whole diagram after layout."
+    description
+        "Whether the zoom level shall be set to view the whole diagram after layout."
     default = false
     targets parents
 }
+

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/labels/Labels.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/labels/Labels.melk
@@ -13,9 +13,9 @@ package org.eclipse.elk.core.^labels
  * Label management definitions of the Eclipse Layout Kernel.
  */
 bundle {
-	label "ELK Label Management"
-	metadataClass LabelManagementOptions
-	idPrefix org.eclipse.elk.^labels
+    label "ELK Label Management"
+    metadataClass LabelManagementOptions
+    idPrefix org.eclipse.elk.^labels
 }
 
 programmatic option labelManager: ILabelManager {


### PR DESCRIPTION
I slightly altered the formatter (without changing the out-of-conventions coding style of the class):
  - no space between layout algorithm id and its implementing class
  - two newlines between groups, options, etc.
  - indent text to 'description' of categories, options, and algorithms
  - no space before commas

Afterwards I reformatted all of the `*.melk` files. One major change is that tabs are replaced by spaces (although that's an editor configuration). 

Anything that feels awkward?

Note that the changes of the formatter are not available within the main eclipse until a new version has been deployed and installed. 