### PR TITLE
Removed 'programmatic' from 'port.index'

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -687,7 +687,7 @@ group port {
         targets ports
     }
 
-    programmatic option index: int {
+    option index: int {
         label "Port Index"
         description
             "The index of a port in the fixed order around a node. The order is assumed as clockwise,


### PR DESCRIPTION
I don't see any reason why it should be programmatic: as soon as port constrains are fixed order, these values can be used to specify the order.