### PR TITLE
build: updated target platform

### DIFF
--- a/build/org.eclipse.elk.targetplatform/org.eclipse.elk.targetplatform.target
+++ b/build/org.eclipse.elk.targetplatform/org.eclipse.elk.targetplatform.target
@@ -1,25 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from Eclipse Layout Kernel" sequenceNumber="3">
+<target name="Generated from Eclipse Layout Kernel" sequenceNumber="4">
   <locations>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <unit id="javax.websocket" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
       <repository location="http://download.eclipse.org/releases/2019-12"/>
     </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.20.0/"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="com.google.gson" version="0.0.0"/>
-      <unit id="com.google.guava" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository/"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="0.0.0"/>
-      <repository location="http://xtext.github.io/download/updates/releases/2.1.1/"/>
+      <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.hamcrest.library" version="0.0.0"/>
+      <repository location="http://download.eclipse.org/eclipse/updates/4.14/R-4.14-201912100610"/>
     </location>
   </locations>
 </target>

--- a/setups/EclipseLayoutKernel.setup
+++ b/setups/EclipseLayoutKernel.setup
@@ -287,7 +287,7 @@
           </detail>
           <detail
               key="includeSource">
-            <value>false</value>
+            <value>true</value>
           </detail>
         </annotation>
         <requirement
@@ -306,11 +306,12 @@
             name="org.eclipse.xtext.sdk.feature.group"
             versionRange="[2.20.0,2.21.0)"/>
         <requirement
-            name="de.itemis.xtext.antlr.sdk.feature.group"/>
-        <requirement
             name="org.eclipse.lsp4j.sdk.feature.group"/>
         <requirement
             name="org.eclipse.gmf.runtime.sdk.feature.group"/>
+        <requirement
+            name="org.hamcrest.library"
+            versionRange="1.3.0"/>
         <sourceLocator
             rootFolder="${git.clone.location}"
             locateNestedProjects="true"/>
@@ -322,8 +323,6 @@
               url="http://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository/"/>
           <repository
               url="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.20.0/"/>
-          <repository
-              url="http://xtext.github.io/download/updates/releases/2.1.1/"/>
         </repositoryList>
       </targlet>
     </setupTask>


### PR DESCRIPTION
 - include 'hamcrest.library' (it's part of the orbit drops update site)
 - add 'includeSource = true' (so far no source was available for guava etc., which is annoying)
 - removed (hopefully) unneccesary xtext 2.1.1 dependency (afair the antlr part is automatically downloaded for mwe execution) 

Note that the `*.target` is generated by oomph. 