### PR TITLE
[PR] Convenient spacing configuration

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -54,6 +54,7 @@ algorithm layered(LayeredLayoutProvider) {
     supports org.eclipse.elk.spacing.individualOverride
     documentation "Most parts of the algorithm do not support this yet."
     // layer-based spacings
+    supports org.eclipse.elk.alg.layered.spacing.baseValue
     supports org.eclipse.elk.alg.layered.spacing.edgeEdgeBetweenLayers
     supports org.eclipse.elk.alg.layered.spacing.edgeNodeBetweenLayers
     supports org.eclipse.elk.alg.layered.spacing.nodeNodeBetweenLayers
@@ -552,6 +553,17 @@ group edgeRouting {
  *    spacing
  * ------------------------*/
 group spacing {
+
+    option baseValue: double {
+        label "Spacing Base Value"
+        description
+            "An optional base value for all other layout options of the 'spacing' group. It can be used to conveniently 
+             alter the overall 'spaciousness' of the drawing. Whenever an explicit value is set for the other layout 
+             options, this base value will have no effect. The base value is not inherited, i.e. it must be set for 
+             each hierarchical node."
+        targets parents
+        lowerBound = 0.0
+    }
 
     option edgeNodeBetweenLayers: double {
         label "Edge Node Between Layers Spacing"

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeredSpacings.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeredSpacings.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0  
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.options;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import org.eclipse.elk.alg.layered.graph.LEdge;
+import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LLabel;
+import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.graph.LPort;
+import org.eclipse.elk.core.LayoutConfigurator;
+import org.eclipse.elk.core.data.LayoutMetaDataService;
+import org.eclipse.elk.core.data.LayoutOptionData;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.util.ElkSpacings.AbstractSpacingsBuilder;
+import org.eclipse.elk.core.util.ElkSpacings.ElkCoreSpacingsBuilder;
+import org.eclipse.elk.graph.properties.IProperty;
+import org.eclipse.elk.graph.properties.IPropertyHolder;
+
+import com.google.common.collect.Lists;
+import com.google.common.math.DoubleMath;
+
+/**
+ * Utility class to conveniently configure core spacing values ({@link LayeredOptions#SPACING_*}) for a graph element or
+ * a whole graph.
+ */
+public final class LayeredSpacings {
+    
+    private LayeredSpacings() { }
+
+    /**
+     * Start constructing a new spacing configurator with the passed {@code baseSpacing} as base value for all other
+     * spacing options. By default the values for other spacing options {@code o} will be determined based on the ratio
+     * between {@link ElkCoreSpacingsBuilder#BASE_SPACING_OPTION}'s default value and {@code o}'s default value.
+     */
+    public static LayeredSpacingsBuilder withBaseValue(final double baseSpacing) {
+        return new LayeredSpacingsBuilder(baseSpacing);
+    }
+
+    /**
+     * Spacing configuration builder implementation for spacing options defined in {@link LayeredOptions}.
+     */
+    public static final class LayeredSpacingsBuilder extends AbstractSpacingsBuilder<LayeredSpacingsBuilder> {
+
+        /** See {@link AbstractSpacingsBuilder#baseSpacing} for details. */
+        public static final IProperty<Double> BASE_SPACING_OPTION = LayeredOptions.SPACING_NODE_NODE;
+        
+        // @formatter:off
+        private static final List<IProperty<Double>> DEPENDENT_SPACING_OPTIONS = Lists.newArrayList(
+            // Sorted alphabetically
+            // First the ones inherited from CoreOptions (with possibly overridden default value)
+            LayeredOptions.SPACING_COMPONENT_COMPONENT,
+            LayeredOptions.SPACING_EDGE_EDGE,
+            LayeredOptions.SPACING_EDGE_LABEL,
+            LayeredOptions.SPACING_EDGE_NODE,
+            LayeredOptions.SPACING_LABEL_LABEL,
+            LayeredOptions.SPACING_LABEL_NODE,
+            LayeredOptions.SPACING_LABEL_PORT,
+            LayeredOptions.SPACING_NODE_SELF_LOOP,
+            LayeredOptions.SPACING_PORT_PORT,
+            // Introduced by LayeredOptions 
+            LayeredOptions.SPACING_EDGE_EDGE_BETWEEN_LAYERS,
+            LayeredOptions.SPACING_EDGE_NODE_BETWEEN_LAYERS,
+            LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS
+        );
+        // @formatter:on
+
+        static {
+            assert BASE_SPACING_OPTION.getDefault() != null : "Base spacing default value must be non-null.";
+            // Avoid division by zero.
+            assert !DoubleMath.fuzzyEquals(0.0d, BASE_SPACING_OPTION.getDefault(),
+                    DOUBLE_EQ_EPSILON) : "Base spacing default value must be different from 0.0d.";
+        }
+        
+        private LayeredSpacingsBuilder(final double d) {
+            super(d);
+        }
+        
+        @Override
+        public LayeredSpacingsBuilder thisT() {
+            return this;
+        }
+
+        @Override
+        protected IProperty<Double> getBaseSpacingOption() {
+            return BASE_SPACING_OPTION;
+        }
+        
+        /**
+         * Note that the super implementation is not simply amended here but completely replaced to properly use the
+         * default values from {@link LayeredOptions} for layout options inherited from {@link CoreOptions}.
+         * 
+         * {@inheritDoc}
+         */
+        @Override
+        protected List<IProperty<Double>> getDependendSpacingOptions() {
+            return DEPENDENT_SPACING_OPTIONS;
+        }
+    }
+    
+    /**
+     * Mimics the behavior of {@link LayoutConfigurator#OPTION_TARGET_FILTER}, just for the {@link LGraph}.
+     */
+    public static final BiFunction<IPropertyHolder, IProperty<?>, Boolean> OPTION_TARGET_FILTER = (e, property) -> {
+        LayoutOptionData optionData = LayoutMetaDataService.getInstance().getOptionData(property.getId());
+        if (optionData != null) {
+            Set<LayoutOptionData.Target> targets = optionData.getTargets();
+            if (e instanceof LGraph) {
+                return targets.contains(LayoutOptionData.Target.NODES)
+                        || targets.contains(LayoutOptionData.Target.PARENTS);
+            } else if (e instanceof LNode) {
+                return targets.contains(LayoutOptionData.Target.NODES);
+            } else if (e instanceof LEdge) {
+                return targets.contains(LayoutOptionData.Target.EDGES);
+            } else if (e instanceof LPort) {
+                return targets.contains(LayoutOptionData.Target.PORTS);
+            } else if (e instanceof LLabel) {
+                return targets.contains(LayoutOptionData.Target.LABELS);
+            }
+        }
+        return true;
+    };
+}

--- a/plugins/org.eclipse.elk.core.service/src/org/eclipse/elk/core/service/DiagramLayoutEngine.java
+++ b/plugins/org.eclipse.elk.core.service/src/org/eclipse/elk/core/service/DiagramLayoutEngine.java
@@ -14,17 +14,13 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.elk.core.IGraphLayoutEngine;
 import org.eclipse.elk.core.LayoutConfigurator;
-import org.eclipse.elk.core.LayoutConfigurator.IOptionFilter;
 import org.eclipse.elk.core.data.LayoutAlgorithmResolver;
-import org.eclipse.elk.core.data.LayoutMetaDataService;
-import org.eclipse.elk.core.data.LayoutOptionData;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.SizeConstraint;
@@ -38,11 +34,8 @@ import org.eclipse.elk.core.util.Maybe;
 import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.core.validation.GraphValidator;
 import org.eclipse.elk.core.validation.LayoutOptionValidator;
-import org.eclipse.elk.graph.ElkEdge;
 import org.eclipse.elk.graph.ElkGraphElement;
-import org.eclipse.elk.graph.ElkLabel;
 import org.eclipse.elk.graph.ElkNode;
-import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
 import org.eclipse.elk.graph.properties.MapPropertyHolder;
@@ -138,7 +131,7 @@ public class DiagramLayoutEngine {
         public IGraphElementVisitor addLayoutRun(final IGraphElementVisitor configurator) {
             configurators.add(configurator);
             if (configurator instanceof LayoutConfigurator) {
-                ((LayoutConfigurator) configurator).addFilter(OPTION_TARGET_FILTER);
+                ((LayoutConfigurator) configurator).addFilter(LayoutConfigurator.OPTION_TARGET_FILTER);
             }
             return configurator;
         }
@@ -157,34 +150,7 @@ public class DiagramLayoutEngine {
     public static final String PREF_DEBUG_STORE = "elk.debug.store";
     /** preference identifier for execution time measurement. */
     public static final String PREF_DEBUG_EXEC_TIME = "elk.debug.exectime";
-    
-    /**
-     * Filter for {@link LayoutConfigurator} that checks for each option whether its configured targets
-     * match the input element.
-     */
-    public static final IOptionFilter OPTION_TARGET_FILTER =
-        (e, property) -> {
-            LayoutOptionData optionData = LayoutMetaDataService.getInstance().getOptionData(property.getId());
-            if (optionData != null) {
-                Set<LayoutOptionData.Target> targets = optionData.getTargets();
-                if (e instanceof ElkNode) {
-                    if (!((ElkNode) e).isHierarchical()) {
-                        return targets.contains(LayoutOptionData.Target.NODES);
-                    } else {
-                        return targets.contains(LayoutOptionData.Target.NODES)
-                                || targets.contains(LayoutOptionData.Target.PARENTS);
-                    }
-                } else if (e instanceof ElkEdge) {
-                    return targets.contains(LayoutOptionData.Target.EDGES);
-                } else if (e instanceof ElkPort) {
-                    return targets.contains(LayoutOptionData.Target.PORTS);
-                } else if (e instanceof ElkLabel) {
-                    return targets.contains(LayoutOptionData.Target.LABELS);
-                }
-            }
-            return true;
-        };
-    
+        
     /**
      * Property for the diagram layout connector used for automatic layout. This property is
      * attached to layout mappings created by the {@code layout} methods.

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkSpacings.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkSpacings.java
@@ -1,0 +1,310 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ ********************************************************************************/
+package org.eclipse.elk.core.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.elk.core.LayoutConfigurator;
+import org.eclipse.elk.core.LayoutConfigurator.IPropertyHolderOptionFilter;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.graph.ElkGraphElement;
+import org.eclipse.elk.graph.properties.IProperty;
+import org.eclipse.elk.graph.properties.IPropertyHolder;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.math.DoubleMath;
+
+/**
+ * Utility class to conveniently configure core spacing values ({@link CoreOptions#SPACING_*}) for a graph element or a
+ * whole graph.
+ * 
+ * Note that individual layout algorithms may specify additional spacing values and may hence provide their own utility
+ * class to configure those spacings. For layered this is definitely the case ({@link LayeredSpacings}).
+ */
+public final class ElkSpacings {
+
+    private ElkSpacings() { }
+
+    /**
+     * Start constructing a new spacing configurator with the passed {@code baseSpacing} as base value for all other
+     * spacing options. By default the values for other spacing options {@code o} will be determined based on the ratio
+     * between {@link ElkCoreSpacingsBuilder#BASE_SPACING_OPTION}'s default value and {@code o}'s default value.
+     */
+    public static ElkCoreSpacingsBuilder withBaseValue(final double baseSpacing) {
+        return new ElkCoreSpacingsBuilder(baseSpacing);
+    }
+    
+    /**
+     * Spacing configuration builder implementation for spacing options defined in {@link CoreOptions}.
+     */
+    public static final class ElkCoreSpacingsBuilder extends AbstractSpacingsBuilder<ElkCoreSpacingsBuilder> {
+
+        /** See {@link AbstractSpacingsBuilder#baseSpacing} for details. */
+        public static final IProperty<Double> BASE_SPACING_OPTION = CoreOptions.SPACING_NODE_NODE;
+        
+        // @formatter:off
+        private static final List<IProperty<Double>> DEPENDENT_SPACING_OPTIONS = Lists.newArrayList(
+            // Sorted alphabetically
+            CoreOptions.SPACING_COMPONENT_COMPONENT,
+            CoreOptions.SPACING_EDGE_EDGE,
+            CoreOptions.SPACING_EDGE_LABEL,
+            CoreOptions.SPACING_EDGE_NODE,
+            CoreOptions.SPACING_LABEL_LABEL,
+            CoreOptions.SPACING_LABEL_NODE,
+            CoreOptions.SPACING_LABEL_PORT,
+            CoreOptions.SPACING_NODE_SELF_LOOP,
+            CoreOptions.SPACING_PORT_PORT
+        );
+        // @formatter:on
+
+        static {
+            assert BASE_SPACING_OPTION.getDefault() != null : "Base spacing default value must be non-null.";
+            // Avoid division by zero.
+            assert !DoubleMath.fuzzyEquals(0.0d, BASE_SPACING_OPTION.getDefault(),
+                    DOUBLE_EQ_EPSILON) : "Base spacing default value must be different from 0.0d.";
+        }
+        
+        private ElkCoreSpacingsBuilder(final double baseSpacing) {
+            super(baseSpacing);
+        }
+
+        @Override
+        protected ElkCoreSpacingsBuilder thisT() {
+            return this;
+        }
+        
+        @Override
+        protected IProperty<Double> getBaseSpacingOption() {
+            return BASE_SPACING_OPTION;
+        }
+        
+        @Override
+        protected Iterable<IProperty<Double>> getDependendSpacingOptions() {
+            return DEPENDENT_SPACING_OPTIONS;
+        }
+    }
+
+    /**
+     * An abstract builder to be extended to cater for the needs of individual layout algorithms when it comes to layout
+     * options only they are aware of.
+     * 
+     * @param <T>
+     *            The class of the inheriting builder itself.
+     */
+    public abstract static class AbstractSpacingsBuilder<T extends AbstractSpacingsBuilder<T>> {
+     
+        /**
+         * Delegates to {@link LayoutConfigurator#OPTION_TARGET_FILTER} if the holder is an {@link ElkGraphElement},
+         * otherwise returns true.
+         * 
+         * Required here since the base spacing builder class should not restrict itself to {@link ElkGraphElement}s
+         * only and thus allows configuration for arbitrary {@link IPropertyHolder}s.
+         */
+        public static final IPropertyHolderOptionFilter ELK_OPTION_TARGET_FILTER = (holder, property) -> {
+            if (property instanceof ElkGraphElement) {
+                return LayoutConfigurator.OPTION_TARGET_FILTER.accept((ElkGraphElement) holder, property);
+            } else {
+                return true;
+            }
+        };
+
+        /** Constant for fuzzy double comparisons. */
+        protected static final double DOUBLE_EQ_EPSILON = 10e-5;
+        
+
+        // Internal builder configuration elements
+        
+        /** The spacing layout option that shall serve as reference when deriving spacing values for all other spacing
+         * layout options. In other words the ratio between this option's default value and a user-specified base
+         * value for a "general spacings" yields a factor to be used for the other spacing layout option default values.
+         */
+        private final double baseSpacing;
+        /** Whether the resulting configurator shall overwrite existing spacing option values. */
+        private boolean overwrite = false;
+        /** Filters to be applied by the resulting configurator. Elements specified directly here are always applied. */
+        private List<IPropertyHolderOptionFilter> filters = Lists.newArrayList(ELK_OPTION_TARGET_FILTER);
+        
+        /**
+         * Internal mapping of dependent layout options to factors that must be applied to those option's default 
+         * values when setting the spacing value for a concrete node.
+         */
+        private Map<IProperty<Double>, Double> factorMap = Maps.newHashMap();
+                
+        /**
+         * Constructs a new builder and computes the initial factors based on the passed based value.
+         */
+        protected AbstractSpacingsBuilder(final double theBaseSpacing) {
+            this.baseSpacing = theBaseSpacing;
+
+            // Put the base spacing option in the map as well to allow iterating all options by using this map
+            factorMap.put(getBaseSpacingOption(), 1.0d);
+
+            // Initially, and by default, set all factors to the ratio given by default values set in the Core.melk
+            getDependendSpacingOptions().forEach(option -> {
+                double factor = (getBaseSpacingOption().getDefault() != null && option.getDefault() != null)
+                        ? option.getDefault() / getBaseSpacingOption().getDefault()
+                        : 1.0d;
+                factorMap.put(option, factor);
+            });
+        }
+        
+        // Protected
+
+        /**
+         * See {@link #baseSpacing}'s javadoc for further details.
+         * 
+         * @return a spacing option that shall serve as the basis for the configuration, i.e. it will serve as basis to
+         *         compute factors to be applied to other spacing values.
+         */
+        protected abstract IProperty<Double> getBaseSpacingOption();
+
+        /**
+         * @return a list of spacing options that shall be affected by the specified base value.
+         */
+        protected abstract Iterable<IProperty<Double>> getDependendSpacingOptions();
+        
+        /**
+         * @return the filters that shall be applied during configuration.
+         */
+        protected List<IPropertyHolderOptionFilter> getFilters() {
+            return filters;
+        }
+
+        /**
+         * @return type of the implementing class - necessary to make suppress a warning whenever a method in this base
+         *         class returns {@code T}.
+         */
+        protected abstract T thisT();
+        
+        /**
+         * @return the factor to be used for {@code value} relative to the specified {@link #baseSpacing}.
+         */
+        protected double computeFactor(final double value) {
+            return value / baseSpacing;
+        }
+        
+        // Public API
+        
+        /**
+         * @return an immutable list of the currently configured factors.
+         */
+        public Map<IProperty<Double>, Double> getFactors() {
+            return ImmutableMap.copyOf(factorMap);
+        }
+
+        /**
+         * Configure the {@code factor} to use for {@code spacingOption} relative to the configured base value.
+         * 
+         * @return this instance.
+         */
+        public T withFactor(final IProperty<Double> spacingOption, final double factor) {
+            if (!factorMap.keySet().contains(spacingOption)) {
+                throw new IllegalArgumentException(
+                        "'" + spacingOption.getId() + "' is not a configurable spacing option.");
+            }
+            if (factor < 0.0) {
+                throw new IllegalArgumentException(
+                        "The factor for '" + spacingOption.getId() + "' must not be negative (" + factor + ").");
+            }
+            if (spacingOption.getId().equals(getBaseSpacingOption().getId())) {
+                throw new IllegalArgumentException("'" + spacingOption.getId()
+                        + "' is the base spacing option not allowed to use with 'withFactor'.");
+            }
+            factorMap.put(spacingOption, factor);
+            return thisT();
+        }
+
+        /**
+         * Configure the {@code value} to use for {@code spacingOption} relative to the configured base value.
+         * 
+         * @return this instance.
+         */
+        public T withValue(final IProperty<Double> spacingOption, final double value) {
+            if (!factorMap.keySet().contains(spacingOption)) {
+                throw new IllegalArgumentException(
+                        "'" + spacingOption.getId() + "' is not a configurable spacing option.");
+            }
+            if (value < 0.0) {
+                throw new IllegalArgumentException(
+                        "The value for '" + spacingOption.getId() + "' must not be negative (" + value + ").");
+            }
+            if (spacingOption.getId().equals(getBaseSpacingOption().getId())) {
+                throw new IllegalArgumentException("'" + spacingOption.getId()
+                        + "' is the base spacing option not allowed to use with 'withValue'.");
+            }
+            factorMap.put(spacingOption, computeFactor(value));
+            return thisT();
+        }
+        
+        /**
+         * If {@code overwrite} is set to false, existing spacing option values will not be overwritten when configuring
+         * an element.
+         * 
+         * @return this instance.
+         */
+        public T withOverwrite(final boolean shallOverwrite) {
+            this.overwrite = shallOverwrite;
+            return thisT();
+        }
+        
+        /**
+         * @return a function accepting a {@link IPropertyHolder} and applying the assembled spacing configuration to it
+         *         when called.
+         */
+        public Consumer<IPropertyHolder> build() {
+            if (!this.overwrite) {
+                filters.add(LayoutConfigurator.NO_OVERWRITE_HOLDER);
+            }
+            
+            // Early exit if we are not allowed to overwrite any options and if the specified base matches the default
+            // values anyway
+            if (!overwrite
+                    && DoubleMath.fuzzyEquals(baseSpacing, getBaseSpacingOption().getDefault(), DOUBLE_EQ_EPSILON)) {
+                return e -> { };
+            }
+
+            return element -> {
+                // Set each spacing option's value based on the computed factors. Remember that the base value option 
+                // is included in the map. Only apply to graph elements:
+                //  - that actually support this option
+                //  - for which the option has not been set so far
+                factorMap.keySet().stream()
+                    .filter(p -> filters.stream().allMatch(filter -> filter.accept(element, p)))
+                    .forEach(p -> {
+                        element.setProperty(p, factorMap.get(p) * baseSpacing);
+                    });
+            };
+        }
+        
+        /**
+         * Apply the built configuration to the passed {@code holder}. Note that no hierarchy is traversed. Use an
+         * {@link IGraphElementVisitor} returned by {@link #toVisitor()} for that.
+         * 
+         * @param holder
+         */
+        public void apply(final IPropertyHolder holder) {
+           build().accept(holder);
+        }
+        
+        /**
+         * @return a new {@link IGraphElementVisitor} that applies the built configuration to each node it visits.
+         */
+        public IGraphElementVisitor toVisitor() {
+            Consumer<IPropertyHolder> consumer = build();
+            return e -> consumer.accept(e);
+        }
+     
+    }
+
+}

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/LayeredSpacingTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/LayeredSpacingTest.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.LayeredSpacings;
+import org.eclipse.elk.alg.layered.options.LayeredSpacings.LayeredSpacingsBuilder;
+import org.eclipse.elk.alg.test.PlainJavaInitialization;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.util.BasicProgressMonitor;
+import org.eclipse.elk.core.util.ElkSpacings;
+import org.eclipse.elk.core.util.ElkUtil;
+import org.eclipse.elk.core.util.IGraphElementVisitor;
+import org.eclipse.elk.graph.ElkEdge;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.properties.IProperty;
+import org.eclipse.elk.graph.properties.Property;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Tests adjustments by {@link LayeredSpacings} to {@link ElkSpacings}. For instance, whether layered's potentially
+ * overwritten default values are considered properly.
+ */
+@RunWith(Enclosed.class)
+public class LayeredSpacingTest {
+
+    static {
+        PlainJavaInitialization.initializePlainJavaLayout();
+    }
+
+    private static double DOUBLE_EQ_EPSILON = 10e-5;
+    
+    private static ElkNode createAndConfigureTestGraph(final IGraphElementVisitor configurator) {
+        ElkNode simpleGraph = createSimpleGraph();
+        ElkUtil.applyVisitors(simpleGraph, configurator);
+        return simpleGraph;
+    }
+
+    @RunWith(Parameterized.class)
+    public static class WithFactorAndValueTest {
+
+        @Parameters(name="{0}")
+        public static Collection<Object[]> data(){
+            return Arrays.asList(new Object[][] {
+                {LayeredOptions.SPACING_EDGE_EDGE},
+                {LayeredOptions.SPACING_EDGE_LABEL},
+                {LayeredOptions.SPACING_EDGE_NODE},
+                {LayeredOptions.SPACING_LABEL_LABEL},
+                {LayeredOptions.SPACING_LABEL_NODE},
+                {LayeredOptions.SPACING_LABEL_PORT},
+                {LayeredOptions.SPACING_NODE_SELF_LOOP},
+                {LayeredOptions.SPACING_PORT_PORT},
+                //
+                {LayeredOptions.SPACING_EDGE_EDGE_BETWEEN_LAYERS},
+                {LayeredOptions.SPACING_EDGE_NODE_BETWEEN_LAYERS},
+                {LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS}
+            });
+        }
+        
+        @Parameter(0)
+        public IProperty<Double> optionToTest;
+        
+        /**
+         * Check that in the (potentially overwritten) default values of the layered options and not the core options
+         * are used.
+         */
+        @Test
+        public void testDefaultFactorsProperlyOverwritten() {
+            LayeredSpacingsBuilder builder = LayeredSpacings.withBaseValue(33.0);
+            double value = builder.getFactors().get(optionToTest);
+            assertEquals(optionToTest.getDefault() / LayeredSpacingsBuilder.BASE_SPACING_OPTION.getDefault(), value,
+                    DOUBLE_EQ_EPSILON);
+        }
+
+    }
+    
+    /**
+     * Tests that the spacing values have actually properly been regarded in the final drawing. 
+     * 
+     * TODO only {@link LayeredOptions#SPACING_NODE_NODE_BETWEEN_LAYERS} is tested so far - add tests for the others!
+     */
+    public static class AfterLayoutTest {
+        
+        @Test
+        public void testSpacingNodeNodeBetweenLayers() {
+            ElkNode graph = createAndConfigureTestGraph(
+                    LayeredSpacings.withBaseValue(33.0)
+                                   .withFactor(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 2.0)
+                                   .toVisitor());
+            
+            LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+            layoutProvider.layout(graph, new BasicProgressMonitor());
+            
+            for (ElkEdge edge : graph.getContainedEdges()) {
+                final ElkNode source = ElkGraphUtil.getSourceNode(edge);
+                final double spacingNodeNodeBetweenLayers =
+                        ElkGraphUtil.getTargetNode(edge).getX() - (source.getX() + source.getWidth());
+                assertEquals(66, spacingNodeNodeBetweenLayers, DOUBLE_EQ_EPSILON);
+            }
+        }
+
+    }
+    
+    /**
+     * As described in #104 there is a conceptual problem with spacings default values. Code that is implemented
+     * independent of the layout algorithm (such as node label placement code) is not aware of the default values that,
+     * for instance, the layered algorithm specifies. It can only access the layout options via the {@link CoreOptions}.
+     * 
+     * However, as soon as a spacing configuration is applied to a graph, spacing values should have been set
+     * explicitly. Thus, the problem with the default values must not occur in that case.
+     */
+    public static class SpacingOverrides {
+        
+
+        final static IProperty<Double> PROPERTY_WITH_DIFFERENT_DEFAULT = new Property<Double>(
+                LayeredOptions.SPACING_EDGE_NODE, LayeredOptions.SPACING_EDGE_NODE.getDefault() + 3.0);
+
+        @Test 
+        public void testExtractsCorrectDefaultForLayeredProperty() {
+            ElkNode node = createSimpleGraph();
+            final double snn = node.getProperty(LayeredOptions.SPACING_EDGE_NODE);
+            assertEquals(LayeredOptions.SPACING_EDGE_NODE.getDefault(), snn, DOUBLE_EQ_EPSILON);
+            // Note that after the 'getProperty' call the default value is actually _set_ on the node
+        }
+     
+        @Test 
+        public void testExtractsCorrectDefaultForInheritingProperty() {
+            ElkNode node = createSimpleGraph();
+            final double sne = node.getProperty(PROPERTY_WITH_DIFFERENT_DEFAULT);
+            assertEquals(LayeredOptions.SPACING_EDGE_NODE.getDefault() + 3.0, sne, DOUBLE_EQ_EPSILON);
+            // Note that after the 'getProperty' call the default value is actually _set_ on the node
+        }
+        
+        @Test
+        public void testExtractsCorrectDefaultValueAfterSpacingConfiguration() {
+            ElkNode node = createSimpleGraph();
+            LayeredSpacingsBuilder builder = LayeredSpacings.withBaseValue(35.0);
+            builder.apply(node);
+            
+            
+            assertTrue(node.hasProperty(LayeredOptions.SPACING_EDGE_NODE));
+            final double expected = 35.0 * builder.getFactors().get(LayeredOptions.SPACING_EDGE_NODE);
+            assertEquals(expected, node.getProperty(PROPERTY_WITH_DIFFERENT_DEFAULT), DOUBLE_EQ_EPSILON);
+            assertEquals(expected, node.getProperty(LayeredOptions.SPACING_EDGE_NODE), DOUBLE_EQ_EPSILON);
+        }
+        
+    }
+
+    /**
+     * Create a simple test graph. The graph has at least two nodes and an edge, the nodes have predefined sizes with
+     * fixed size constraint, but neither nodes nor edges have predefined coordinates, i.e. they are all set to (0,0).
+     * The graph size is initially 0 as well.
+     */
+    private static ElkNode createSimpleGraph() {
+        ElkNode graph = ElkGraphUtil.createGraph();
+
+        ElkNode node1 = ElkGraphUtil.createNode(graph);
+        node1.setWidth(30);
+        node1.setHeight(30);
+
+        ElkNode node2 = ElkGraphUtil.createNode(graph);
+        node2.setWidth(30);
+        node2.setHeight(30);
+
+        ElkGraphUtil.createSimpleEdge(node1, node2);
+
+        return graph;
+    }
+
+}

--- a/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/alg/SpacingConfigurationTest.java
+++ b/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/alg/SpacingConfigurationTest.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.core.alg;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.elk.alg.test.PlainJavaInitialization;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.util.ElkSpacings;
+import org.eclipse.elk.core.util.ElkSpacings.ElkCoreSpacingsBuilder;
+import org.eclipse.elk.core.util.ElkSpacings.AbstractSpacingsBuilder;
+import org.eclipse.elk.core.util.ElkUtil;
+import org.eclipse.elk.core.util.IGraphElementVisitor;
+import org.eclipse.elk.graph.ElkGraphElement;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.properties.IProperty;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.Streams;
+
+/**
+ * Test the utility class {@link ElkSpacings}, which allows to conveniently configure spacings for the overall graph.
+ */
+@RunWith(Enclosed.class)
+public class SpacingConfigurationTest {
+
+    static {
+        PlainJavaInitialization.initializePlainJavaLayout();
+    }
+
+    private static double DOUBLE_EQ_EPSILON = 10e-5;
+    
+    public static ElkNode createAndConfigureTestGraph(final IGraphElementVisitor configurator) {
+        ElkNode simpleGraph = createSimpleGraph();
+        ElkUtil.applyVisitors(simpleGraph, configurator);
+        return simpleGraph;
+    }
+
+    public static void checkOptionValue(ElkNode graph, Class<? extends ElkGraphElement> clazz,
+            IProperty<Double> option, final double value) {
+        // It's important to also check the root node here.
+        Streams.stream(ElkGraphUtil.propertiesSkippingIteratorFor(graph, true))
+                .filter(e -> clazz.isInstance(e))
+                .map(ElkGraphElement.class::cast).forEach(e -> {
+                    assertEquals(option.getId(), value, e.getProperty(option), DOUBLE_EQ_EPSILON);
+                });
+    }
+
+    public static class Basics {
+        
+        @Test
+        public void testCreateVisitor() {
+            ElkNode node = ElkGraphUtil.createNode(null);
+            IGraphElementVisitor visitor = ElkSpacings.withBaseValue(3.0).toVisitor();
+            visitor.visit(node);
+            assertEquals(3.0, node.getProperty(ElkCoreSpacingsBuilder.BASE_SPACING_OPTION), DOUBLE_EQ_EPSILON);
+        }
+        
+        @Test
+        public void testApplyTo() {
+            ElkNode node = ElkGraphUtil.createNode(null);
+            ElkSpacings.withBaseValue(3.0).apply(node);
+            assertEquals(3.0, node.getProperty(ElkCoreSpacingsBuilder.BASE_SPACING_OPTION), DOUBLE_EQ_EPSILON);
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testSpacingWithNegativeFactor() {
+            createAndConfigureTestGraph(
+                    ElkSpacings.withBaseValue(33.0)
+                               .withFactor(CoreOptions.SPACING_EDGE_EDGE, -Double.MIN_VALUE)
+                               .toVisitor());
+        }
+        
+        @Test(expected = IllegalArgumentException.class)
+        public void testSpacingWithNegativeValue() {
+            createAndConfigureTestGraph(
+                    ElkSpacings.withBaseValue(33.0)
+                               .withValue(CoreOptions.SPACING_EDGE_EDGE, -Double.MIN_VALUE)
+                               .toVisitor());
+        }
+    }
+    
+    /**
+     * Tests the basic functionality of {@link AbstractSpacingsBuilder#withFactor(IProperty, double)} and
+     * {@link AbstractSpacingsBuilder#withValue(IProperty, double)}.
+     */
+    @RunWith(Parameterized.class)
+    public static class WithFactorAndValueTest {
+
+        @Parameters(name = "{0}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] { 
+                { CoreOptions.SPACING_COMPONENT_COMPONENT },
+                { CoreOptions.SPACING_EDGE_EDGE },
+                { CoreOptions.SPACING_EDGE_LABEL },
+                { CoreOptions.SPACING_EDGE_NODE },
+                { CoreOptions.SPACING_LABEL_LABEL },
+                { CoreOptions.SPACING_LABEL_NODE }, 
+                { CoreOptions.SPACING_LABEL_PORT },
+                { CoreOptions.SPACING_NODE_SELF_LOOP }, 
+                { CoreOptions.SPACING_PORT_PORT } 
+            });
+        }
+        
+        @Parameter(0)
+        public IProperty<Double> optionToTest;
+        
+        @Test
+        public void testDefaultFactors() {
+            ElkCoreSpacingsBuilder builder = ElkSpacings.withBaseValue(33.0);
+            double value = builder.getFactors().get(optionToTest);
+            assertEquals(optionToTest.getDefault() / ElkCoreSpacingsBuilder.BASE_SPACING_OPTION.getDefault(), value,
+                    DOUBLE_EQ_EPSILON);
+        }
+        
+        @Test
+        public void testSpacingWithFactor() {
+            ElkNode graph =
+                    createAndConfigureTestGraph(ElkSpacings.withBaseValue(33.0)
+                                                           .withFactor(optionToTest, 2.0)
+                                                           .toVisitor());
+            checkOptionValue(graph, ElkNode.class, optionToTest, 66.0);
+        }
+
+        @Test
+        public void testSpacingWithValue() {
+            ElkNode graph =
+                    createAndConfigureTestGraph(ElkSpacings.withBaseValue(33.0)
+                                                           .withValue(optionToTest, 24.0)
+                                                           .toVisitor());
+            checkOptionValue(graph, ElkNode.class, optionToTest, 24.0);
+        }
+        
+        @Test
+        public void testOverwriteIfRequested() {
+            ElkNode graph = createSimpleGraph();
+            final ElkNode firstChild = graph.getChildren().get(0);
+            final ElkNode secondChild = graph.getChildren().get(1);
+            firstChild.setProperty(optionToTest, 22.0);
+            ElkUtil.applyVisitors(graph, ElkSpacings.withBaseValue(1)
+                                                    .withValue(optionToTest, 3)
+                                                    .withOverwrite(true)
+                                                    .toVisitor());
+            assertEquals("Should overwrite", 3.0, firstChild.getProperty(optionToTest), DOUBLE_EQ_EPSILON);
+            assertEquals(3.0, secondChild.getProperty(optionToTest), DOUBLE_EQ_EPSILON);
+        }
+        
+        @Test
+        public void testDontOverwriteIfNotRequested() {
+            ElkNode graph = createSimpleGraph();
+            final ElkNode firstChild = graph.getChildren().get(0);
+            final ElkNode secondChild = graph.getChildren().get(1);
+            firstChild.setProperty(optionToTest, 22.0);
+            ElkUtil.applyVisitors(graph, ElkSpacings.withBaseValue(1)
+                                                    .withValue(optionToTest, 3)
+                                                    .withOverwrite(false)
+                                                    .toVisitor());
+            assertEquals("Should not overwrite", 22.0, firstChild.getProperty(optionToTest), DOUBLE_EQ_EPSILON);
+            assertEquals(3.0, secondChild.getProperty(optionToTest), DOUBLE_EQ_EPSILON);
+        }
+    }
+    
+    /**
+     * Tests that trying to configure factors and values for non-spacing layout options is rejected.
+     */
+    @RunWith(Parameterized.class)
+    public static class InvalidOptionConfigurationTest {
+
+        @Parameters(name = "{0}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(
+                    new Object[][] { { ElkCoreSpacingsBuilder.BASE_SPACING_OPTION }, { CoreOptions.ASPECT_RATIO } });
+        }
+        
+        @Parameter(0)
+        public IProperty<Double> optionToTest;
+        
+        @Test(expected = IllegalArgumentException.class)
+        public void testSpacingWithFactor() {
+            createAndConfigureTestGraph(
+                    ElkSpacings.withBaseValue(33.0)
+                               .withFactor(optionToTest, 2.0)
+                               .toVisitor());
+        }
+        
+        @Test(expected = IllegalArgumentException.class)
+        public void testSpacingWithValue() {
+            createAndConfigureTestGraph(
+                    ElkSpacings.withBaseValue(33.0)
+                               .withValue(optionToTest, 24.0)
+                               .toVisitor());
+        }
+        
+    }
+    
+
+    /**
+     * Create a simple test graph. The graph has at least two nodes and an edge, the nodes have predefined sizes with
+     * fixed size constraint, but neither nodes nor edges have predefined coordinates, i.e. they are all set to (0,0).
+     * The graph size is initially 0 as well.
+     */
+    private static ElkNode createSimpleGraph() {
+        ElkNode graph = ElkGraphUtil.createGraph();
+
+        ElkNode node1 = ElkGraphUtil.createNode(graph);
+        node1.setWidth(30);
+        node1.setHeight(30);
+
+        ElkNode node2 = ElkGraphUtil.createNode(graph);
+        node2.setWidth(30);
+        node2.setHeight(30);
+
+        ElkGraphUtil.createSimpleEdge(node1, node2);
+
+        return graph;
+    }
+
+}


### PR DESCRIPTION
Efforts in the direction of #105.

The new class `ElkSpacings` is intended to be used by layout algorithm-integrators to configure a graph with spacing values before the graph is passed to the layout algorithm itself. It supports the spacing options provided by `CoreOptions`. 

The `LayeredSpacings` class adjusts and extends the functionality of `ElkSpacings` by what layered offers in terms of additional spacing options (in particular the _between layers_ options). 

Furthermore, there's a new layout option in `Layered.melk`: `spacing.baseValue`. It can be used to alter the overall "spaciousness" of a drawing. In other words, in can in-/decrease _all_ spacing values. If one desires to fine-tune individual spacing option values, the `LayeredSpacings` class would have to be used manually as described for `ElkSpacings` above. 

@le-cds I'm interested in your opinion regarding the actual integration into layered's `ElkGraphImporter` (see the code comment for a rationale). 

Documenting the usage of the new classes as part of the website shall be done as part of #335.