### PR TITLE
[PR] Streamlined port label placement

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/NodeMarginCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/NodeMarginCalculator.java
@@ -189,7 +189,7 @@ public final class NodeMarginCalculator  {
                 KVector requiredPortLabelSpace = new KVector(-labelSpacing, -labelSpacing);
                 
                 // TODO: maybe leave space for manually placed ports 
-                if (node.getProperty(CoreOptions.PORT_LABELS_PLACEMENT) == PortLabelPlacement.OUTSIDE) {
+                if (node.getProperty(CoreOptions.PORT_LABELS_PLACEMENT).contains(PortLabelPlacement.OUTSIDE)) {
                     for (LabelAdapter<?> label : port.getLabels()) {
                         requiredPortLabelSpace.x += label.getSize().x + labelSpacing;
                         requiredPortLabelSpace.y += label.getSize().y + labelSpacing;

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
@@ -64,7 +64,7 @@ public final class NodeContext {
     /** Port constraints set on the node. */
     public final PortConstraints portConstraints;
     /** Whether port labels are placed inside or outside. */
-    public final PortLabelPlacement portLabelsPlacement;
+    public final Set<PortLabelPlacement> portLabelsPlacement;
     /** Whether port labels are to be placed next to their port, if possible. */
     public final boolean portLabelsNextToPort;
     /** Whether to treat port labels as a group when centering them next to eastern or western ports. */
@@ -138,7 +138,8 @@ public final class NodeContext {
         sizeOptions = node.getProperty(CoreOptions.NODE_SIZE_OPTIONS);
         portConstraints = node.getProperty(CoreOptions.PORT_CONSTRAINTS);
         portLabelsPlacement = node.getProperty(CoreOptions.PORT_LABELS_PLACEMENT);
-        portLabelsNextToPort = node.getProperty(CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE);
+        portLabelsNextToPort = portLabelsPlacement.contains(PortLabelPlacement.NEXT_TO_PORT_IF_POSSIBLE);
+        
         portLabelsTreatAsGroup = node.getProperty(CoreOptions.PORT_LABELS_TREAT_AS_GROUP);
         nodeLabelPlacement = node.getProperty(CoreOptions.NODE_LABELS_PLACEMENT);
         

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
@@ -65,8 +65,6 @@ public final class NodeContext {
     public final PortConstraints portConstraints;
     /** Whether port labels are placed inside or outside. */
     public final Set<PortLabelPlacement> portLabelsPlacement;
-    /** Whether port labels are to be placed next to their port, if possible. */
-    public final boolean portLabelsNextToPort;
     /** Whether to treat port labels as a group when centering them next to eastern or western ports. */
     public final boolean portLabelsTreatAsGroup;
     /** Where node labels are placed by default. */
@@ -138,7 +136,6 @@ public final class NodeContext {
         sizeOptions = node.getProperty(CoreOptions.NODE_SIZE_OPTIONS);
         portConstraints = node.getProperty(CoreOptions.PORT_CONSTRAINTS);
         portLabelsPlacement = node.getProperty(CoreOptions.PORT_LABELS_PLACEMENT);
-        portLabelsNextToPort = portLabelsPlacement.contains(PortLabelPlacement.NEXT_TO_PORT_IF_POSSIBLE);
         
         portLabelsTreatAsGroup = node.getProperty(CoreOptions.PORT_LABELS_TREAT_AS_GROUP);
         nodeLabelPlacement = node.getProperty(CoreOptions.NODE_LABELS_PLACEMENT);

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
@@ -18,6 +18,7 @@ import org.eclipse.elk.alg.common.nodespacing.cellsystem.GridContainerCell;
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.LabelCell;
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.StripContainerCell;
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.StripContainerCell.Strip;
+import org.eclipse.elk.core.UnsupportedConfigurationException;
 import org.eclipse.elk.core.math.ElkMargin;
 import org.eclipse.elk.core.math.ElkPadding;
 import org.eclipse.elk.core.math.KVector;
@@ -136,9 +137,15 @@ public final class NodeContext {
         sizeOptions = node.getProperty(CoreOptions.NODE_SIZE_OPTIONS);
         portConstraints = node.getProperty(CoreOptions.PORT_CONSTRAINTS);
         portLabelsPlacement = node.getProperty(CoreOptions.PORT_LABELS_PLACEMENT);
-        
+        if (!PortLabelPlacement.isValid(portLabelsPlacement)) {
+            throw new UnsupportedConfigurationException("Invalid port label placement: " + portLabelsPlacement);
+        }
+
         portLabelsTreatAsGroup = node.getProperty(CoreOptions.PORT_LABELS_TREAT_AS_GROUP);
         nodeLabelPlacement = node.getProperty(CoreOptions.NODE_LABELS_PLACEMENT);
+        if (!NodeLabelPlacement.isValid(nodeLabelPlacement)) {
+            throw new UnsupportedConfigurationException("Invalid node label placement: " + nodeLabelPlacement);
+        }
         
         // Copy spacings for convenience
         nodeLabelsPadding = IndividualSpacings.getIndividualOrInherited(node, CoreOptions.NODE_LABELS_PADDING);

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/PortContext.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/PortContext.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.common.nodespacing.internal;
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.LabelCell;
 import org.eclipse.elk.core.math.ElkMargin;
 import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.PortLabelPlacement;
 import org.eclipse.elk.core.util.adapters.GraphAdapters.PortAdapter;
 
 /**
@@ -66,8 +67,7 @@ public final class PortContext {
         
         // Whether labels are supposed to be placed next to their port is determined differently depending on whether
         // they are to be placed inside or outside
-        switch (parentNodeContext.portLabelsPlacement) {
-        case INSIDE:
+        if (parentNodeContext.portLabelsPlacement.contains(PortLabelPlacement.INSIDE)) {
             if (parentNodeContext.treatAsCompoundNode) {
                 // There might be connections to the inside. That means that we may want to place port labels next to
                 // their port, if possible
@@ -76,9 +76,7 @@ public final class PortContext {
             } else {
                 labelsNextToPort = true;
             }
-            break;
-            
-        case OUTSIDE:
+        } else if (parentNodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE)) {
             if (parentNodeContext.portLabelsNextToPort) {
                 // We can place a label next to an outside port if that port doesn't have incident edges
                 labelsNextToPort =
@@ -87,9 +85,7 @@ public final class PortContext {
                 // We are not to place labels next to the port anyway
                 labelsNextToPort = false;
             }
-            break;
-            
-        default:
+        } else {
             labelsNextToPort = false;
         }
     }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/PortContext.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/PortContext.java
@@ -65,19 +65,22 @@ public final class PortContext {
         this.port = port;
         this.portPosition = new KVector(port.getPosition());
         
+        final boolean portLabelsNextToPort =
+                parentNodeContext.portLabelsPlacement.contains(PortLabelPlacement.NEXT_TO_PORT_IF_POSSIBLE);
+        
         // Whether labels are supposed to be placed next to their port is determined differently depending on whether
         // they are to be placed inside or outside
         if (parentNodeContext.portLabelsPlacement.contains(PortLabelPlacement.INSIDE)) {
             if (parentNodeContext.treatAsCompoundNode) {
                 // There might be connections to the inside. That means that we may want to place port labels next to
                 // their port, if possible
-                labelsNextToPort = parentNodeContext.portLabelsNextToPort && !port.hasCompoundConnections();
+                labelsNextToPort = portLabelsNextToPort && !port.hasCompoundConnections();
                 
             } else {
                 labelsNextToPort = true;
             }
         } else if (parentNodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE)) {
-            if (parentNodeContext.portLabelsNextToPort) {
+            if (portLabelsNextToPort) {
                 // We can place a label next to an outside port if that port doesn't have incident edges
                 labelsNextToPort =
                         !(port.getIncomingEdges().iterator().hasNext() || port.getOutgoingEdges().iterator().hasNext());

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
@@ -260,12 +260,12 @@ public final class HorizontalPortPlacementSizeCalculator {
         Collection<PortContext> portContexts = nodeContext.portContexts.get(portSide);
         
         boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
-        boolean spaceEfficientPortLabels =
-                !nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE)
-                        && (nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
-                                || portContexts.size() == 2);
+        boolean alwaysSameSide = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE);
+        boolean spaceEfficient = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT);
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
         
+        boolean spaceEfficientPortLabels = !alwaysSameSide && (spaceEfficient || portContexts.size() == 2);
+
         // Set the horizontal port margins of all ports according to how their labels will be placed. We'll be
         // modifying the margins soon enough.
         computeHorizontalPortMargins(nodeContext, portSide, portLabelsOutside);

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
@@ -260,8 +260,10 @@ public final class HorizontalPortPlacementSizeCalculator {
         Collection<PortContext> portContexts = nodeContext.portContexts.get(portSide);
         
         boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
-        boolean spaceEfficientPortLabels = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
-                || portContexts.size() == 2;
+        boolean spaceEfficientPortLabels =
+                !nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE)
+                        && (nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
+                                || portContexts.size() == 2);
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
         
         // Set the horizontal port margins of all ports according to how their labels will be placed. We'll be

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
@@ -112,7 +112,7 @@ public final class HorizontalPortPlacementSizeCalculator {
             return;
         }
 
-        boolean portLabelsInside = nodeContext.portLabelsPlacement == PortLabelPlacement.INSIDE;
+        boolean portLabelsInside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.INSIDE);
         double minWidth = 0;
         
         // Go over all pairs of consecutive ports
@@ -259,8 +259,8 @@ public final class HorizontalPortPlacementSizeCalculator {
     private static void setupPortMargins(final NodeContext nodeContext, final PortSide portSide) {
         Collection<PortContext> portContexts = nodeContext.portContexts.get(portSide);
         
-        boolean portLabelsOutside = nodeContext.portLabelsPlacement == PortLabelPlacement.OUTSIDE;
-        boolean spaceEfficientPortLabels = nodeContext.sizeOptions.contains(SizeOptions.SPACE_EFFICIENT_PORT_LABELS)
+        boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
+        boolean spaceEfficientPortLabels = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
                 || portContexts.size() == 2;
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
         

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/InsidePortLabelCellCreator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/InsidePortLabelCellCreator.java
@@ -100,7 +100,7 @@ public final class InsidePortLabelCellCreator {
      * Does the work for {@link #calculatePortLabelWidth(NodeContext)} for the given port side.
      */
     private static void setupEastOrWestPortLabelCell(final NodeContext nodeContext, final PortSide portSide) {
-        if (nodeContext.portLabelsPlacement == PortLabelPlacement.INSIDE) {
+        if (nodeContext.portLabelsPlacement.contains(PortLabelPlacement.INSIDE)) {
             calculateWidthDueToLabels(nodeContext, portSide);   
         }
         setupTopAndBottomPadding(nodeContext, portSide);

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
@@ -204,8 +204,11 @@ public final class NodeLabelAndSizeUtilities {
      * Outside ports usually have their labels placed below or to the right. The first port, however, may have its label
      * placed on the other side. This is true if several conditions apply:
      * <ul>
-     *   <li>The port actually wants its label to be placed next to it.</li>
-     *   <li>There are only two ports or space-efficient port label placement is turned on.</li>
+     *   <li>The port does <b>not</b> want its label to be placed next to it (see
+     *       {@link PortLabelPlacement#NEXT_TO_PORT_IF_POSSIBLE}.</li>
+     *   <li>{@link PortLabelPlacement#ALWAYS_SAME_SIDE} is <b>not</b> set.</li>
+     *   <li>There are only two ports or space-efficient port label placement is turned on (see
+     *       {@link PortLabelPlacement#SPACE_EFFICIENT}).</li>
      * </ul>
      */
     public static boolean isFirstOutsidePortLabelPlacedDifferently(final NodeContext nodeContext,
@@ -215,8 +218,12 @@ public final class NodeLabelAndSizeUtilities {
         if (portContexts.size() >= 2) {
             PortContext firstPort = portContexts.iterator().next();
             
-            return !firstPort.labelsNextToPort && (portContexts.size() == 2
-                    || nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT));
+            final boolean alwaysSameSide =
+                    nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE);
+            final boolean spaceEfficient = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT);
+
+            return !firstPort.labelsNextToPort && !alwaysSameSide 
+                    && (portContexts.size() == 2 || spaceEfficient);
         } else {
             return false;
         }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
@@ -18,6 +18,7 @@ import org.eclipse.elk.core.math.ElkPadding;
 import org.eclipse.elk.core.math.ElkRectangle;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.PortLabelPlacement;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.options.SizeConstraint;
 import org.eclipse.elk.core.options.SizeOptions;
@@ -215,7 +216,7 @@ public final class NodeLabelAndSizeUtilities {
             PortContext firstPort = portContexts.iterator().next();
             
             return !firstPort.labelsNextToPort && (portContexts.size() == 2
-                    || nodeContext.sizeOptions.contains(SizeOptions.SPACE_EFFICIENT_PORT_LABELS));
+                    || nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT));
         } else {
             return false;
         }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortContextCreator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortContextCreator.java
@@ -36,9 +36,10 @@ public final class PortContextCreator {
      * @param nodeContext
      */
     public static void createPortContexts(final NodeContext nodeContext, final boolean ignoreInsidePortLabels) {
-        // Hue hue hue...
-        boolean imPortLabels = !ignoreInsidePortLabels || nodeContext.portLabelsPlacement != PortLabelPlacement.INSIDE;
-        
+        // Hue hue hue... gimme color?
+        boolean imPortLabels =
+                !ignoreInsidePortLabels || !nodeContext.portLabelsPlacement.contains(PortLabelPlacement.INSIDE);
+
         int volatileId = 0;
         for (PortAdapter<?> port : nodeContext.node.getPorts()) {
             if (port.getSide() == PortSide.UNDEFINED) {
@@ -61,7 +62,7 @@ public final class PortContextCreator {
         nodeContext.portContexts.put(port.getSide(), portContext);
         
         // If the port has labels and if port labels are to be placed, we need to remember them
-        if (imPortLabels && nodeContext.portLabelsPlacement != PortLabelPlacement.FIXED) {
+        if (imPortLabels && !PortLabelPlacement.isFixed(nodeContext.portLabelsPlacement)) {
             portContext.portLabelCell = new LabelCell(nodeContext.labelLabelSpacing);
             port.getLabels().forEach(label -> portContext.portLabelCell.addLabel(label));
         }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
@@ -24,6 +24,7 @@ import org.eclipse.elk.core.math.ElkRectangle;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.options.PortConstraints;
+import org.eclipse.elk.core.options.PortLabelPlacement;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.options.SizeConstraint;
 import org.eclipse.elk.core.options.SizeOptions;
@@ -66,26 +67,21 @@ public final class PortLabelPlacementCalculator {
         // fixed positions, we don't have an arbitrary amount of freedom to place our labels
         boolean constrainedPlacement = !nodeContext.sizeConstraints.contains(SizeConstraint.PORT_LABELS)
                 || nodeContext.portConstraints == PortConstraints.FIXED_POS;
-        
-        switch (nodeContext.portLabelsPlacement) {
-        case INSIDE:
+
+        if (nodeContext.portLabelsPlacement.contains(PortLabelPlacement.INSIDE)) {
             if (constrainedPlacement) {
                 constrainedInsidePortLabelPlacement(nodeContext, portSide);
             } else {
                 simpleInsidePortLabelPlacement(nodeContext, portSide);
             }
-            break;
-            
-        case OUTSIDE:
+        } else if (nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE)) {
             if (constrainedPlacement) {
                 constrainedOutsidePortLabelPlacement(nodeContext, portSide);
             } else {
                 simpleOutsidePortLabelPlacement(nodeContext, portSide);
             }
-            break;
         }
     }
-    
     
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Simple Inside Port Labels
@@ -463,8 +459,8 @@ public final class PortLabelPlacementCalculator {
         
         // If space-efficient port labels are active, the leftmost / topmost port's label must be placed to its left /
         // above it
-        boolean portWithSpecialNeeds = nodeContext.sizeOptions.contains(SizeOptions.SPACE_EFFICIENT_PORT_LABELS);
-        
+        boolean portWithSpecialNeeds = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT);
+
         // Prepare things
         OverlapRemovalDirection overlapRemovalDirection = portSide == PortSide.NORTH
                 ? OverlapRemovalDirection.UP

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
@@ -110,7 +110,7 @@ public final class VerticalPortPlacementSizeCalculator {
             return;
         }
 
-        boolean portLabelsInside = nodeContext.portLabelsPlacement == PortLabelPlacement.INSIDE;
+        boolean portLabelsInside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.INSIDE);
         double minHeight = 0;
         
         // If port labels are to be respected, we need to calculate the port's margins to do so (we ignore the
@@ -230,12 +230,12 @@ public final class VerticalPortPlacementSizeCalculator {
      */
     private static void setupPortMargins(final NodeContext nodeContext, final PortSide portSide) {
         Collection<PortContext> portContexts = nodeContext.portContexts.get(portSide);
-        
-        boolean portLabelsOutside = nodeContext.portLabelsPlacement == PortLabelPlacement.OUTSIDE;
-        boolean spaceEfficientPortLabels = nodeContext.sizeOptions.contains(SizeOptions.SPACE_EFFICIENT_PORT_LABELS)
+
+        boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
+        boolean spaceEfficientPortLabels = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
                 || portContexts.size() == 2;
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
-        
+
         // Set the vertical port margins of all ports according to how their labels will be placed. We'll be
         // modifying the margins soon enough.
         computeVerticalPortMargins(nodeContext, portSide, portLabelsOutside);

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
@@ -232,11 +232,11 @@ public final class VerticalPortPlacementSizeCalculator {
         Collection<PortContext> portContexts = nodeContext.portContexts.get(portSide);
 
         boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
-        boolean spaceEfficientPortLabels =
-                !nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE)
-                        && (nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
-                                || portContexts.size() == 2);
+        boolean alwaysSameSide = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE);
+        boolean spaceEfficient = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT);
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
+
+        boolean spaceEfficientPortLabels = !alwaysSameSide && (spaceEfficient || portContexts.size() == 2);
 
         // Set the vertical port margins of all ports according to how their labels will be placed. We'll be
         // modifying the margins soon enough.

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
@@ -232,8 +232,10 @@ public final class VerticalPortPlacementSizeCalculator {
         Collection<PortContext> portContexts = nodeContext.portContexts.get(portSide);
 
         boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
-        boolean spaceEfficientPortLabels = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
-                || portContexts.size() == 2;
+        boolean spaceEfficientPortLabels =
+                !nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE)
+                        && (nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT)
+                                || portContexts.size() == 2);
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
 
         // Set the vertical port margins of all ports according to how their labels will be placed. We'll be

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
@@ -169,8 +169,8 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
                     // We need the port constraints to position external ports (Issues KIPRA-1528, ELK-48) 
                     PortConstraints portConstraints = node.getProperty(LayeredOptions.PORT_CONSTRAINTS);
                     boolean insidePortLabels =
-                            node.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT) == PortLabelPlacement.INSIDE;
-                    
+                            node.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT).contains(PortLabelPlacement.INSIDE);
+
                     for (LPort port : node.getPorts()) {
                         // Make sure that every port has a dummy node created for it
                         LNode dummyNode = dummyNodeMap.get(port);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -534,8 +534,8 @@ class ElkGraphImporter {
      */
     private void checkExternalPorts(final ElkNode elkgraph, final Set<GraphProperties> graphProperties) {
         final boolean enableSelfLoops = elkgraph.getProperty(LayeredOptions.INSIDE_SELF_LOOPS_ACTIVATE);
-        final PortLabelPlacement portLabelPlacement = elkgraph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT);
-        
+        final Set<PortLabelPlacement> portLabelPlacement = elkgraph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT);
+
         // We're iterating over the ports until we've determined that we have both external ports and
         // hyperedges, or if there are no more ports left
         boolean hasExternalPorts = false;
@@ -567,7 +567,7 @@ class ElkGraphImporter {
             // External ports?
             if (externalPortEdges > 0) {
                 hasExternalPorts = true;
-            } else if (portLabelPlacement == PortLabelPlacement.INSIDE && elkport.getLabels().size() > 0) {
+            } else if (portLabelPlacement.contains(PortLabelPlacement.INSIDE) && elkport.getLabels().size() > 0) {
                 hasExternalPorts = true;
             }
             
@@ -632,7 +632,7 @@ class ElkGraphImporter {
         // The dummy only has one port
         LPort dummyPort = dummy.getPorts().get(0);
         dummyPort.setConnectedToExternalNodes(isConnectedToExternalNodes(elkport));
-        dummy.setProperty(LayeredOptions.PORT_LABELS_PLACEMENT, PortLabelPlacement.OUTSIDE);
+        dummy.setProperty(LayeredOptions.PORT_LABELS_PLACEMENT, PortLabelPlacement.outside());
         
         // If the compound node wants to have its port labels placed on the inside, we need to leave
         // enough space for them by creating an LLabel for the KLabels. If the compound node wants to
@@ -641,8 +641,8 @@ class ElkGraphImporter {
         // space inside. Thus, for east and west ports, we reduce the label width to zero, otherwise
         // we reduce the label height to zero
         boolean insidePortLabels =
-                elkgraph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT) == PortLabelPlacement.INSIDE;
-        
+                elkgraph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT).contains(PortLabelPlacement.INSIDE);
+
         // Transform all of the port's labels
         for (ElkLabel elklabel : elkport.getLabels()) {
             if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !Strings.isNullOrEmpty(elklabel.getText())) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
@@ -198,7 +198,7 @@ class ElkGraphLayoutTransferrer {
         }
         
         // Set port label positions, if they were not fixed
-        if (lnode.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT) != PortLabelPlacement.FIXED) {
+        if (!PortLabelPlacement.isFixed(lnode.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT))) {
             for (LPort lport : lnode.getPorts()) {
                 for (LLabel llabel : lport.getLabels()) {
                     ElkLabel elklabel = (ElkLabel) llabel.getProperty(InternalProperties.ORIGIN);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
@@ -218,8 +218,8 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
             double portLabelSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT);
             double labelLabelSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_LABEL);
             
-            PortLabelPlacement portLabelPlacement = graph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT);
-            if (portLabelPlacement == PortLabelPlacement.INSIDE) {
+            Set<PortLabelPlacement> portLabelPlacement = graph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT);
+            if (portLabelPlacement.contains(PortLabelPlacement.INSIDE)) {
                 double currentY = portLabelSpacing;
                 double xCenterRelativeToPort = dummy.getSize().x / 2 - dummyPort.getPosition().x;
                 
@@ -230,7 +230,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
                     currentY += label.getSize().y + labelLabelSpacing;
                 }
                 
-            } else if (portLabelPlacement == PortLabelPlacement.OUTSIDE) {
+            } else if (portLabelPlacement.contains(PortLabelPlacement.OUTSIDE)) {
                 // Port labels have a vertical size of 0, but we need to set their x coordinate
                 for (LLabel label : dummyPort.getLabels()) {
                     label.getPosition().x = portLabelSpacing + dummy.getSize().x - dummyPort.getPosition().x;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelAndNodeSizeProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelAndNodeSizeProcessor.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.intermediate;
 
+import java.util.Set;
+
 import org.eclipse.elk.alg.common.nodespacing.NodeDimensionCalculation;
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LGraphAdapters;
@@ -67,8 +69,8 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
         // If the graph has external ports, we need to treat labels of external port dummies a bit differently,
         // which is the reason why we haven't handed them to the label and node size processing code
         if (layeredGraph.getProperty(InternalProperties.GRAPH_PROPERTIES).contains(GraphProperties.EXTERNAL_PORTS)) {
-            PortLabelPlacement portLabelPlacement = layeredGraph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT);
-            boolean placeNextToPort = layeredGraph.getProperty(LayeredOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE);
+            Set<PortLabelPlacement> portLabelPlacement = layeredGraph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT);
+            boolean placeNextToPort = portLabelPlacement.contains(PortLabelPlacement.NEXT_TO_PORT_IF_POSSIBLE);
             boolean treatAsGroup = layeredGraph.getProperty(LayeredOptions.PORT_LABELS_TREAT_AS_GROUP);
             
             for (Layer layer : layeredGraph.getLayers()) {
@@ -86,9 +88,9 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
      * Places the labels of the given external port dummy such that it results in correct node margins later on that
      * will reserve enough space for the labels to be placed once label and node placement is called on the graph.
      */
-    private void placeExternalPortDummyLabels(final LNode dummy, final PortLabelPlacement graphPortLabelPlacement,
+    private void placeExternalPortDummyLabels(final LNode dummy, final Set<PortLabelPlacement> graphPortLabelPlacement,
             final boolean placeNextToPortIfPossible, final boolean treatAsGroup) {
-        
+    
         double labelPortSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT);
         double labelLabelSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_LABEL);
         
@@ -105,7 +107,7 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
         
         // Determine the position of the box
         // TODO We could handle FIXED here as well
-        if (graphPortLabelPlacement == PortLabelPlacement.INSIDE) {
+        if (graphPortLabelPlacement.contains(PortLabelPlacement.INSIDE)) {
             // (port label placement has to support this case first, though)
             switch (dummy.getProperty(InternalProperties.EXT_PORT_SIDE)) {
             case NORTH:
@@ -142,7 +144,7 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
                 portLabelBox.x = labelPortSpacing;
                 break;
             }
-        } else if (graphPortLabelPlacement == PortLabelPlacement.OUTSIDE) {
+        } else if (graphPortLabelPlacement.contains(PortLabelPlacement.OUTSIDE)) {
             switch (dummy.getProperty(InternalProperties.EXT_PORT_SIDE)) {
             case NORTH:
             case SOUTH:

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -734,7 +734,6 @@ group portLabels {
         targets nodes
     }
 
-    // TODO where to add the deprecated thingy? both graph import in layered and in common label placement?
     deprecated option nextToPortIfPossible: boolean {
         label "Port Labels Next to Port"
         description

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -725,22 +725,20 @@ group port {
 // --- PORT LABELS
 group portLabels {
 
-    option placement: PortLabelPlacement {
+    option placement: EnumSet<PortLabelPlacement> {
         label "Port Label Placement"
         description
-            "Decides on a placement method for port labels."
-        default = PortLabelPlacement.OUTSIDE
+            "Decides on a placement method for port labels; if empty, the node label's position is not
+            modified."
+        default = PortLabelPlacement.outside
         targets nodes
     }
 
-    option nextToPortIfPossible: boolean {
+    // TODO where to add the deprecated thingy? both graph import in layered and in common label placement?
+    deprecated option nextToPortIfPossible: boolean {
         label "Port Labels Next to Port"
         description
-            "Usually, inside port labels of hierarchical nodes are placed not next to their port,
-           but with an offset to avoid edge-label crossings. The offset is not necessary if the
-           port has no connections that would cross the label, but is usually applied anyway to
-           keep things uniform. Setting this option to true places labels next to their ports if
-           they won't be crossed by edges."
+            "Use 'portLabels.placement': NEXT_TO_PORT_OF_POSSIBLE."
         default = false
         targets nodes
     }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 
+import org.eclipse.elk.core.data.DeprecatedLayoutOptionReplacer;
 import org.eclipse.elk.core.data.LayoutAlgorithmData;
 import org.eclipse.elk.core.data.LayoutAlgorithmResolver;
 import org.eclipse.elk.core.options.CoreOptions;
@@ -84,6 +85,8 @@ public class RecursiveGraphLayoutEngine implements IGraphLayoutEngine {
         int nodeCount = countNodesRecursively(layoutGraph, true);
         progressMonitor.begin("Recursive Graph Layout", nodeCount);
         
+        ElkUtil.applyVisitors(layoutGraph, new DeprecatedLayoutOptionReplacer());
+
         if (!layoutGraph.hasProperty(CoreOptions.RESOLVED_ALGORITHM)) {
             // Apply the default algorithm resolver to the graph in order to obtain algorithm meta data
             ElkUtil.applyVisitors(layoutGraph, new LayoutAlgorithmResolver());

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacer.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacer.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0  
+ *******************************************************************************/
+package org.eclipse.elk.core.data;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.PortLabelPlacement;
+import org.eclipse.elk.core.options.SizeOptions;
+import org.eclipse.elk.core.util.IGraphElementVisitor;
+import org.eclipse.elk.graph.ElkGraphElement;
+import org.eclipse.elk.graph.properties.IProperty;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Replaces (and removes) any deprecated layout options from {@link CoreOptions} with a corresponding new layout option
+ * (or whatever is required to reconstruct the old behavior).
+ */
+public class DeprecatedLayoutOptionReplacer implements IGraphElementVisitor {
+
+    /**
+     * Rule to replace {@link CoreOptions#PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE}.
+     */
+    @SuppressWarnings("deprecation")
+    private static final Consumer<ElkGraphElement> NEXT_TO_PORT_IF_POSSIBLE = (e) -> {
+        e.getProperty(CoreOptions.PORT_LABELS_PLACEMENT).add(PortLabelPlacement.NEXT_TO_PORT_IF_POSSIBLE);
+        e.setProperty(CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE, null);
+    };
+
+    /**
+     * Rule to move the deprecated enum value {@link SizeOptions#SPACE_EFFICIENT_PORT_LABELS} to
+     * {@link PortLabelPlacement}.
+     */
+    @SuppressWarnings("deprecation")
+    private static final Consumer<ElkGraphElement> SPACE_EFFICIENT = (e) -> {
+        if (e.getProperty(CoreOptions.NODE_SIZE_OPTIONS).contains(SizeOptions.SPACE_EFFICIENT_PORT_LABELS)) {
+            e.getProperty(CoreOptions.PORT_LABELS_PLACEMENT).add(PortLabelPlacement.SPACE_EFFICIENT);
+            e.getProperty(CoreOptions.NODE_SIZE_OPTIONS).remove(SizeOptions.SPACE_EFFICIENT_PORT_LABELS);
+        }
+    };
+
+    /**
+     * Mapping of deprecated layout options to replacing rules.
+     */
+    @SuppressWarnings("deprecation")
+    public static final Map<IProperty<?>, Consumer<ElkGraphElement>> RULES =
+            ImmutableMap.of(
+                CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE, NEXT_TO_PORT_IF_POSSIBLE,
+                CoreOptions.NODE_SIZE_OPTIONS, SPACE_EFFICIENT
+            );
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void visit(final ElkGraphElement element) {
+        RULES.forEach((option, replacer) -> {
+            if (element.hasProperty(option)) {
+                replacer.accept(element);
+                // Note that the option is _not_ removed here. The replacer has to take care of it;
+                // It depends on the concrete layout option whether it should be removed or not.
+            }
+        });
+    }
+
+}

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/NodeLabelPlacement.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/NodeLabelPlacement.java
@@ -10,6 +10,9 @@
 package org.eclipse.elk.core.options;
 
 import java.util.EnumSet;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 
 /**
  * Options for controlling how node labels are placed by layout algorithms. The corresponding layout
@@ -240,5 +243,31 @@ public enum NodeLabelPlacement {
      */
     public static EnumSet<NodeLabelPlacement> outsideBottomRight() {
         return EnumSet.of(OUTSIDE, V_BOTTOM, H_RIGHT);
+    }
+    
+    
+    /**
+     * @return whether the passed {@value placement} is considered valid as described in the class's javadoc.
+     */
+    public static boolean isValid(final Set<NodeLabelPlacement> placement) {
+        final Set<NodeLabelPlacement> validInsideOutside =
+                EnumSet.of(NodeLabelPlacement.INSIDE, NodeLabelPlacement.OUTSIDE);
+        if (Sets.intersection(validInsideOutside, placement).size() > 1) {
+            return false;
+        }
+
+        final Set<NodeLabelPlacement> validHorizontal =
+                EnumSet.of(NodeLabelPlacement.H_LEFT, NodeLabelPlacement.H_CENTER, NodeLabelPlacement.H_RIGHT);
+        if (Sets.intersection(validHorizontal, placement).size() > 1) {
+            return false;
+        }
+
+        final Set<NodeLabelPlacement> validVertical =
+                EnumSet.of(NodeLabelPlacement.V_TOP, NodeLabelPlacement.V_CENTER, NodeLabelPlacement.V_BOTTOM);
+        if (Sets.intersection(validVertical, placement).size() > 1) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 Kiel University and others.
+ * Copyright (c) 2012, 2020 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,19 +9,93 @@
  *******************************************************************************/
 package org.eclipse.elk.core.options;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
- * Definition of port label placement strategies. The chosen strategy determines whether port
- * labels are placed inside or outside of the respective node.
- *
- * @author jjc
+ * Options for controlling how port labels are placed by layout algorithms. The corresponding layout
+ * option will usually accept an {@link EnumSet} over this enumeration, theoretically allowing
+ * arbitrary and even contradictory subsets of options to be set. Note that you are restricted to
+ * the following combinations if you want your choice to make sense:
+ * <ul>
+ *   <li>Exactly one of the {@link #INSIDE} and {@link #OUTSIDE} options (if neither is set, 
+ *       label positions are not computed but left untouched).</li>
+ *   <li>Exactly one of the {@link #ALWAYS_SAME_SIDE}, {@link #SPACE_EFFICIENT} options.</li>
+ * </ul>
+ * 
+ * Additionally {@link #NEXT_TO_PORT_IF_POSSIBLE} can be used to indicate that, if possible, 
+ * a label should be placed center-aligned with the corresponding port. 
+ * 
+ * <p><b>This enumeration is not set directly on {@link CoreOptions#PORT_LABELS_PLACEMENT}; instead,
+ * an {@code EnumSet} over this enumeration is used there.</b></p>
+ * 
+ * <p><i>Note:</i> Layout algorithms may only support a subset of these options.</p>
  */
 public enum PortLabelPlacement {
-    
-    /** Port labels are placed outside of the node, beside the edge. */
-    OUTSIDE,
-    /** Port labels are placed inside of the node, next to the port. */
-    INSIDE,
-    /** Port labels are left on the position the user chose. */
-    FIXED;
 
+    /** Port labels are placed outside of the node. */
+    OUTSIDE,
+
+    /** Port labels are placed inside of the node. */
+    INSIDE,
+
+    /**
+     * Not in all cases port labels are placed <i>next to</i> the port (that is, center-aligned). This option can be set
+     * to direct the layout algorithm to place the label next to the port if no edge would cross the label.
+     * 
+     * Cases in which this behavior is not the default:
+     * <ul>
+     *   <li>Outside labels of both hierarchical and non-hierarchical nodes,</li>
+     *   <li>Inside labels of hierarchical nodes.</li>
+     * </ul>
+     * 
+     * Cases in which the behavior is the default anyway:
+     * <ul>
+     *   <li>Inside labels of non-hierarchical nodes.</li>
+     * </ul>
+     */
+    NEXT_TO_PORT_IF_POSSIBLE,
+
+    /**
+     * The port labels shall always be placed on the same side relative to their corresponding port. For
+     * {@link PortSide#WEST} and {@link PortSide#EAST} this is <i>below</i> the port and for {@link PortSide#NORTH} and
+     * {@link PortSide#SOUTH} it is <i>right</i> of the port.
+     * 
+     * Note: the option does not apply to inside port labels.
+     */
+    ALWAYS_SAME_SIDE,
+
+    /**
+     * Unless there are exactly two ports at a given port side, outside port labels are usually all placed to the same
+     * side of their port. For example, if there are three northern ports, all of their labels will be placed to the
+     * right of their ports. If this option is active, the leftmost label will be placed to the left of its port while
+     * the others stay on the right side (and similar for the other port sides). This allows the node to be smaller
+     * because the node size doesn't have to accommodate as many port labels, but it breaks symmetry.
+     * 
+     * Note: the option does not apply to inside port labels.
+     */
+    SPACE_EFFICIENT;
+
+    /**
+     * @return a set of {@link PortLabelPlacement} enum values indicating fixed port label positions.
+     */
+    public static EnumSet<PortLabelPlacement> fixed() {
+        return EnumSet.noneOf(PortLabelPlacement.class);
+    }
+
+    /**
+     * @return a set of {@link PortLabelPlacement} enum values indicating default outside port label positions.
+     */
+    public static EnumSet<PortLabelPlacement> outside() {
+        return EnumSet.of(PortLabelPlacement.OUTSIDE);
+    }
+
+    /**
+     * @return whether the passed placement represents a fixed port label placement, i.e. whether neither
+     *         {@link #INSIDE} nor {@link #OUTSIDE} are included.
+     */
+    public static boolean isFixed(final Set<PortLabelPlacement> placement) {
+        return !placement.contains(PortLabelPlacement.INSIDE) && !placement.contains(PortLabelPlacement.OUTSIDE);
+    }
 }
+

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
@@ -12,6 +12,8 @@ package org.eclipse.elk.core.options;
 import java.util.EnumSet;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
+
 /**
  * Options for controlling how port labels are placed by layout algorithms. The corresponding layout
  * option will usually accept an {@link EnumSet} over this enumeration, theoretically allowing
@@ -61,7 +63,8 @@ public enum PortLabelPlacement {
      * {@link PortSide#WEST} and {@link PortSide#EAST} this is <i>below</i> the port and for {@link PortSide#NORTH} and
      * {@link PortSide#SOUTH} it is <i>right</i> of the port.
      * 
-     * Note: the option does not apply to inside port labels.
+     * <p>
+     * Note: the option does not apply to inside port labels (unless a hierarchical edge connects).
      */
     ALWAYS_SAME_SIDE,
 
@@ -72,7 +75,8 @@ public enum PortLabelPlacement {
      * the others stay on the right side (and similar for the other port sides). This allows the node to be smaller
      * because the node size doesn't have to accommodate as many port labels, but it breaks symmetry.
      * 
-     * Note: the option does not apply to inside port labels.
+     * <p>
+     * Note: the option does not apply to inside port labels (unless a hierarchical edge connects).
      */
     SPACE_EFFICIENT;
 
@@ -96,6 +100,25 @@ public enum PortLabelPlacement {
      */
     public static boolean isFixed(final Set<PortLabelPlacement> placement) {
         return !placement.contains(PortLabelPlacement.INSIDE) && !placement.contains(PortLabelPlacement.OUTSIDE);
+    }
+    
+    /**
+     * @return whether the passed {@value placement} is considered valid as described in the class's javadoc.
+     */
+    public static boolean isValid(final Set<PortLabelPlacement> placement) {
+        final Set<PortLabelPlacement> validInsideOutside =
+                EnumSet.of(PortLabelPlacement.INSIDE, PortLabelPlacement.OUTSIDE);
+        if (Sets.intersection(validInsideOutside, placement).size() > 1) {
+            return false;
+        }
+
+        final Set<PortLabelPlacement> validPosition =
+                EnumSet.of(PortLabelPlacement.ALWAYS_SAME_SIDE, PortLabelPlacement.SPACE_EFFICIENT);
+        if (Sets.intersection(validPosition, placement).size() > 1) {
+            return false;
+        }
+
+        return true;
     }
 }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/SizeOptions.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/SizeOptions.java
@@ -63,16 +63,13 @@ public enum SizeOptions {
      * between every pair of ports to the largest amount of space between any pair of ports.
      */
     UNIFORM_PORT_SPACING,
-    
+
     /**
-     * Unless there are exactly two ports at a given port side, outside port labels are usually all placed to the same
-     * side of their port. For example, if there are three northern ports, all of their labels will be placed to the
-     * right of their ports. If this option is active, the leftmost label will be placed to the left of its port while
-     * the others stay on the right side (and similar for the other port sides). This allows the node to be smaller
-     * because the node size doesn't have to accommodate as many port labels, but it breaks symmetry.
+     * @deprecated Use {@link PortLabelPlacement#SPACE_EFFICIENT}.
      */
+    @Deprecated
     SPACE_EFFICIENT_PORT_LABELS,
-    
+
     /**
      * By default, inside node labels will be laid out in three rows of three cells, with no relation between the
      * width of cells in different rows. If this option is enabled, the cells will be treated as cells of a table,

--- a/test/org.eclipse.elk.alg.common.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.common.test/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Require-Bundle: com.google.guava;bundle-version="15.0.0",
  org.eclipse.elk.alg.layered,
  org.eclipse.elk.alg.test,
  org.eclipse.elk.graph,
- org.junit;bundle-version="4.12.0"
+ org.junit;bundle-version="4.12.0",
+ org.hamcrest.library

--- a/test/org.eclipse.elk.alg.common.test/src/org/eclipse/elk/alg/common/nodespacing/NextToPortLabelPlacementTest.java
+++ b/test/org.eclipse.elk.alg.common.test/src/org/eclipse/elk/alg/common/nodespacing/NextToPortLabelPlacementTest.java
@@ -63,7 +63,7 @@ public class NextToPortLabelPlacementTest {
             nodeQueue.addAll(currentNode.getChildren());
             
             boolean insideLabelPlacement =
-                    currentNode.getProperty(CoreOptions.PORT_LABELS_PLACEMENT) == PortLabelPlacement.INSIDE;
+                    currentNode.getProperty(CoreOptions.PORT_LABELS_PLACEMENT).contains(PortLabelPlacement.INSIDE);
             for (ElkPort port : currentNode.getPorts()) {
                 testPortLabel(port, insideLabelPlacement);
             }

--- a/test/org.eclipse.elk.alg.common.test/src/org/eclipse/elk/alg/common/nodespacing/PortLabelPlacementVariantsTest.java
+++ b/test/org.eclipse.elk.alg.common.test/src/org/eclipse/elk/alg/common/nodespacing/PortLabelPlacementVariantsTest.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.common.nodespacing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.test.framework.LayoutTestRunner;
+import org.eclipse.elk.alg.test.framework.annotations.Algorithm;
+import org.eclipse.elk.alg.test.framework.annotations.ConfiguratorProvider;
+import org.eclipse.elk.alg.test.framework.annotations.DefaultConfiguration;
+import org.eclipse.elk.alg.test.framework.annotations.GraphResourceProvider;
+import org.eclipse.elk.alg.test.framework.io.AbstractResourcePath;
+import org.eclipse.elk.alg.test.framework.io.ModelResourcePath;
+import org.eclipse.elk.core.LayoutConfigurator;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.PortLabelPlacement;
+import org.eclipse.elk.core.options.PortSide;
+import org.eclipse.elk.graph.ElkLabel;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.ElkPort;
+import org.eclipse.emf.common.util.ECollections;
+import org.hamcrest.number.OrderingComparison;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Tests the various variants of port label placement that are configurable using {@link PortLabelPlacement}.
+ */
+@RunWith(LayoutTestRunner.class)
+@Algorithm(LayeredOptions.ALGORITHM_ID)
+@DefaultConfiguration(nodes = true, ports = true)
+public class PortLabelPlacementVariantsTest {
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Sources
+
+    @GraphResourceProvider
+    public List<AbstractResourcePath> testGraphs() {
+        return Lists.newArrayList(
+                new ModelResourcePath("tests/core/label_placement/port_labels/variants.elkt"));
+    }
+    
+    @ConfiguratorProvider
+    public LayoutConfigurator westSidePorts() {
+        return configuratorFor(PortSide.WEST);
+    }
+
+    // TODO activate if behavior for NORTH/SOUTH is consistent
+    // @ConfiguratorProvider
+    // public LayoutConfigurator northSidePort() {
+    // return configuratorFor(PortSide.NORTH);
+    // }
+    
+    @ConfiguratorProvider
+    public LayoutConfigurator eastSidePorts() {
+        return configuratorFor(PortSide.EAST);
+    }
+    
+    // TODO activate if behavior for NORTH/SOUTH is consistent
+    // @ConfiguratorProvider
+    // public LayoutConfigurator southSidePorts() {
+    // return configuratorFor(PortSide.SOUTH);
+    // }
+
+    private LayoutConfigurator configuratorFor(final PortSide ps) {
+        LayoutConfigurator config = new LayoutConfigurator();
+        // By default this would override already set options
+        config.configure(ElkPort.class).setProperty(LayeredOptions.PORT_SIDE, ps);
+        return config;
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Tests
+    
+    /* - - -  OUTSIDE - - -  */
+    
+    @Test
+    public void testOutsideTwoDefault(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "outside_two_default");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        assertBelowOrRight(ports.get(0));
+        assertAboveOrLeft(ports.get(1));
+    }
+    
+    @Test
+    public void testOutsideTwoSameSide(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "outside_two_same_side");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        assertBelowOrRight(ports.get(0));
+        assertBelowOrRight(ports.get(1));
+    }
+    
+    @Test
+    public void testOutsideTwoNextToPort(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "outside_two_next_to_port");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        assertCentered(ports.get(0));
+        assertCentered(ports.get(1));
+    }
+    
+    @Test
+    public void testOutsideThreeDefault(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "outside_three_default");
+        assertEquals("Unexpected test graph", 3, ports.size());
+        assertBelowOrRight(ports.get(0));
+        assertBelowOrRight(ports.get(1));
+        assertBelowOrRight(ports.get(2));
+    }
+    
+    @Test
+    public void testOutsideThreeSpaceEfficient(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "outside_three_space_efficient");
+        assertEquals("Unexpected test graph", 3, ports.size());
+        assertBelowOrRight(ports.get(0));
+        assertBelowOrRight(ports.get(1));
+        assertAboveOrLeft(ports.get(2));
+    }
+    
+    /* - - -  INSIDE - - -  */
+    
+    @Test
+    public void testInsideTwoDefault(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "inside_two_default");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        assertCentered(ports.get(0));
+        assertCentered(ports.get(1));
+    }
+
+    @Test
+    public void testInsideTwoDefaultHierarchical(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "inside_two_default_hierarchical");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        assertBelowOrRight(ports.get(0));
+        assertBelowOrRight(ports.get(1));
+    }
+
+    @Test
+    public void testInsideTwoNextToPortHierarchical(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "inside_two_next_to_port_hierarchical");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        assertCentered(ports.get(0));
+        assertCentered(ports.get(1));
+    }
+
+    @Test
+    public void testInsideTwoWithOneEdge(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "inside_two_with_one_edge");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        assertBelowOrRight(ports.get(0));
+        assertBelowOrRight(ports.get(1));
+    }
+    
+    @Test
+    public void testInsideTwoWithOneEdgeNextToPort(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "inside_two_with_one_edge_next_to_port");
+        assertEquals("Unexpected test graph", 2, ports.size());
+        // Unfortunately this test is not symmetric
+        ElkPort portWithEdge = ports.get(0).getOutgoingEdges().isEmpty() ? ports.get(1) : ports.get(0);
+        ElkPort theOther = ports.get(0).getOutgoingEdges().isEmpty() ? ports.get(0) : ports.get(1);
+        assertBelowOrRight(portWithEdge);
+        assertCentered(theOther);
+    }
+    
+    @Test
+    public void testInsideThreeWithOneEdge(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "inside_three_with_one_edge");
+        assertEquals("Unexpected test graph", 3, ports.size());
+        assertBelowOrRight(ports.get(0));
+        assertBelowOrRight(ports.get(1));
+        assertBelowOrRight(ports.get(2));
+    }
+    
+    @Test
+    public void testInsideThreeWithOneEdgeNextToPort(final ElkNode graph) {
+        List<ElkPort> ports = getPortsOfNode(graph, "inside_three_with_one_edge_next_to_port");
+        assertEquals("Unexpected test graph", 3, ports.size());
+        assertCentered(ports.get(0));
+        assertBelowOrRight(ports.get(1));
+        assertCentered(ports.get(2));
+    }
+    
+    /* - - - Checks and utility - - - */
+    
+    private void assertBelowOrRight(final ElkPort port) {
+        final ElkLabel label = getLabel(port);
+        // Note that port label positions are relative to the port
+        double portPosition = 0;
+        if (PortSide.SIDES_EAST_WEST.contains(port.getProperty(CoreOptions.PORT_SIDE))) {
+            portPosition = label.getY();
+        } else if (PortSide.SIDES_NORTH_SOUTH.contains(port.getProperty(CoreOptions.PORT_SIDE))) {
+            portPosition = label.getX();
+        } else {
+            assertTrue(false);
+        }
+        assertThat(portPosition, OrderingComparison.greaterThan(0.0));
+    }
+
+    private void assertAboveOrLeft(final ElkPort port) {
+        final ElkLabel label = getLabel(port);
+        // Note that port label positions are relative to the port
+        double portPosition = 0;
+        if (PortSide.SIDES_EAST_WEST.contains(port.getProperty(CoreOptions.PORT_SIDE))) {
+            portPosition = label.getY();
+        } else if (PortSide.SIDES_NORTH_SOUTH.contains(port.getProperty(CoreOptions.PORT_SIDE))) {
+            portPosition = label.getX();
+        } else {
+            assertTrue(false);
+        }
+        assertThat(portPosition, OrderingComparison.lessThan(0.0));
+    }
+    
+    private void assertCentered(final ElkPort port) {
+        final ElkLabel label = getLabel(port);
+        if (PortSide.SIDES_EAST_WEST.contains(port.getProperty(CoreOptions.PORT_SIDE))) {
+            final double portCenter = port.getHeight() / 2.0;
+            final double labelCenter = label.getY() + label.getHeight() / 2.0;
+            assertThat(labelCenter, OrderingComparison.comparesEqualTo(portCenter));
+        } else if (PortSide.SIDES_NORTH_SOUTH.contains(port.getProperty(CoreOptions.PORT_SIDE))) {
+            final double portCenter = port.getWidth() / 2.0;
+            final double labelCenter = label.getX() + label.getWidth() / 2.0;
+            assertThat(labelCenter, OrderingComparison.comparesEqualTo(portCenter));
+        } else {
+            assertTrue(false);
+        }
+    }
+
+    private ElkLabel getLabel(final ElkPort port) {
+        return port.getLabels().get(0);
+    }
+
+    private List<ElkPort> getPortsOfNode(final ElkNode parent, final String nodeId) {
+        return parent.getChildren().stream()
+            .filter(n -> n.getIdentifier().equals(nodeId))
+            .map(n -> n.getPorts())
+            .findFirst()
+            // Sort the ports based on their index (which by definition is specified clock-wise).
+            // For west and east sort them top-down, and for north and south sort them left-to-right.
+            .map(l -> {
+                ECollections.sort(l, (p1, p2) -> {
+                    if (PortSide.SIDES_SOUTH_WEST.contains(p1.getProperty(CoreOptions.PORT_SIDE))) {
+                        return p1.getProperty(LayeredOptions.PORT_INDEX)
+                                - p2.getProperty(LayeredOptions.PORT_INDEX);
+                    } else {
+                        return p2.getProperty(LayeredOptions.PORT_INDEX)
+                                - p1.getProperty(LayeredOptions.PORT_INDEX);
+                    }
+                });
+                return l;
+            })
+            .map(l -> (List<ElkPort>) l) // only for the next line to work
+            .orElse(Collections.emptyList());
+    }
+}

--- a/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacerTest.java
+++ b/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacerTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.core.data;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.EnumSet;
+
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.PortLabelPlacement;
+import org.eclipse.elk.core.options.SizeOptions;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests {@link DeprecatedLayoutOptionReplacer}.
+ */
+public class DeprecatedLayoutOptionReplacerTest {
+
+    private final DeprecatedLayoutOptionReplacer replacer = new DeprecatedLayoutOptionReplacer();
+
+    @Before
+    public void initMetaDataService() {
+        LayoutMetaDataService.getInstance().registerLayoutMetaDataProviders(new CoreOptions());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testReplacesNextToPortIfPossible() {
+        ElkNode node = ElkGraphUtil.createGraph();
+        node.setProperty(CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE, true);
+
+        replacer.visit(node);
+
+        assertFalse(node.hasProperty(CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE));
+        assertTrue(node.hasProperty(CoreOptions.PORT_LABELS_PLACEMENT));
+        assertTrue(node.getProperty(CoreOptions.PORT_LABELS_PLACEMENT)
+                .contains(PortLabelPlacement.NEXT_TO_PORT_IF_POSSIBLE));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testMovesSpaceEfficientPortLabels() {
+        ElkNode node = ElkGraphUtil.createGraph();
+        node.setProperty(CoreOptions.NODE_SIZE_OPTIONS, EnumSet.of(SizeOptions.SPACE_EFFICIENT_PORT_LABELS));
+
+        replacer.visit(node);
+
+        assertFalse(node.getProperty(CoreOptions.NODE_SIZE_OPTIONS).contains(SizeOptions.SPACE_EFFICIENT_PORT_LABELS));
+        assertTrue(node.hasProperty(CoreOptions.PORT_LABELS_PLACEMENT));
+        assertTrue(node.getProperty(CoreOptions.PORT_LABELS_PLACEMENT)
+                .contains(PortLabelPlacement.SPACE_EFFICIENT));        
+    }
+}


### PR DESCRIPTION
See #626. 

It probably makes sense to go through the PR commit by commit. 

There's one `TODO` open: where to implement the legacy behavior (see comment in code). 

While working on this (and in particular while writing the test), I found the behavior rather inconsistent: 
* inside and outside behave differently by default (inside even behaves differently for non- and hierarchical edges) 
* always same side and space efficient do not apply to inside labels 
* north/south behaves differently by default

I'd suggest to create another issue for this, though. 
