### PR TITLE
Graph Text: Change default property proposal mechanism.

### DIFF
--- a/plugins/org.eclipse.elk.graph.text.ide/src/org/eclipse/elk/graph/text/ide/contentassist/ElkGraphProposalProvider.xtend
+++ b/plugins/org.eclipse.elk.graph.text.ide/src/org/eclipse/elk/graph/text/ide/contentassist/ElkGraphProposalProvider.xtend
@@ -122,7 +122,12 @@ class ElkGraphProposalProvider extends IdeContentProposalProvider {
     
     protected def proposeProperties(ElkGraphElement element, LayoutAlgorithmData algorithmData,
         LayoutOptionData.Target targetType, ContentAssistContext context, IIdeContentProposalAcceptor acceptor) {
-        proposeProperties(element, algorithmData, #{targetType}, context, acceptor)
+        proposeProperties(
+            element,
+            algorithmData,
+            targetType !== null ? #{targetType} : #{},
+            context,
+            acceptor)
     }
     
     protected def proposeProperties(ElkGraphElement element, LayoutAlgorithmData algorithmData,


### PR DESCRIPTION
For a `null` argument, the properties proposed now includes properties for all possible targets, not for none.

Signed-off-by: Christoph Daniel Schulze <cds@informatik.uni-kiel.de>