### PR TITLE
[PR] Basic individual spacings in elkg and elkt

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -51,7 +51,7 @@ algorithm layered(LayeredLayoutProvider) {
     supports org.eclipse.elk.spacing.nodeNode
     supports org.eclipse.elk.spacing.nodeSelfLoop
     supports org.eclipse.elk.spacing.portPort
-    supports org.eclipse.elk.spacing.individualOverride
+    supports org.eclipse.elk.spacing.individual
     documentation "Most parts of the algorithm do not support this yet."
     // layer-based spacings
     supports org.eclipse.elk.alg.layered.spacing.baseValue

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
@@ -1088,8 +1088,8 @@ public final class LGraphUtil {
     public static <T> T getIndividualOrInherited(final LNode node, final IProperty<T> property) {
         T result = null;
         
-        if (node.hasProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE)) {
-            IPropertyHolder individualSpacings = node.getProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE);
+        if (node.hasProperty(CoreOptions.SPACING_INDIVIDUAL)) {
+            IPropertyHolder individualSpacings = node.getProperty(CoreOptions.SPACING_INDIVIDUAL);
             if (individualSpacings.hasProperty(property)) {
                 result = individualSpacings.getProperty(property);
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/CuttingUtils.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/CuttingUtils.java
@@ -85,7 +85,7 @@ public final class CuttingUtils {
             dummyNode.setProperty(InternalProperties.ORIGIN, edge);
             dummyNode.setProperty(LayeredOptions.PORT_CONSTRAINTS,
                     PortConstraints.FIXED_POS);
-            dummyNode.setProperty(LayeredOptions.SPACING_INDIVIDUAL_OVERRIDE, is);
+            dummyNode.setProperty(LayeredOptions.SPACING_INDIVIDUAL, is);
             
             Layer nextLayer = layeredGraph.getLayers().get(i);
             if (i == srcIndex) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/Spacings.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/Spacings.java
@@ -234,8 +234,8 @@ public final class Spacings {
     public static <T> T getIndividualOrDefault(final LNode node, final IProperty<T> property) {
         T result = null;
         // check for individual value
-        if (node.hasProperty(LayeredOptions.SPACING_INDIVIDUAL_OVERRIDE)) {
-            IPropertyHolder individualSpacings = node.getProperty(LayeredOptions.SPACING_INDIVIDUAL_OVERRIDE);
+        if (node.hasProperty(LayeredOptions.SPACING_INDIVIDUAL)) {
+            IPropertyHolder individualSpacings = node.getProperty(LayeredOptions.SPACING_INDIVIDUAL);
             if (individualSpacings.hasProperty(property)) {
                 result = individualSpacings.getProperty(property);
             }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -398,7 +398,10 @@ group spacing {
             on the graph would result in the ports of all of the graph's nodes to be spaced apart by 5px. 
             A single node may desire a larger spacing and hence set an individual spacing.portPort of 10.
             Note that not all algorithms (or concrete configurations of a specific algorithm)
-            support this behavior."
+            support this behavior.
+
+            When specified as a string (in elkg or elkt) the individual options must be separated by ';,;'.
+            Example: \"spacing.portPort:5;,;spacing.nodeNode:10\""
         targets nodes, edges, ports, labels
     }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -384,12 +384,21 @@ group spacing {
         targets parents, nodes
     }
 
-    advanced option individualOverride: IndividualSpacings {
-        label "Individual Spacing Override"
-        description
-            "In general spacing values apply to the children of the hierarchical node 
-            (possibly the root node) for which the values are actually specified. Hereby,
-            the children include ports, edges, and labels. "
+    advanced option individual: IndividualSpacings {
+        label "Individual Spacing"
+        description 
+            "Allows to specify individual spacing values for graph elements that shall be different from 
+            the value specified for the element's parent."
+        documentation
+            "In most cases, spacing values apply to the children of the hierarchical node 
+            (possibly the root node) for which the values are actually specified. 
+            Hereby, the children may include ports, edges, and labels.
+            This option allows to specify a different spacing for a certain element, 
+            thus overriding the parent's value. To give an example, a spacing.portPort of 5 configured 
+            on the graph would result in the ports of all of the graph's nodes to be spaced apart by 5px. 
+            A single node may desire a larger spacing and hence set an individual spacing.portPort of 10.
+            Note that not all algorithms (or concrete configurations of a specific algorithm)
+            support this behavior."
         targets nodes, edges, ports, labels
     }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
@@ -24,6 +24,7 @@ import org.eclipse.elk.core.math.ElkPadding;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.util.IndividualSpacings;
 import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.graph.util.ElkReflect;
 
@@ -111,6 +112,9 @@ public final class LayoutMetaDataService {
         ElkReflect.register(ElkPadding.class, 
                 () -> new ElkPadding(),
                 (p) -> new ElkPadding((ElkPadding) p));
+        ElkReflect.register(IndividualSpacings.class, 
+                () -> new IndividualSpacings(), 
+                (is) -> new IndividualSpacings((IndividualSpacings) is));
         
         // Commonly used classes for internal properties
         ElkReflect.register(ArrayList.class, 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutOptionData.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutOptionData.java
@@ -229,7 +229,7 @@ public final class LayoutOptionData implements ILayoutMetaData, IProperty<Object
             return null;
         }
         
-        // if this open data instance is an ENUMSET or a REMOTE_ENUMSET, we need to allow empty strings
+        // if this open data instance is an ENUMSET, we need to allow empty strings
         // to denote that no enumeration value is selected. Otherwise, we forbid empty strings
         if (valueString.length() == 0 && type != Type.ENUMSET) {
             return null;

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/IndividualSpacings.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/IndividualSpacings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Kiel University and others.
+ * Copyright (c) 2016, 2020 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +9,10 @@
  *******************************************************************************/
 package org.eclipse.elk.core.util;
 
+import java.util.stream.Collectors;
+
+import org.eclipse.elk.core.data.LayoutMetaDataService;
+import org.eclipse.elk.core.data.LayoutOptionData;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.util.adapters.GraphAdapters.NodeAdapter;
 import org.eclipse.elk.graph.ElkNode;
@@ -16,15 +20,28 @@ import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
 import org.eclipse.elk.graph.properties.MapPropertyHolder;
 
+import com.google.common.base.Strings;
+
 /**
  * A property holder which can be used to define individual spacing overrides. The overrides are applied to the
  * element this object is set on, which is done through the {@link CoreOptions#SPACING_INDIVIDUAL} property.
  */
-public class IndividualSpacings extends MapPropertyHolder {
+public class IndividualSpacings extends MapPropertyHolder implements IDataObject {
 
     /** Serialization identifier. */
     private static final long serialVersionUID = 737614242607924309L;
     
+    /**
+     * Constructs an empty spacings container.
+     */
+    public IndividualSpacings() { }
+    
+    /**
+     * Constructs a new spacings container and copies all properties of {@code other} to the new container.
+     */
+    public IndividualSpacings(final IndividualSpacings other) {
+        getAllProperties().putAll(other.getAllProperties());
+    }
     
     /**
      * Returns the value of the given property as it applies to the given node. First checks whether an individual
@@ -87,6 +104,49 @@ public class IndividualSpacings extends MapPropertyHolder {
         }
         
         return result;
+    }
+    
+    /** A (hopefully) unique separator that allows single occurrences of commas, colons, and semi-colons in-between. */
+    private static final String SERIALIZED_OPTION_SEPARATOR = ";,;";
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        final String serialized = getAllProperties().entrySet().stream()
+                .map(entry -> entry.getKey().getId() + ":" + entry.getValue().toString())
+                .collect(Collectors.joining(SERIALIZED_OPTION_SEPARATOR));
+        return serialized;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void parse(final String string) {
+        if (Strings.isNullOrEmpty(string)) {
+            // Nothing to do.
+            return;
+        }
+        try {
+            String[] options = string.split(SERIALIZED_OPTION_SEPARATOR);
+            for (String optionString : options) {
+                String[] option = optionString.split("\\:");
+                LayoutOptionData optionData = LayoutMetaDataService.getInstance().getOptionDataBySuffix(option[0]);
+                if (optionData == null) {
+                    throw new IllegalArgumentException("Invalid option id: " + option[0]);
+                }
+                Object value = optionData.parseValue(option[1]);
+                if (value == null) {
+                    throw new IllegalArgumentException("Invalid option value: " + option[1]);
+                }
+                setProperty(optionData, value);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "The given string does not match the expected format for individual spacings.", e);
+        }
     }
 
 }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/IndividualSpacings.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/IndividualSpacings.java
@@ -18,7 +18,7 @@ import org.eclipse.elk.graph.properties.MapPropertyHolder;
 
 /**
  * A property holder which can be used to define individual spacing overrides. The overrides are applied to the
- * element this object is set on, which is done through the {@link CoreOptions#SPACING_INDIVIDUAL_OVERRIDE} property.
+ * element this object is set on, which is done through the {@link CoreOptions#SPACING_INDIVIDUAL} property.
  */
 public class IndividualSpacings extends MapPropertyHolder {
 
@@ -40,8 +40,8 @@ public class IndividualSpacings extends MapPropertyHolder {
     public static <T> T getIndividualOrInherited(final ElkNode node, final IProperty<T> property) {
         T result = null;
         
-        if (node.hasProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE)) {
-            IPropertyHolder individualSpacings = node.getProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE);
+        if (node.hasProperty(CoreOptions.SPACING_INDIVIDUAL)) {
+            IPropertyHolder individualSpacings = node.getProperty(CoreOptions.SPACING_INDIVIDUAL);
             if (individualSpacings.hasProperty(property)) {
                 result = individualSpacings.getProperty(property);
             }
@@ -69,8 +69,8 @@ public class IndividualSpacings extends MapPropertyHolder {
     public static <T> T getIndividualOrInherited(final NodeAdapter<?> node, final IProperty<T> property) {
         T result = null;
         
-        if (node.hasProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE)) {
-            IPropertyHolder individualSpacings = node.getProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE);
+        if (node.hasProperty(CoreOptions.SPACING_INDIVIDUAL)) {
+            IPropertyHolder individualSpacings = node.getProperty(CoreOptions.SPACING_INDIVIDUAL);
             if (individualSpacings.hasProperty(property)) {
                 result = individualSpacings.getProperty(property);
             }

--- a/plugins/org.eclipse.elk.graph.json/src/org/eclipse/elk/graph/json/JsonExporter.xtend
+++ b/plugins/org.eclipse.elk.graph.json/src/org/eclipse/elk/graph/json/JsonExporter.xtend
@@ -309,7 +309,7 @@ final class JsonExporter {
         parent.addJsonObj("layoutOptions", jsonProps)
         holder.getAllProperties.entrySet
             .filter[ key !== null ]
-            .filter[ key != CoreOptions.SPACING_INDIVIDUAL_OVERRIDE ]
+            .filter[ key != CoreOptions.SPACING_INDIVIDUAL ]
             .forEach [ p |
                 if (!omitUnknownLayoutOptions || p.key.isKnown) {
                     var key = if (shortLayoutOptionKeys) p.key.id.shortOptionKey else p.key.id
@@ -320,10 +320,10 @@ final class JsonExporter {
     
     private def void transformIndividualSpacings(IPropertyHolder holder, Object parentA) {
         // skip if empty
-        if (holder === null || !holder.hasProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE)) {
+        if (holder === null || !holder.hasProperty(CoreOptions.SPACING_INDIVIDUAL)) {
             return
         }
-        val individualSpacings = holder.getProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE)
+        val individualSpacings = holder.getProperty(CoreOptions.SPACING_INDIVIDUAL)
         if (individualSpacings.allProperties === null || individualSpacings.allProperties.empty) {
             return;
         }

--- a/plugins/org.eclipse.elk.graph.json/src/org/eclipse/elk/graph/json/JsonImporter.xtend
+++ b/plugins/org.eclipse.elk.graph.json/src/org/eclipse/elk/graph/json/JsonImporter.xtend
@@ -425,10 +425,10 @@ final class JsonImporter {
         
         val jsonIndividualSpacings = jsonObj.optJSONObject("individualSpacings")
         if (jsonIndividualSpacings !== null) {
-            if (!layoutData.hasProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE)) {
-                layoutData.setProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE, new IndividualSpacings())   
+            if (!layoutData.hasProperty(CoreOptions.SPACING_INDIVIDUAL)) {
+                layoutData.setProperty(CoreOptions.SPACING_INDIVIDUAL, new IndividualSpacings())   
             }
-            val individualSpacings = layoutData.getProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE);
+            val individualSpacings = layoutData.getProperty(CoreOptions.SPACING_INDIVIDUAL);
             val opts = jsonIndividualSpacings
             opts?.keysJsonObj?.forEach[ k |
                 val value = opts.getJsonObj(k)?.stringVal

--- a/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/IndividualSpacingsTest.xtend
+++ b/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/IndividualSpacingsTest.xtend
@@ -85,8 +85,8 @@ class IndividualSpacingsTest {
         val i1 = outer.children.findFirst[ identifier == "i1" ]
         val i2 = outer.children.findFirst[ identifier == "i2" ]        
         
-        assertFalse(i1.hasProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE))
-        assertTrue(i2.hasProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE))
+        assertFalse(i1.hasProperty(CoreOptions.SPACING_INDIVIDUAL))
+        assertTrue(i2.hasProperty(CoreOptions.SPACING_INDIVIDUAL))
         
         PlainJavaInitialization.initializePlainJavaLayout    
         new RecursiveGraphLayoutEngine().layout(root, new NullElkProgressMonitor())
@@ -105,7 +105,7 @@ class IndividualSpacingsTest {
 
         val individualSpacings = new IndividualSpacings()
         individualSpacings.setProperty(CoreOptions.SPACING_NODE_NODE, 20.0)
-        graph.setProperty(CoreOptions.SPACING_INDIVIDUAL_OVERRIDE, individualSpacings)
+        graph.setProperty(CoreOptions.SPACING_INDIVIDUAL, individualSpacings)
 
         val json = ElkGraphJson.forGraph(graph)
                                .omitUnknownLayoutOptions(true)


### PR DESCRIPTION
Light version of #629, addressing #620: allows to specify the individual spacings via a plain string. I.e. no formatting and content assist within `elkt`. But better than nothing 🙄. 

```
spacing.portPort: 5

node n1 {
    spacing.individual: "spacing.portPort: 10"   
    port p1
    port p2 
}

node n2 {
    port p1
    port p2 
}
```