### PR TITLE
layered: removed superfluous default on spacing.nodeNode

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -48,7 +48,7 @@ algorithm layered(LayeredLayoutProvider) {
 	supports org.eclipse.elk.spacing.labelLabel
 	supports org.eclipse.elk.spacing.labelPort
 	supports org.eclipse.elk.spacing.labelNode
-	supports org.eclipse.elk.spacing.nodeNode = 20
+	supports org.eclipse.elk.spacing.nodeNode
 	supports org.eclipse.elk.spacing.nodeSelfLoop
 	supports org.eclipse.elk.spacing.portPort
 	supports org.eclipse.elk.spacing.individualOverride


### PR DESCRIPTION
The default value in `Core.melk` is already `20`. And since we're not explicitly setting default values for the other inherited spacing options, I suggest to be consistent and remove it for `nodeNode`.