### PR TITLE
Remove superfluous {@inheritDoc}s

### DIFF
--- a/docs/content/documentation/algorithmdevelopers/algorithmimplementation/algorithmstructure.md
+++ b/docs/content/documentation/algorithmdevelopers/algorithmimplementation/algorithmstructure.md
@@ -184,9 +184,7 @@ public enum NodeOrderStrategy implements ILayoutPhaseFactory<LayoutPhases, ElkNo
     NODE_ORDERER,
     ORDER_BALANCER;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutPhase<LayoutPhases, ElkNode> create() {
         switch (this) {
         case NODE_ORDERER:

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/Point.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/Point.java
@@ -66,17 +66,11 @@ public class Point {
         return new Point(v.x, v.y);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "(" + x + ", " + y + (convex ? "cx" : "") + quadrant + ")";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj == null) {
@@ -90,9 +84,6 @@ public class Point {
         return Objects.equals(x, p2.x) && Objects.equals(y, p2.y);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         return Objects.hash(x, y);

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/TEdge.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/TEdge.java
@@ -35,9 +35,6 @@ public class TEdge {
         this.v = v;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof TEdge) {
@@ -49,9 +46,6 @@ public class TEdge {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         return Objects.hashCode(u) + Objects.hashCode(v);

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/TTriangle.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/TTriangle.java
@@ -107,9 +107,6 @@ public class TTriangle {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         // Note that the hash is independent of the vertex order to guarantee that equal triangles

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/CNode.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/CNode.java
@@ -82,9 +82,6 @@ public final class CNode {
         return sb.toString();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (toStringDelegate != null) {

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/LongestPathCompaction.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/LongestPathCompaction.java
@@ -24,9 +24,6 @@ import com.google.common.collect.Lists;
  */
 public class LongestPathCompaction implements ICompactionAlgorithm {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void compact(final OneDimensionalCompactor compactor) {
 

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/QuadraticConstraintCalculation.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/QuadraticConstraintCalculation.java
@@ -15,9 +15,6 @@ package org.eclipse.elk.alg.common.compaction.oned;
  */
 public class QuadraticConstraintCalculation implements IConstraintCalculationAlgorithm {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void calculateConstraints(final OneDimensionalCompactor compactor) {
 

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/ScanlineConstraintCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/compaction/oned/ScanlineConstraintCalculator.java
@@ -37,9 +37,6 @@ public class ScanlineConstraintCalculator implements IConstraintCalculationAlgor
     /** The surrounding compactor object. */
     protected OneDimensionalCompactor compactor;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void calculateConstraints(final OneDimensionalCompactor theCompactor) {
         this.compactor = theCompactor;

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/networksimplex/NEdge.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/networksimplex/NEdge.java
@@ -106,9 +106,6 @@ public class NEdge {
         return this;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "NEdge[id=" + id + " w=" + weight + " d=" + delta + "]";

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/PolyominoCompactor.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/PolyominoCompactor.java
@@ -145,9 +145,7 @@ public class PolyominoCompactor {
      * boxes.
      */
     private class MinPerimeterComparator implements Comparator<PlanarGrid> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final PlanarGrid o1, final PlanarGrid o2) {
             int halfPeri1 = o1.getWidth() + o1.getHeight();
             int halfPeri2 = o2.getWidth() + o2.getHeight();
@@ -167,9 +165,7 @@ public class PolyominoCompactor {
      * boxes, but preferring polyominoes with the shortest short sides.
      */
     private class MinPerimeterComparatorWithShape implements Comparator<PlanarGrid> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final PlanarGrid o1, final PlanarGrid o2) {
             int width = o1.getWidth();
             int height = o1.getHeight();
@@ -207,9 +203,7 @@ public class PolyominoCompactor {
      * Comparator for sorting {@link Polyomino polyominoes} based on the minimum number of their extensions.
      */
     private class MinNumOfExtensionsComparator implements Comparator<Polyomino> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final Polyomino o1, final Polyomino o2) {
             int numExt1 = o1.getPolyominoExtensions().size();
             int numExt2 = o2.getPolyominoExtensions().size();
@@ -228,9 +222,7 @@ public class PolyominoCompactor {
      * Comparator for sorting {@link Polyomino polyominoes} based on the minimum number of their extension directions.
      */
     private class MinNumOfExtensionDirectionsComparator implements Comparator<Polyomino> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final Polyomino o1, final Polyomino o2) {
             Function<UniqueTriple<Direction, Integer, Integer>, Direction> detectDirections =
                     (UniqueTriple<Direction, Integer, Integer> polyExt) -> polyExt.getFirst();
@@ -257,9 +249,7 @@ public class PolyominoCompactor {
      * direction (greater) and all other cases (less).
      */
     private class SingleExtensionSideGreaterThanRestComparator implements Comparator<Polyomino> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final Polyomino o1, final Polyomino o2) {
             Function<UniqueTriple<Direction, Integer, Integer>, Direction> detectDirections =
                     (UniqueTriple<Direction, Integer, Integer> polyExt) -> polyExt.getFirst();
@@ -290,9 +280,7 @@ public class PolyominoCompactor {
      * orthogonal directions (one horizontally, one vertically -- greater) and all other cases (less).
      */
     private class CornerCasesGreaterThanRestComparator implements Comparator<Polyomino> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final Polyomino o1, final Polyomino o2) {
             Function<UniqueTriple<Direction, Integer, Integer>, Direction> detectDirections =
                     (UniqueTriple<Direction, Integer, Integer> polyExt) -> polyExt.getFirst();

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorCombination.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorCombination.java
@@ -41,9 +41,6 @@ public class SuccessorCombination implements BiFunction<Pair<Integer, Integer>, 
         this.externalFun = externalFun;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Pair<Integer, Integer> apply(final Pair<Integer, Integer> coords, final Polyomino poly) {
         if (poly.getPolyominoExtensions().size() > 0) {

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorJitter.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorJitter.java
@@ -67,9 +67,6 @@ import org.eclipse.elk.core.util.Pair;
  */
 public class SuccessorJitter implements BiFunction<Pair<Integer, Integer>, Polyomino, Pair<Integer, Integer>> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Pair<Integer, Integer> apply(final Pair<Integer, Integer> coords, final Polyomino poly) {
         int x = coords.getFirst();

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorLineByLine.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorLineByLine.java
@@ -66,9 +66,6 @@ import org.eclipse.elk.core.util.Pair;
  */
 public class SuccessorLineByLine implements BiFunction<Pair<Integer, Integer>, Polyomino, Pair<Integer, Integer>> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Pair<Integer, Integer> apply(final Pair<Integer, Integer> coords, final Polyomino poly) {
         int x = coords.getFirst();

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorManhattan.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorManhattan.java
@@ -49,9 +49,6 @@ import org.eclipse.elk.core.util.Pair;
  */
 public class SuccessorManhattan implements BiFunction<Pair<Integer, Integer>, Polyomino, Pair<Integer, Integer>> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Pair<Integer, Integer> apply(final Pair<Integer, Integer> coords, final Polyomino poly) {
         int x = coords.getFirst();

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorMaxNormWindingInMathPosSense.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorMaxNormWindingInMathPosSense.java
@@ -67,9 +67,6 @@ import org.eclipse.elk.core.util.Pair;
 public class SuccessorMaxNormWindingInMathPosSense
         implements BiFunction<Pair<Integer, Integer>, Polyomino, Pair<Integer, Integer>> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Pair<Integer, Integer> apply(final Pair<Integer, Integer> coords, final Polyomino poly) {
         int x = coords.getFirst();

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorQuadrantsGeneric.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/polyomino/SuccessorQuadrantsGeneric.java
@@ -80,9 +80,6 @@ public class SuccessorQuadrantsGeneric
         this.costFun = costFun;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Pair<Integer, Integer> apply(final Pair<Integer, Integer> coords, final Polyomino poly) {
         if (!poly.equals(lastPoly)) {

--- a/plugins/org.eclipse.elk.alg.disco.debug/src/org/eclipse/elk/alg/disco/debug/views/DisCoDebugView.java
+++ b/plugins/org.eclipse.elk.alg.disco.debug/src/org/eclipse/elk/alg/disco/debug/views/DisCoDebugView.java
@@ -90,9 +90,6 @@ public class DisCoDebugView extends ViewPart {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void createPartControl(final Composite parent) {
         // create actions in the view toolbar
@@ -131,9 +128,6 @@ public class DisCoDebugView extends ViewPart {
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setFocus() {
         scrolledComposite.setFocus();

--- a/plugins/org.eclipse.elk.alg.disco.debug/src/org/eclipse/elk/alg/disco/debug/views/DisCoGraphRenderingCanvas.java
+++ b/plugins/org.eclipse.elk.alg.disco.debug/src/org/eclipse/elk/alg/disco/debug/views/DisCoGraphRenderingCanvas.java
@@ -80,9 +80,6 @@ public class DisCoGraphRenderingCanvas extends Canvas implements PaintListener {
         setBackground(backgroundColor);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void dispose() {
         graphRenderer.dispose();

--- a/plugins/org.eclipse.elk.alg.disco.debug/src/org/eclipse/elk/alg/disco/debug/views/DisCoImageExportAction.java
+++ b/plugins/org.eclipse.elk.alg.disco.debug/src/org/eclipse/elk/alg/disco/debug/views/DisCoImageExportAction.java
@@ -56,9 +56,6 @@ public class DisCoImageExportAction extends Action {
         setImageDescriptor(DisCoDebugPlugin.imageDescriptorFromPlugin(DisCoDebugPlugin.PLUGIN_ID, ICON_PATH));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void run() {
         final DisCoGraphRenderingCanvas canvas = view.getCanvas();

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/ElkGraphImporter.java
@@ -39,9 +39,7 @@ public class ElkGraphImporter implements IGraphImporter<ElkNode> {
     ///////////////////////////////////////////////////////////////////////////////
     // Transformation KGraph -> FGraph
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public FGraph importGraph(final ElkNode kgraph) {
         FGraph fgraph = new FGraph();
         
@@ -151,9 +149,7 @@ public class ElkGraphImporter implements IGraphImporter<ElkNode> {
     ///////////////////////////////////////////////////////////////////////////////
     // Apply Layout Results
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void applyLayout(final FGraph fgraph) {
         ElkNode kgraph = (ElkNode) fgraph.getProperty(InternalProperties.ORIGIN);
         

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/ForceLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/ForceLayoutProvider.java
@@ -35,9 +35,6 @@ public final class ForceLayoutProvider extends AbstractLayoutProvider {
     /** connected components processor. */
     private ComponentsProcessor componentsProcessor = new ComponentsProcessor();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode kgraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("ELK Force", 1);

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FBendpoint.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FBendpoint.java
@@ -35,9 +35,6 @@ public final class FBendpoint extends FParticle {
         edge.getBendpoints().add(this);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (edge != null) {

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FEdge.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FEdge.java
@@ -36,9 +36,6 @@ public final class FEdge extends MapPropertyHolder {
     /** the target node of the edge. */
     private FNode target;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (source != null && target != null) {

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FLabel.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FLabel.java
@@ -41,9 +41,6 @@ public final class FLabel extends FParticle {
         edge.getLabels().add(this);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (text == null || text.length() == 0) {

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FNode.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FNode.java
@@ -65,9 +65,6 @@ public final class FNode extends FParticle {
         this.parent = theParent;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (label == null || label.length() == 0) {

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/EadesModel.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/EadesModel.java
@@ -31,9 +31,6 @@ public final class EadesModel extends AbstractForceModel {
     /** additional factor for repulsive forces. */
     private double repulsionFactor = ForceOptions.REPULSION.getDefault();
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void initialize(final FGraph graph) {
         super.initialize(graph);
@@ -42,17 +39,11 @@ public final class EadesModel extends AbstractForceModel {
         repulsionFactor = graph.getProperty(ForceOptions.REPULSION).doubleValue();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean moreIterations(final int count) {
         return count < maxIterations;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected KVector calcDisplacement(final FParticle forcer, final FParticle forcee) {
         avoidSamePosition(getRandom(), forcer, forcee);

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/FruchtermanReingoldModel.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/FruchtermanReingoldModel.java
@@ -36,9 +36,6 @@ public final class FruchtermanReingoldModel extends AbstractForceModel {
     /** the main constant used for force calculations. */
     private double k;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void initialize(final FGraph graph) {
         super.initialize(graph);
@@ -58,17 +55,11 @@ public final class FruchtermanReingoldModel extends AbstractForceModel {
         k = Math.sqrt(area / (2 * n)) * c;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean moreIterations(final int count) {
         return temperature > 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected KVector calcDisplacement(final FParticle forcer, final FParticle forcee) {
         avoidSamePosition(getRandom(), forcer, forcee);
@@ -93,9 +84,6 @@ public final class FruchtermanReingoldModel extends AbstractForceModel {
         return displacement;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void iterationDone() {
         super.iterationDone();

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/stress/StressLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/stress/StressLayoutProvider.java
@@ -33,9 +33,6 @@ public class StressLayoutProvider extends AbstractLayoutProvider {
     /** implementation of stress majorization. */
     private StressMajorization stressMajorization = new StressMajorization();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode layoutGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("ELK Stress", 1);

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/GraphvizDotActivator.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/GraphvizDotActivator.java
@@ -51,18 +51,12 @@ public class GraphvizDotActivator extends Plugin {
         return injector;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void start(final BundleContext context) throws Exception {
         super.start(context);
         instance = this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void stop(final BundleContext context) throws Exception {
         injectors.clear();

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/GraphvizDotExecutableExtensionFactory.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/GraphvizDotExecutableExtensionFactory.java
@@ -36,9 +36,7 @@ public class GraphvizDotExecutableExtensionFactory implements IExecutableExtensi
     private String clazzName;
     private IConfigurationElement config;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     @SuppressWarnings({ "unchecked" })
     public void setInitializationData(final IConfigurationElement theconfig, final String propertyName,
             final Object data)
@@ -54,9 +52,7 @@ public class GraphvizDotExecutableExtensionFactory implements IExecutableExtensi
         this.config = theconfig;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object create() throws CoreException {
         Bundle bundle = GraphvizDotActivator.getInstance().getBundle();
         try {

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/serializer/GraphvizDotSyntacticSequencer.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/serializer/GraphvizDotSyntacticSequencer.java
@@ -25,9 +25,6 @@ public class GraphvizDotSyntacticSequencer extends AbstractGraphvizDotSyntacticS
     
     // CHECKSTYLEOFF MethodName
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void emit_AttributeStatement_CommaKeyword_2_1_0_q(final EObject semanticObject,
             final ISynNavigable transition, final List<INode> nodes) {
@@ -35,9 +32,6 @@ public class GraphvizDotSyntacticSequencer extends AbstractGraphvizDotSyntacticS
                 ",", null);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void emit_EdgeStatement_CommaKeyword_2_1_1_0_q(final EObject semanticObject,
             final ISynNavigable transition, final List<INode> nodes) {
@@ -45,9 +39,6 @@ public class GraphvizDotSyntacticSequencer extends AbstractGraphvizDotSyntacticS
                 ",", null);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void emit_NodeStatement_CommaKeyword_1_1_1_0_q(final EObject semanticObject,
             final ISynNavigable transition, final List<INode> nodes) {
@@ -55,9 +46,6 @@ public class GraphvizDotSyntacticSequencer extends AbstractGraphvizDotSyntacticS
                 ",", null);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void emit_Statement_SemicolonKeyword_1_q(final EObject semanticObject,
             final ISynNavigable transition, final List<INode> nodes) {
@@ -65,9 +53,6 @@ public class GraphvizDotSyntacticSequencer extends AbstractGraphvizDotSyntacticS
                 ";", null);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void emit_Subgraph_SubgraphKeyword_1_0_q(final EObject semanticObject,
             final ISynNavigable transition, final List<INode> nodes) {

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/transform/Command.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/src/org/eclipse/elk/alg/graphviz/dot/transform/Command.java
@@ -44,9 +44,6 @@ public enum Command {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return super.toString().toLowerCase();

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizLayoutProvider.java
@@ -68,9 +68,6 @@ public class GraphvizLayoutProvider extends AbstractLayoutProvider {
     /** lazily created injector for creating required resource set creators. */
     private Injector injector;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void initialize(final String parameter) {
         command = Command.valueOf(parameter);
@@ -82,9 +79,6 @@ public class GraphvizLayoutProvider extends AbstractLayoutProvider {
         dotResourceSetProvider = getInjector().getInstance(DotResourceSetProvider.class);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void dispose() {
         graphvizTool.cleanup(Cleanup.STOP);
@@ -103,9 +97,6 @@ public class GraphvizLayoutProvider extends AbstractLayoutProvider {
         return injector;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode parentNode, final IElkProgressMonitor progressMonitor) {
         if (command == Command.INVALID) {

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizLayouterPlugin.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizLayouterPlugin.java
@@ -31,18 +31,12 @@ public class GraphvizLayouterPlugin extends Plugin {
     public GraphvizLayouterPlugin() {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void start(final BundleContext context) throws Exception {
         super.start(context);
         plugin = this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void stop(final BundleContext context) throws Exception {
         plugin = null;

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizTool.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizTool.java
@@ -477,9 +477,6 @@ public class GraphvizTool {
             this.stream = thestream;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public int read() throws IOException {
             if (buf >= 0) {
@@ -515,9 +512,6 @@ public class GraphvizTool {
             return c;
         }
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public int available() throws IOException {
             return stream.available();
@@ -533,9 +527,6 @@ public class GraphvizTool {
      */
     private class Watchdog extends Thread {
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void run() {
             do {

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/LayoutDotExporter.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/LayoutDotExporter.java
@@ -38,9 +38,6 @@ import com.google.common.collect.Iterables;
  */
 public class LayoutDotExporter extends DotExporter {
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void transform(final IDotTransformationData<ElkNode, GraphvizModel> transData) {
         ElkNode sourceGraph = transData.getSourceGraph();
@@ -60,9 +57,6 @@ public class LayoutDotExporter extends DotExporter {
     /** Base factor for setting {@link Attributes#SIMPLEX_LIMIT} from the iterations limit. */
     private static final float NSLIMIT_BASE = 100.0f;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void setGraphAttributes(final List<Statement> statements, final ElkNode parentNode,
             final IDotTransformationData<ElkNode, GraphvizModel> transData) {
@@ -209,9 +203,6 @@ public class LayoutDotExporter extends DotExporter {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void setEdgeLabels(final ElkEdge kedge, final List<Attribute> attributes, final boolean isVertical) {
         super.setEdgeLabels(kedge, attributes, isVertical);

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/preferences/GraphvizLayouterPreferenceInitializer.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/preferences/GraphvizLayouterPreferenceInitializer.java
@@ -22,9 +22,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
  */
 public class GraphvizLayouterPreferenceInitializer extends AbstractPreferenceInitializer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void initializeDefaultPreferences() {
         IPreferenceStore store = GraphvizLayouterPreferenceStore.getInstance().getPreferenceStore();

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/preferences/GraphvizPreferencePage.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/preferences/GraphvizPreferencePage.java
@@ -45,9 +45,6 @@ public class GraphvizPreferencePage extends FieldEditorPreferencePage implements
                 + "its path must be entered here.");
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void createFieldEditors() {
         // Process group
@@ -69,16 +66,11 @@ public class GraphvizPreferencePage extends FieldEditorPreferencePage implements
         addField(restartGraphvizProcessCheckbox);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void init(final IWorkbench workbench) {
         setPreferenceStore(GraphvizLayouterPreferenceStore.getInstance().getPreferenceStore());
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean performOk() {
         // dispose all cached Graphviz instances to ensure creation of new processes

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/util/ForkedOutputStream.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/util/ForkedOutputStream.java
@@ -42,9 +42,6 @@ public class ForkedOutputStream extends OutputStream {
         this.outputStreams = Arrays.asList(streams);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void write(final int b) throws IOException {
         for (OutputStream stream : outputStreams) {
@@ -52,9 +49,6 @@ public class ForkedOutputStream extends OutputStream {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void flush() throws IOException {
         for (OutputStream stream : outputStreams) {
@@ -62,9 +56,6 @@ public class ForkedOutputStream extends OutputStream {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void close() throws IOException {
         for (OutputStream stream : outputStreams) {

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/util/ForwardingInputStream.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/util/ForwardingInputStream.java
@@ -37,9 +37,6 @@ public class ForwardingInputStream extends InputStream {
         this.outputStream = theoutputStream;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int read() throws IOException {
         int data = inputStream.read();
@@ -49,9 +46,6 @@ public class ForwardingInputStream extends InputStream {
         return data;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int read(final byte[] b) throws IOException {
         int count = inputStream.read(b);
@@ -61,9 +55,6 @@ public class ForwardingInputStream extends InputStream {
         return count;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
         int count = inputStream.read(b, off, len);
@@ -73,17 +64,11 @@ public class ForwardingInputStream extends InputStream {
         return count;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public long skip(final long n) throws IOException {
         return inputStream.skip(n);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int available() throws IOException {
         return inputStream.available();
@@ -99,25 +84,16 @@ public class ForwardingInputStream extends InputStream {
         inputStream.close();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public synchronized void mark(final int readlimit) {
         inputStream.mark(readlimit);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public synchronized void reset() throws IOException {
         inputStream.reset();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean markSupported() {
         return inputStream.markSupported();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/components/ComponentsToCGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/components/ComponentsToCGraphTransformer.java
@@ -122,9 +122,6 @@ public class ComponentsToCGraphTransformer<N, E> implements
      *                    Graph Transformation
      * ----------------------------------------------------------- */
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CGraph transform(final IConnectedComponents<N, E> ccs) {
 
@@ -242,9 +239,6 @@ public class ComponentsToCGraphTransformer<N, E> implements
      *                    Layout Application 
      * ----------------------------------------------------------- */
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void applyLayout() {
 
@@ -299,42 +293,27 @@ public class ComponentsToCGraphTransformer<N, E> implements
             this.individualSpacing = spacing;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public double getHorizontalSpacing() {
             return individualSpacing != null ? individualSpacing : spacing;
         }
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public double getVerticalSpacing() {
            return individualSpacing != null ? individualSpacing : spacing;
         }
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void applyElementPosition() {
             rect.x = hitbox.x;
             rect.y = hitbox.y;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public double getElementPosition() {
             return rect.x;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public String toString() {
             // for debug output be quiet! :)

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/LongestPathCompaction.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/LongestPathCompaction.java
@@ -27,9 +27,6 @@ import com.google.common.collect.Lists;
  */
 public class LongestPathCompaction implements ICompactionAlgorithm {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void compact(final OneDimensionalCompactor compactor) {
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/QuadraticConstraintCalculation.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/QuadraticConstraintCalculation.java
@@ -19,9 +19,6 @@ import org.eclipse.elk.alg.layered.compaction.oned.OneDimensionalCompactor;
  */
 public class QuadraticConstraintCalculation implements IConstraintCalculationAlgorithm {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void calculateConstraints(final OneDimensionalCompactor compactor) {
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ScanlineConstraintCalculator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ScanlineConstraintCalculator.java
@@ -42,9 +42,6 @@ public class ScanlineConstraintCalculator implements IConstraintCalculationAlgor
     /** The surrounding compactor object. */
     protected OneDimensionalCompactor compactor;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void calculateConstraints(final OneDimensionalCompactor theCompactor) {
         this.compactor = theCompactor;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/Point.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/Point.java
@@ -66,17 +66,11 @@ public class Point {
         return new Point(v.x, v.y);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "(" + x + ", " + y + (convex ? "cx" : "") + quadrant + ")";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj == null) {
@@ -90,9 +84,6 @@ public class Point {
         return Objects.equals(x, p2.x) && Objects.equals(y, p2.y);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         return Objects.hash(x, y);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/SimpleRowGraphPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/SimpleRowGraphPlacer.java
@@ -34,9 +34,7 @@ import org.eclipse.elk.core.math.KVector;
  */
 final class SimpleRowGraphPlacer extends AbstractGraphPlacer {
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void combine(final List<LGraph> components, final LGraph target) {
         if (components.size() == 1) {
             LGraph source = components.get(0);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPostprocessor.java
@@ -66,9 +66,7 @@ public class CompoundGraphPostprocessor implements ILayoutProcessor<LGraph> {
     };
     
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph graph, final IElkProgressMonitor monitor) {
         monitor.begin("Compound graph postprocessor", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
@@ -93,9 +93,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
     ////////////////////////////////////////////////////////////////////////////////////////////
     // Processing
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph graph, final IElkProgressMonitor monitor) {
         monitor.begin("Compound graph preprocessor", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CrossHierarchyEdge.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CrossHierarchyEdge.java
@@ -47,9 +47,7 @@ public class CrossHierarchyEdge {
         this.type = type;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String toString() {
         return type.toString() + ":" + newEdge.toString();
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CrossHierarchyEdgeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CrossHierarchyEdgeComparator.java
@@ -34,9 +34,7 @@ final class CrossHierarchyEdgeComparator implements Comparator<CrossHierarchyEdg
         this.graph = graph;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int compare(final CrossHierarchyEdge edge1, final CrossHierarchyEdge edge2) {
         if (edge1.getType() == PortType.OUTPUT
                 && edge2.getType() == PortType.INPUT) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphTransformer.java
@@ -30,16 +30,12 @@ import com.google.common.base.Strings;
  */
 public class ElkGraphTransformer implements IGraphTransformer<ElkNode> {
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LGraph importGraph(final ElkNode graph) {
         return new ElkGraphImporter().importGraph(graph);
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void applyLayout(final LGraph layeredGraph) {
         new ElkGraphLayoutTransferrer().applyLayout(layeredGraph);
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/CommentPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/CommentPostprocessor.java
@@ -44,9 +44,7 @@ import com.google.common.collect.Lists;
  */
 public final class CommentPostprocessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Comment post-processing", 1);
         double spacing = layeredGraph.getProperty(LayeredOptions.SPACING_NODE_NODE).doubleValue();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/DummySelfLoopProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/DummySelfLoopProcessor.java
@@ -61,9 +61,7 @@ import com.google.common.collect.Lists;
  */
 public final class DummySelfLoopProcessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Self-loop processing", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/FinalSplineBendpointsCalculator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/FinalSplineBendpointsCalculator.java
@@ -73,9 +73,6 @@ public class FinalSplineBendpointsCalculator implements ILayoutProcessor<LGraph>
     /** Multiplier used to determine the curvature of certain sloppy splines (for {@link SplineRoutingMode#SLOPPY}). */
     private static final double SLOPPY_CENTER_CP_MULTIPLIER = 0.4;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph graph, final IElkProgressMonitor progressMonitor) {
         this.edgeEdgeSpacing = graph.getProperty(LayeredOptions.SPACING_EDGE_EDGE_BETWEEN_LAYERS);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/GraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/GraphTransformer.java
@@ -63,9 +63,7 @@ public final class GraphTransformer implements ILayoutProcessor<LGraph> {
         this.mode = themode;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Graph transformation (" + mode + ")", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalNodeResizingProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalNodeResizingProcessor.java
@@ -45,9 +45,6 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public class HierarchicalNodeResizingProcessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Resize child graph to fit parent.", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortConstraintProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortConstraintProcessor.java
@@ -78,9 +78,7 @@ public final class HierarchicalPortConstraintProcessor implements ILayoutProcess
      * @author cds
      */
     private static class NodeComparator implements Comparator<LNode> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final LNode node1, final LNode node2) {
             NodeType nodeType1 = node1.getType();
             double nodePos1 = node1.getProperty(InternalProperties.PORT_RATIO_OR_POSITION);
@@ -114,9 +112,7 @@ public final class HierarchicalPortConstraintProcessor implements ILayoutProcess
     private static final int DUMMY_OUTPUT_PORT = 1;
     
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Hierarchical port constraint processing", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortDummySizeProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortDummySizeProcessor.java
@@ -51,9 +51,7 @@ import com.google.common.collect.Lists;
  */
 public final class HierarchicalPortDummySizeProcessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Hierarchical port dummy size processing", 1);
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
@@ -92,9 +92,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
      */
     private double northernExtPortEdgeRoutingHeight;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Orthogonally routing hierarchical port edges", 1);
         northernExtPortEdgeRoutingHeight = 0.0;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortPositionProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortPositionProcessor.java
@@ -58,9 +58,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public final class HierarchicalPortPositionProcessor implements ILayoutProcessor<LGraph> {
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Hierarchical port position processing", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HighDegreeNodeLayeringProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HighDegreeNodeLayeringProcessor.java
@@ -60,9 +60,6 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
     /** The maximum height of a tree to be considered. Trees with larger height are neglected. */
     private int treeHeightThreshold;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph graph, final IElkProgressMonitor progressMonitor) {
   

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HyperedgeDummyMerger.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HyperedgeDummyMerger.java
@@ -58,9 +58,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public final class HyperedgeDummyMerger implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Hyperedge merging", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HypernodesProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HypernodesProcessor.java
@@ -40,9 +40,7 @@ import com.google.common.collect.Lists;
  */
 public final class HypernodesProcessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Hypernodes processing", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessor.java
@@ -43,9 +43,7 @@ import com.google.common.collect.Lists;
  */
 public final class InLayerConstraintProcessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Layer constraint edge reversal", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InteractiveExternalPortPositioner.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InteractiveExternalPortPositioner.java
@@ -55,9 +55,6 @@ public class InteractiveExternalPortPositioner implements ILayoutProcessor<LGrap
     private double minX = Double.POSITIVE_INFINITY, maxX = Double.NEGATIVE_INFINITY;
     private double minY = Double.POSITIVE_INFINITY, maxY = Double.NEGATIVE_INFINITY;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor progressMonitor) {
      

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyInserter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyInserter.java
@@ -56,9 +56,7 @@ public final class LabelDummyInserter implements ILayoutProcessor<LGraph> {
         }
     };
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Label dummy insertions", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
@@ -58,9 +58,7 @@ import com.google.common.collect.Lists;
  */
 public final class LabelSideSelector implements ILayoutProcessor<LGraph> {
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         EdgeLabelSideSelection mode = layeredGraph.getProperty(LayeredOptions.EDGE_LABELS_SIDE_SELECTION);
         monitor.begin("Label side selection (" + mode + ")", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoiner.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LongEdgeJoiner.java
@@ -57,9 +57,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public final class LongEdgeJoiner implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Edge joining", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NodePromotion.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NodePromotion.java
@@ -126,9 +126,7 @@ public class NodePromotion implements ILayoutProcessor<LGraph> {
     /** The strategy which is used for the node promotion. */
     private NodePromotionStrategy promotionStrategy;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor progressMonitor) {
 
         progressMonitor.begin("Node promotion heuristic", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPostprocessor.java
@@ -49,9 +49,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public final class NorthSouthPortPostprocessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Odd port side processing", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPreprocessor.java
@@ -141,9 +141,6 @@ public final class NorthSouthPortPreprocessor implements ILayoutProcessor<LGraph
      */
     private static final boolean USE_NEW_APPROACH = true;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Odd port side processing", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PortListSorter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PortListSorter.java
@@ -52,9 +52,7 @@ import org.eclipse.elk.core.util.Pair;
  */
 public final class PortListSorter implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Port order processing", 1);
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ReversedEdgeRestorer.java
@@ -37,9 +37,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public final class ReversedEdgeRestorer implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Restoring reversed edges", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/EdgeAwareScanlineConstraintCalculation.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/EdgeAwareScanlineConstraintCalculation.java
@@ -45,9 +45,6 @@ public class EdgeAwareScanlineConstraintCalculation extends ScanlineConstraintCa
         this.edgeRouting = graph.getProperty(LayeredOptions.EDGE_ROUTING);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void calculateConstraints(final OneDimensionalCompactor theCompactor) {
         this.compactor = theCompactor;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/HorizontalGraphCompactor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/HorizontalGraphCompactor.java
@@ -71,9 +71,7 @@ public class HorizontalGraphCompactor implements ILayoutProcessor<LGraph> {
     
     private LGraph lGraph;
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor progressMonitor) {
 
         GraphCompactionStrategy strategy = layeredGraph.getProperty(LayeredOptions.COMPACTION_POST_COMPACTION_STRATEGY);
@@ -194,9 +192,6 @@ public class HorizontalGraphCompactor implements ILayoutProcessor<LGraph> {
      */
     private final ISpacingsHandler specialSpacingsHandler = new ISpacingsHandler() {
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public double getHorizontalSpacing(final CNode cNode1, final CNode cNode2) {
                         
@@ -229,9 +224,6 @@ public class HorizontalGraphCompactor implements ILayoutProcessor<LGraph> {
                     node2 != null ? node2.getType() : NodeType.LONG_EDGE);
         }
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public double getVerticalSpacing(final CNode cNode1, final CNode cNode2) {
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/LGraphToCGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/LGraphToCGraphTransformer.java
@@ -72,7 +72,7 @@ public final class LGraphToCGraphTransformer {
     private static final Function<CNode, String> VS_TO_STRING_DELEGATE = n -> ((VerticalSegment) n.origin).toString();
     
     /**
-     * {@inheritDoc}
+     * @return the input graph transformed into a corresponding constraint graph.
      */
     public CGraph transform(final LGraph inputGraph) {
         this.layeredGraph = inputGraph;
@@ -425,7 +425,7 @@ public final class LGraphToCGraphTransformer {
     }
 
     /**
-     * {@inheritDoc}
+     * Apply the layout from the internal constraint graph back to the original lgraph.
      */
     public void applyLayout() {
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/NetworkSimplexCompaction.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/NetworkSimplexCompaction.java
@@ -48,9 +48,6 @@ public class NetworkSimplexCompaction implements ICompactionAlgorithm {
     private static final int SEPARATION_WEIGHT = 1;
     private static final int EDGE_WEIGHT = 100;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void compact(final OneDimensionalCompactor theCompactor) {
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/VerticalSegment.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/VerticalSegment.java
@@ -160,9 +160,6 @@ public final class VerticalSegment implements Comparable<VerticalSegment> {
                         || CompareFuzzy.lt(o.hitbox.getBottomLeft().y, this.hitbox.y));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int compareTo(final VerticalSegment o) {
         int d = DoubleMath.fuzzyCompare(hitbox.x, o.hitbox.x, CompareFuzzy.TOLERANCE);
@@ -172,9 +169,6 @@ public final class VerticalSegment implements Comparable<VerticalSegment> {
         return d;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/GreedySwitchHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/GreedySwitchHeuristic.java
@@ -54,9 +54,6 @@ public class GreedySwitchHeuristic implements ICrossingMinimizationHeuristic {
         greedySwitchType = greedyType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean minimizeCrossings(final LNode[][] order, final int freeLayerIndex,
             final boolean forwardSweep, final boolean isFirstSweep) {
@@ -64,9 +61,6 @@ public class GreedySwitchHeuristic implements ICrossingMinimizationHeuristic {
         return continueSwitchingUntilNoImprovementInLayer(freeLayerIndex);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean setFirstLayerOrder(final LNode[][] currentOrder, final boolean isForwardSweep) {
         int startIndex = startIndex(isForwardSweep, currentOrder.length);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/SwitchDecider.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/SwitchDecider.java
@@ -114,10 +114,9 @@ public final class SwitchDecider {
     }
 
     /**
-     * {@inheritDoc}
+     * @return whether switching the nodes represented by the indices would reduce the number of crossings.
      */
-    public boolean doesSwitchReduceCrossings(final int upperNodeIndex,
-            final int lowerNodeIndex) {
+    public boolean doesSwitchReduceCrossings(final int upperNodeIndex, final int lowerNodeIndex) {
         
         if (constraintsPreventSwitch(upperNodeIndex, lowerNodeIndex)) {
             return false;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/ARDCutIndexHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/ARDCutIndexHeuristic.java
@@ -21,9 +21,6 @@ import com.google.common.collect.Lists;
  */
 public class ARDCutIndexHeuristic implements ICutIndexCalculator {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<Integer> getCutIndexes(final LGraph graph, final GraphStats gs) {
         int rows = getChunkCount(gs);
@@ -57,9 +54,6 @@ public class ARDCutIndexHeuristic implements ICutIndexCalculator {
         return rows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean guaranteeValid() {
         return false;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointInserter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointInserter.java
@@ -64,9 +64,6 @@ import com.google.common.collect.Sets;
  */
 public class BreakingPointInserter implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Breaking Point Insertion", 1);
@@ -406,9 +403,6 @@ public class BreakingPointInserter implements ILayoutProcessor<LGraph> {
             return false;
         }
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointProcessor.java
@@ -58,9 +58,6 @@ import com.google.common.collect.Lists;
  */
 public class BreakingPointProcessor implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Breaking Point Processor", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointRemover.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointRemover.java
@@ -63,9 +63,6 @@ public class BreakingPointRemover implements ILayoutProcessor<LGraph> {
 
     private EdgeRouting edgeRouting;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Breaking Point Removing", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/ICutIndexCalculator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/ICutIndexCalculator.java
@@ -43,9 +43,6 @@ public interface ICutIndexCalculator {
      * from the layout option {@link LayeredOptions#WRAPPING_CUTTING_CUTS}.
      */
     public static class ManualCutIndexCalculator implements ICutIndexCalculator {
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public List<Integer> getCutIndexes(final LGraph graph, final GraphStats gs) {
             List<Integer> cuts = graph.getProperty(LayeredOptions.WRAPPING_CUTTING_CUTS);
@@ -55,9 +52,6 @@ public interface ICutIndexCalculator {
                 return Collections.emptyList();
             }
         }
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public boolean guaranteeValid() {
             return false;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/MSDCutIndexHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/MSDCutIndexHeuristic.java
@@ -26,17 +26,11 @@ import com.google.common.collect.Lists;
  */
 public class MSDCutIndexHeuristic implements ICutIndexCalculator {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean guaranteeValid() {
         return false;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<Integer> getCutIndexes(final LGraph graph, final GraphStats gs) {
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/SingleEdgeGraphWrapper.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/SingleEdgeGraphWrapper.java
@@ -59,9 +59,7 @@ import com.google.common.collect.Lists;
  */
 public class SingleEdgeGraphWrapper implements ILayoutProcessor<LGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Path-Like Graph Wrapping", 1);
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CrossingMinimizationStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CrossingMinimizationStrategy.java
@@ -43,9 +43,7 @@ public enum CrossingMinimizationStrategy implements ILayoutPhaseFactory<LayeredP
     INTERACTIVE;
     
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutPhase<LayeredPhases, LGraph> create() {
         switch (this) {
         case LAYER_SWEEP:

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CycleBreakingStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CycleBreakingStrategy.java
@@ -43,9 +43,7 @@ public enum CycleBreakingStrategy implements ILayoutPhaseFactory<LayeredPhases, 
     INTERACTIVE;
     
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutPhase<LayeredPhases, LGraph> create() {
         switch (this) {
         case GREEDY:

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeringStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeringStrategy.java
@@ -62,9 +62,7 @@ public enum LayeringStrategy implements ILayoutPhaseFactory<LayeredPhases, LGrap
     @ExperimentalPropertyValue
     MIN_WIDTH;
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutPhase<LayeredPhases, LGraph> create() {
         switch (this) {
         case NETWORK_SIMPLEX:

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/NodePlacementStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/NodePlacementStrategy.java
@@ -55,9 +55,7 @@ public enum NodePlacementStrategy implements ILayoutPhaseFactory<LayeredPhases, 
      */
     NETWORK_SIMPLEX;
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutPhase<LayeredPhases, LGraph> create() {
         switch (this) {
         case SIMPLE:

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/DepthFirstCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/DepthFirstCycleBreaker.java
@@ -63,16 +63,11 @@ public class DepthFirstCycleBreaker implements ILayoutPhase<LayeredPhases, LGrap
     /** node at which the dfs started. */
     private int[] root;
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIGURATION;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph graph, final IElkProgressMonitor monitor) {
         monitor.begin("Depth-first cycle removal", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
@@ -73,16 +73,12 @@ public final class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
     /** list of sink nodes. */
     private final LinkedList<LNode> sinks = Lists.newLinkedList();
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIGURATION;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Greedy cycle removal", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/InteractiveCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/InteractiveCycleBreaker.java
@@ -44,16 +44,12 @@ public final class InteractiveCycleBreaker implements ILayoutPhase<LayeredPhases
                     IntermediateProcessorStrategy.INTERACTIVE_EXTERNAL_PORT_POSITIONER)
             .addAfter(LayeredPhases.P5_EDGE_ROUTING, IntermediateProcessorStrategy.REVERSED_EDGE_RESTORER);
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIGURATION;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Interactive cycle breaking", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/CoffmanGrahamLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/CoffmanGrahamLayerer.java
@@ -290,9 +290,6 @@ public class CoffmanGrahamLayerer implements ILayoutPhase<LayeredPhases, LGraph>
                     IntermediateProcessorStrategy.EDGE_AND_LAYER_CONSTRAINT_EDGE_REVERSER)
             .addBefore(LayeredPhases.P3_NODE_ORDERING, IntermediateProcessorStrategy.LAYER_CONSTRAINT_PROCESSOR);    
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         return BASELINE_PROCESSING_CONFIGURATION;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/MinWidthLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/MinWidthLayerer.java
@@ -119,9 +119,7 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
     private int[] inDegree;
     private int[] outDegree;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         return LayoutProcessorConfiguration.<LayeredPhases, LGraph>create()
                 .addBefore(LayeredPhases.P1_CYCLE_BREAKING,
@@ -129,9 +127,7 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
                 .addBefore(LayeredPhases.P3_NODE_ORDERING, IntermediateProcessorStrategy.LAYER_CONSTRAINT_PROCESSOR);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("MinWidth layering", 1);
 
@@ -471,9 +467,7 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
      */
     private class SelfLoopPredicate implements Predicate<LEdge> {
 
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public boolean apply(final LEdge input) {
             return input.getSource().getNode().equals(input.getTarget().getNode());
         }
@@ -488,9 +482,7 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
      * @author mic
      */
     private class MinOutgoingEdgesComparator implements Comparator<LNode> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final LNode o1, final LNode o2) {
             int outs1 = outDegree[o1.id];
             int outs2 = outDegree[o2.id];

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/StretchWidthLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/StretchWidthLayerer.java
@@ -96,9 +96,7 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
     /** the size of the dummy nodes, that should be considered. */
     private double dummySize;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         return LayoutProcessorConfiguration.<LayeredPhases, LGraph>create()
                 .addBefore(LayeredPhases.P1_CYCLE_BREAKING,
@@ -106,9 +104,7 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
                 .addBefore(LayeredPhases.P3_NODE_ORDERING, IntermediateProcessorStrategy.LAYER_CONSTRAINT_PROCESSOR);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("StretchWidth layering", 1);
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/BarycenterHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/BarycenterHeuristic.java
@@ -64,7 +64,10 @@ public final class BarycenterHeuristic implements ICrossingMinimizationHeuristic
         this.portDistributor = portDistributor;
     }
 
-    @Override
+    /**
+     * Don't use!
+     * Only public to be accessible by a test.
+     */
     public void minimizeCrossings(final List<LNode> layer, final boolean preOrdered,
             final boolean randomize, final boolean forward) {
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/BarycenterHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/BarycenterHeuristic.java
@@ -64,9 +64,7 @@ public final class BarycenterHeuristic implements ICrossingMinimizationHeuristic
         this.portDistributor = portDistributor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void minimizeCrossings(final List<LNode> layer, final boolean preOrdered,
             final boolean randomize, final boolean forward) {
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -425,9 +425,6 @@ public class LayerSweepCrossingMinimizer
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         LayoutProcessorConfiguration<LayeredPhases, LGraph> configuration =

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerTotalPortDistributor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerTotalPortDistributor.java
@@ -32,9 +32,6 @@ public final class LayerTotalPortDistributor extends AbstractBarycenterPortDistr
         super(numLayers);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected float calculatePortRanks(final LNode node, final float rankSum, final PortType type) {
         float[] portRanks = getPortRanks();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/NodeRelativePortDistributor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/NodeRelativePortDistributor.java
@@ -37,9 +37,6 @@ public final class NodeRelativePortDistributor extends AbstractBarycenterPortDis
         super(numLayers);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected float calculatePortRanks(final LNode node, final float rankSum, final PortType type) {
         float[] portRanks = getPortRanks();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/HyperedgeCrossingsCounter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/HyperedgeCrossingsCounter.java
@@ -73,9 +73,7 @@ public class HyperedgeCrossingsCounter {
         private int upperRight;
         private int lowerRight;
         
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compareTo(final Hyperedge other) {
             if (this.upperLeft < other.upperLeft) {
                 return -1;
@@ -112,9 +110,7 @@ public class HyperedgeCrossingsCounter {
             UPPER, LOWER;
         }
 
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compareTo(final HyperedgeCorner other) {
             if (this.position < other.position) {
                 return -1;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/InteractiveNodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/InteractiveNodePlacer.java
@@ -51,9 +51,7 @@ public final class InteractiveNodePlacer implements ILayoutPhase<LayeredPhases, 
             .addBefore(LayeredPhases.P5_EDGE_ROUTING,
                     IntermediateProcessorStrategy.HIERARCHICAL_PORT_POSITION_PROCESSOR);
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         if (graph.getProperty(InternalProperties.GRAPH_PROPERTIES).contains(GraphProperties.EXTERNAL_PORTS)) {
             return HIERARCHY_PROCESSING_ADDITIONS;
@@ -65,9 +63,7 @@ public final class InteractiveNodePlacer implements ILayoutPhase<LayeredPhases, 
     /** Spacing values. */
     private Spacings spacings;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Interactive node placement", 1);
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/NetworkSimplexPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/NetworkSimplexPlacer.java
@@ -202,9 +202,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
     /** Epsilon for double equality testing. */
     private static final double EPSILON = 0.00001d;
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         if (graph.getProperty(InternalProperties.GRAPH_PROPERTIES)
                 .contains(GraphProperties.EXTERNAL_PORTS)) {
@@ -214,9 +212,6 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Network simplex node placement", 1);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/SimpleNodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/SimpleNodePlacer.java
@@ -44,9 +44,7 @@ public final class SimpleNodePlacer implements ILayoutPhase<LayeredPhases, LGrap
             .addBefore(LayeredPhases.P5_EDGE_ROUTING,
                     IntermediateProcessorStrategy.HIERARCHICAL_PORT_POSITION_PROCESSOR);
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         if (graph.getProperty(InternalProperties.GRAPH_PROPERTIES).contains(GraphProperties.EXTERNAL_PORTS)) {
             return HIERARCHY_PROCESSING_ADDITIONS;
@@ -55,9 +53,7 @@ public final class SimpleNodePlacer implements ILayoutPhase<LayeredPhases, LGrap
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Simple node placement", 1);
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/NeighborhoodInformation.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/NeighborhoodInformation.java
@@ -189,9 +189,7 @@ public final class NeighborhoodInformation {
     
     // SUPPRESS CHECKSTYLE NEXT 1 Javadoc
     private final class NeighborComparator implements Comparator<Pair<LNode, LEdge>> {
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final Pair<LNode, LEdge> o1, final Pair<LNode, LEdge> o2) {
             int cmp = nodeIndex[o1.getFirst().id] - nodeIndex[o2.getFirst().id];
             return (int) Math.signum(cmp);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/ThresholdStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/ThresholdStrategy.java
@@ -137,9 +137,6 @@ public abstract class ThresholdStrategy {
      * It calculates a threshold value such that it has no effect.
      */
     public static class NullThresholdStrategy extends ThresholdStrategy {
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public double calculateThreshold(final double oldThresh, final LNode blockRoot,
                 final LNode currentNode) {
@@ -151,9 +148,6 @@ public abstract class ThresholdStrategy {
             }
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void postProcess() {
         }
@@ -167,9 +161,7 @@ public abstract class ThresholdStrategy {
      */
     public static class SimpleThresholdStrategy extends ThresholdStrategy {
         
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public double calculateThreshold(final double oldThresh,
                 final LNode blockRoot, final LNode currentNode) {
             
@@ -335,9 +327,6 @@ public abstract class ThresholdStrategy {
             return invalid;
         }
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void postProcess() {
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/EdgeRouterFactory.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/EdgeRouterFactory.java
@@ -49,9 +49,7 @@ public final class EdgeRouterFactory implements ILayoutPhaseFactory<LayeredPhase
         return factoryCache.get(edgeRoutingStrategy);
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutPhase<LayeredPhases, LGraph> create() {
         switch (edgeRoutingStrategy) {
         case POLYLINE:

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalEdgeRouter.java
@@ -165,9 +165,7 @@ public final class OrthogonalEdgeRouter implements ILayoutPhase<LayeredPhases, L
             .addBefore(LayeredPhases.P4_NODE_PLACEMENT, IntermediateProcessorStrategy.END_LABEL_PREPROCESSOR)
             .addAfter(LayeredPhases.P5_EDGE_ROUTING, IntermediateProcessorStrategy.END_LABEL_POSTPROCESSOR);
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
         Set<GraphProperties> graphProperties = graph.getProperty(InternalProperties.GRAPH_PROPERTIES);
         
@@ -214,9 +212,7 @@ public final class OrthogonalEdgeRouter implements ILayoutPhase<LayeredPhases, L
         return configuration;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Orthogonal edge routing", 1);
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/NubSpline.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/NubSpline.java
@@ -996,9 +996,7 @@ public class NubSpline {
         return new KVector(xVal + xVal - original.x, original.y);
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String toString() {
         return controlPoints.toString();
     }
@@ -1122,9 +1120,7 @@ public class NubSpline {
         }
 
         // elkjs-exclude-start
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public String toString() {
             return polarCoordinate + " " + SplinesMath.convertKVectorToString(cp);
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineEdgeRouter.java
@@ -1036,9 +1036,6 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
             target.incoming.add(this);
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public String toString() {
             return source + " ->(" + weight + ") " + target;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineSegment.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineSegment.java
@@ -252,9 +252,7 @@ public final class SplineSegment implements Comparable<SplineSegment> {
         return edges.size() > 1;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int compareTo(final SplineSegment other) {
         return this.mark - other.mark;
     }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/ElkGraphImporter.java
@@ -37,9 +37,7 @@ public class ElkGraphImporter implements IGraphImporter<ElkNode> {
     // /////////////////////////////////////////////////////////////////////////////
     // Transformation KGraph -> TGraph
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public TGraph importGraph(final ElkNode elkgraph) {
         TGraph tGraph = new TGraph();
 
@@ -141,9 +139,7 @@ public class ElkGraphImporter implements IGraphImporter<ElkNode> {
     // /////////////////////////////////////////////////////////////////////////////
     // Apply Layout Results
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void applyLayout(final TGraph tGraph) {
         // get the corresponding kGraph
         ElkNode elkgraph = (ElkNode) tGraph.getProperty(InternalProperties.ORIGIN);

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeLayoutProvider.java
@@ -36,9 +36,6 @@ public class TreeLayoutProvider extends AbstractLayoutProvider {
     // /////////////////////////////////////////////////////////////////////////////
     // Regular Layout
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode kgraph, final IElkProgressMonitor progressMonitor) {
         // build tGraph

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TEdge.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TEdge.java
@@ -50,9 +50,6 @@ public class TEdge extends TGraphElement {
         this.target = target;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (source != null && target != null) {

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TGraph.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TGraph.java
@@ -39,9 +39,6 @@ public class TGraph extends MapPropertyHolder {
         this.edges = new LinkedList<TEdge>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         String tmp = null;

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TLabel.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TLabel.java
@@ -39,9 +39,6 @@ public class TLabel extends TShape {
         edge.getLabels().add(this);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (text == null || text.length() == 0) {

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TNode.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/graph/TNode.java
@@ -70,9 +70,6 @@ public class TNode extends TShape {
 
     // GETTERS
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (label == null || label.length() == 0) {

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/FanProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/FanProcessor.java
@@ -36,9 +36,7 @@ public class FanProcessor implements ILayoutProcessor<TGraph> {
     /** this map temporarily contains the number of descendants of each node in the given graph. */
     private Map<String, Integer> gloDescMap = new HashMap<String, Integer>();
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor compute fanout", 1);
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelHeightProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelHeightProcessor.java
@@ -33,9 +33,7 @@ public class LevelHeightProcessor implements ILayoutProcessor<TGraph> {
     /** number of nodes in the graph. */
     private int numberOfNodes;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
 
         progressMonitor.begin("Processor determine the height for each level", 1f);

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NeighborsProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NeighborsProcessor.java
@@ -33,9 +33,7 @@ public class NeighborsProcessor implements ILayoutProcessor<TGraph> {
     /** the number of nodes in the given graph. */
     private int numberOfNodes;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor set neighbors", 1f);
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NodePositionProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NodePositionProcessor.java
@@ -31,9 +31,7 @@ public class NodePositionProcessor implements ILayoutProcessor<TGraph> {
     /** number of nodes in the graph. */
     private int numberOfNodes;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor set coordinates", 1);
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/RootProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/RootProcessor.java
@@ -28,9 +28,7 @@ public class RootProcessor implements ILayoutProcessor<TGraph> {
 
     private ArrayList<TNode> roots = new ArrayList<TNode>();
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
 
         /** clear list of roots if processor is reused */

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/Untreeifyer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/Untreeifyer.java
@@ -27,9 +27,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public class Untreeifyer implements ILayoutProcessor<TGraph> {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         List<TEdge>  edges = tGraph.getProperty(InternalProperties.REMOVABLE_EDGES);
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p1treeify/DFSTreeifyer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p1treeify/DFSTreeifyer.java
@@ -43,9 +43,7 @@ public class DFSTreeifyer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
             LayoutProcessorConfiguration.<TreeLayoutPhases, TGraph>create()
                     .addAfter(TreeLayoutPhases.P4_EDGE_ROUTING, IntermediateProcessorStrategy.DETREEIFYING_PROC);
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("DFS Treeifying phase", 1);
 
@@ -57,9 +55,6 @@ public class DFSTreeifyer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
         progressMonitor.done();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/NodeOrderer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/NodeOrderer.java
@@ -42,17 +42,12 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
                         .add(IntermediateProcessorStrategy.ROOT_PROC)
                         .add(IntermediateProcessorStrategy.FAN_PROC);
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
 
         progressMonitor.begin("Processor arrange node", 1);

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/OrderBalance.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/OrderBalance.java
@@ -55,17 +55,12 @@ public class OrderBalance implements ILayoutPhase<TreeLayoutPhases, TGraph> {
      */
     private IProperty<Integer> weighting;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor arrange node", 1);
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p3place/NodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p3place/NodePlacer.java
@@ -71,17 +71,12 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
     private double xTopAdjustment = 0d;
     private double yTopAdjustment = 0d;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor order nodes", 2);
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/EdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/EdgeRouter.java
@@ -32,17 +32,12 @@ public class EdgeRouter implements ILayoutPhase<TreeLayoutPhases, TGraph> {
     private static final LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> INTERMEDIATE_PROCESSING_CONFIG =
             LayoutProcessorConfiguration.<TreeLayoutPhases, TGraph>create();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Dull edge routing", 1);
 

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/RadialLayoutPhases.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/RadialLayoutPhases.java
@@ -26,9 +26,7 @@ public enum RadialLayoutPhases implements ILayoutPhaseFactory<RadialLayoutPhases
     /** Route the edges of the graph. */
     P2_EDGE_ROUTING;
 
-   /**
-    * {@inheritDoc}
-    */
+   @Override
     public ILayoutPhase<RadialLayoutPhases, ElkNode> create() {
         switch (this) {
         case P1_NODE_PLACEMENT:

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/IntermediateProcessorStrategy.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/IntermediateProcessorStrategy.java
@@ -30,9 +30,7 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<Elk
     /** Calculate the graph size to the new values. */
     GRAPH_SIZE_CALCULATION;
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutProcessor<ElkNode> create() {
         switch (this) {
         case OVERLAP_REMOVAL:

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/compaction/GeneralCompactor.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/compaction/GeneralCompactor.java
@@ -19,9 +19,6 @@ import org.eclipse.elk.graph.ElkNode;
  */
 public class GeneralCompactor implements ILayoutProcessor<ElkNode> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final ElkNode graph, final IElkProgressMonitor progressMonitor) {
         IRadialCompactor compactor = graph.getProperty(RadialOptions.COMPACTOR).create();

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/p1position/EadesRadial.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/p1position/EadesRadial.java
@@ -39,9 +39,6 @@ public class EadesRadial implements ILayoutPhase<RadialLayoutPhases, ElkNode> {
     private IEvaluation optimizer;
     private ElkNode root;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final ElkNode graph, final IElkProgressMonitor progressMonitor) {
         root = graph.getProperty(InternalProperties.ROOT_NODE);
@@ -123,9 +120,6 @@ public class EadesRadial implements ILayoutPhase<RadialLayoutPhases, ElkNode> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<RadialLayoutPhases, ElkNode> getLayoutProcessorConfiguration(
             final ElkNode graph) {

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/ElkGraphImporter.java
@@ -97,9 +97,6 @@ public class ElkGraphImporter implements IGraphImporter<ElkNode> {
         return -(Utils.overlap(r1, r2) - 1) * s;
     };
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Graph importGraph(final ElkNode inputGraph) {
         
@@ -221,9 +218,6 @@ public class ElkGraphImporter implements IGraphImporter<ElkNode> {
         return graph;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void updateGraph(final Graph g) {
         Map<KVector, Pair<Node, ElkNode>> updatedNodeMap = Maps.newHashMap();
@@ -240,9 +234,6 @@ public class ElkGraphImporter implements IGraphImporter<ElkNode> {
         nodeMap = updatedNodeMap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void applyPositions(final Graph g) {
         // set new node positions

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/OverlapRemovalLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/OverlapRemovalLayoutProvider.java
@@ -48,9 +48,6 @@ public class OverlapRemovalLayoutProvider extends AbstractLayoutProvider {
             AlgorithmAssembler.<SPOrEPhases, Graph>create(SPOrEPhases.class);
     private List<ILayoutProcessor<Graph>> algorithm;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode layoutGraph, final IElkProgressMonitor progressMonitor) {
         // If desired, apply a layout algorithm

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/ShrinkTreeLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/ShrinkTreeLayoutProvider.java
@@ -25,9 +25,6 @@ public class ShrinkTreeLayoutProvider extends AbstractLayoutProvider {
     /** the compaction algorithm. */
     private ShrinkTree shrinktree = new ShrinkTree();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode layoutGraph, final IElkProgressMonitor progressMonitor) {
         

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/CompactionStrategy.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/CompactionStrategy.java
@@ -22,9 +22,6 @@ public enum CompactionStrategy implements ILayoutPhaseFactory<SPOrEPhases, Graph
     /** Simple compaction strategy. */
     DEPTH_FIRST;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ILayoutPhase<SPOrEPhases, Graph> create() {
         switch (this) {

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/OverlapRemovalStrategy.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/OverlapRemovalStrategy.java
@@ -22,9 +22,6 @@ public enum OverlapRemovalStrategy implements ILayoutPhaseFactory<SPOrEPhases, G
     /** Overlap removal by growing a tree. */
     GROW_TREE;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ILayoutPhase<SPOrEPhases, Graph> create() {
         return new GrowTreePhase();

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/StructureExtractionStrategy.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/StructureExtractionStrategy.java
@@ -22,9 +22,6 @@ public enum StructureExtractionStrategy implements ILayoutPhaseFactory<SPOrEPhas
     /** A Delaunay triangulation. */
     DELAUNAY_TRIANGULATION;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ILayoutPhase<SPOrEPhases, Graph> create() {
         switch (this) {

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/TreeConstructionStrategy.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/options/TreeConstructionStrategy.java
@@ -25,9 +25,6 @@ public enum TreeConstructionStrategy implements ILayoutPhaseFactory<SPOrEPhases,
     /** Maximum spanning tree construction. */
     MAXIMUM_SPANNING_TREE;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ILayoutPhase<SPOrEPhases, Graph> create() {
         switch (this) {

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p1structure/DelaunayTriangulationPhase.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p1structure/DelaunayTriangulationPhase.java
@@ -28,17 +28,11 @@ import com.google.common.collect.Lists;
  */
 public class DelaunayTriangulationPhase implements ILayoutPhase<SPOrEPhases, Graph> {
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<SPOrEPhases, Graph> getLayoutProcessorConfiguration(final Graph graph) {
         return LayoutProcessorConfiguration.<SPOrEPhases, Graph>create();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final Graph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Delaunay triangulation", 1);

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p2processingorder/MaxSTPhase.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p2processingorder/MaxSTPhase.java
@@ -23,9 +23,6 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  * specified root {@link Graph#preferredRoot}.
  */
 public class MaxSTPhase extends MinSTPhase {
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final Graph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Maximum spanning tree construction", 1);

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p2processingorder/MinSTPhase.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p2processingorder/MinSTPhase.java
@@ -33,17 +33,11 @@ public class MinSTPhase implements ILayoutPhase<SPOrEPhases, Graph> {
     
     private Map<KVector, Node> nodeMap = Maps.newHashMap();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<SPOrEPhases, Graph> getLayoutProcessorConfiguration(final Graph graph) {
         return LayoutProcessorConfiguration.<SPOrEPhases, Graph>create();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final Graph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Minimum spanning tree construction", 1);

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p3execution/GrowTreePhase.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p3execution/GrowTreePhase.java
@@ -30,17 +30,11 @@ public class GrowTreePhase implements ILayoutPhase<SPOrEPhases, Graph> {
     
     private boolean overlapsExisted;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<SPOrEPhases, Graph> getLayoutProcessorConfiguration(final Graph graph) {
         return LayoutProcessorConfiguration.<SPOrEPhases, Graph>create();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final Graph graph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Grow Tree", 1);

--- a/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p3execution/ShrinkTreeCompactionPhase.java
+++ b/plugins/org.eclipse.elk.alg.spore/src/org/eclipse/elk/alg/spore/p3execution/ShrinkTreeCompactionPhase.java
@@ -28,17 +28,11 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public class ShrinkTreeCompactionPhase implements ILayoutPhase<SPOrEPhases, Graph> {
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public LayoutProcessorConfiguration<SPOrEPhases, Graph> getLayoutProcessorConfiguration(final Graph graph) {
         return LayoutProcessorConfiguration.<SPOrEPhases, Graph>create();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void process(final Graph graph, final IElkProgressMonitor progressMonitor) {
         

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/ElkLayoutProvider.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/ElkLayoutProvider.java
@@ -40,9 +40,7 @@ import com.google.common.collect.Iterables;
  */
 public class ElkLayoutProvider extends AbstractProvider implements ILayoutNodeProvider {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean provides(final IOperation operation) {
         return operation instanceof ILayoutNodeOperation;
     }
@@ -89,9 +87,7 @@ public class ElkLayoutProvider extends AbstractProvider implements ILayoutNodePr
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     @SuppressWarnings("rawtypes")
     public Runnable layoutLayoutNodes(final List layoutNodes, final boolean offsetFromBoundingBox,
             final IAdaptable layoutHint) {

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfDiagramLayoutConnector.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfDiagramLayoutConnector.java
@@ -175,9 +175,7 @@ public class GmfDiagramLayoutConnector implements IDiagramLayoutConnector {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public LayoutMapping buildLayoutGraph(final IWorkbenchPart workbenchPart, final Object diagramPart) {
         // get the diagram editor part
         DiagramEditor diagramEditor = getDiagramEditor(workbenchPart);
@@ -344,9 +342,7 @@ public class GmfDiagramLayoutConnector implements IDiagramLayoutConnector {
         return mapping;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void applyLayout(final LayoutMapping mapping, final IPropertyHolder settings) {
         boolean zoomToFit = settings.getProperty(CoreOptions.ZOOM_TO_FIT);
         IWorkbenchPart workbenchPart = mapping.getWorkbenchPart();

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutCommand.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutCommand.java
@@ -155,9 +155,6 @@ public class GmfLayoutCommand extends AbstractTransactionalCommand {
         this.obliqueRouting = theobliqueRouting;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @SuppressWarnings("unchecked")
     @Override
     protected CommandResult doExecuteWithResult(final IProgressMonitor monitor,
@@ -255,9 +252,6 @@ public class GmfLayoutCommand extends AbstractTransactionalCommand {
         return CommandResult.newOKCommandResult();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<?> getAffectedFiles() {
         if (diagramViewAdapter != null) {

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutConfigurationStore.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutConfigurationStore.java
@@ -93,9 +93,7 @@ public class GmfLayoutConfigurationStore implements ILayoutConfigurationStore {
         this.editPartFilter = filter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object getOptionValue(final String optionId) {
         View view = editPart.getNotationView();
         if (view != null) {
@@ -133,9 +131,7 @@ public class GmfLayoutConfigurationStore implements ILayoutConfigurationStore {
         return result;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     @SuppressWarnings("unchecked")
     public void setOptionValue(final String optionId, final String value) {
         View view = editPart.getNotationView();
@@ -176,9 +172,7 @@ public class GmfLayoutConfigurationStore implements ILayoutConfigurationStore {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Collection<String> getAffectedOptions() {
         Set<String> options = new HashSet<String>();
         View view = editPart.getNotationView();
@@ -200,16 +194,12 @@ public class GmfLayoutConfigurationStore implements ILayoutConfigurationStore {
         return options;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public EditingDomain getEditingDomain() {
         return editPart.getEditingDomain();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Set<Target> getOptionTargets() {
         if (editPart instanceof AbstractBorderItemEditPart) {
             // This is a border item, i.e. a port 
@@ -260,9 +250,7 @@ public class GmfLayoutConfigurationStore implements ILayoutConfigurationStore {
         return null;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILayoutConfigurationStore getParent() {
         EditPart container = getContainer();
         if (container != null) {

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutEditPolicy.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutEditPolicy.java
@@ -73,17 +73,11 @@ public class GmfLayoutEditPolicy extends AbstractEditPolicy {
     /** map of edge layouts to existing point lists. */
     private Map<ElkEdgeSection, PointList> pointListMap = new HashMap<>();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean understandsRequest(final Request req) {
         return (ApplyLayoutRequest.REQ_APPLY_LAYOUT.equals(req.getType()));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Command getCommand(final Request request) {
         if (ApplyLayoutRequest.REQ_APPLY_LAYOUT.equals(request.getType())) {

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutSetup.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/GmfLayoutSetup.java
@@ -29,9 +29,6 @@ import com.google.inject.util.Modules;
  */
 public class GmfLayoutSetup implements ILayoutSetup {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean supports(final Object object) {
         if (object instanceof Collection) {
@@ -47,9 +44,6 @@ public class GmfLayoutSetup implements ILayoutSetup {
                 || object instanceof IAdaptable && ((IAdaptable) object).getAdapter(DiagramEditor.class) != null;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Injector createInjector(final Module defaultModule) {
         return Guice.createInjector(Modules.override(defaultModule).with(new GmfLayoutModule()));

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/LayoutDiagramFileHandler.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/LayoutDiagramFileHandler.java
@@ -45,9 +45,7 @@ import org.eclipse.ui.handlers.HandlerUtil;
  */
 public class LayoutDiagramFileHandler extends AbstractHandler {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object execute(final ExecutionEvent event) throws ExecutionException {
         ISelection selection = HandlerUtil.getCurrentSelection(event);
         if (selection instanceof IStructuredSelection) {

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/LayoutEditPolicyProvider.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/LayoutEditPolicyProvider.java
@@ -27,9 +27,7 @@ public class LayoutEditPolicyProvider extends AbstractProvider implements
     /** the key used to install an <i>apply layout</i> edit policy. */
     public static final String APPLY_LAYOUT_ROLE = "ApplyLayoutEditPolicy";
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void createEditPolicies(final EditPart editPart) {
         if (editPart instanceof DiagramEditPart) {
             editPart.installEditPolicy(APPLY_LAYOUT_ROLE,
@@ -37,9 +35,7 @@ public class LayoutEditPolicyProvider extends AbstractProvider implements
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean provides(final IOperation operation) {
         return operation instanceof CreateEditPoliciesOperation;
     }

--- a/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/layouter/Draw2DLayoutProvider.java
+++ b/plugins/org.eclipse.elk.conn.gmf/src/org/eclipse/elk/conn/gmf/layouter/Draw2DLayoutProvider.java
@@ -50,17 +50,11 @@ public class Draw2DLayoutProvider extends AbstractLayoutProvider {
     /** indicates whether the compound graph version of the algorithm shall be used. */
     private boolean compoundMode = false;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void initialize(final String parameter) {
         compoundMode = PARAM_COMPOUND.equals(parameter);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode layoutNode, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Draw2D Directed Graph layout", 1);

--- a/plugins/org.eclipse.elk.core.debug.grandom/src/org/eclipse/elk/core/debug/grandom/generators/RandomGraphGenerator.java
+++ b/plugins/org.eclipse.elk.core.debug.grandom/src/org/eclipse/elk/core/debug/grandom/generators/RandomGraphGenerator.java
@@ -1004,9 +1004,7 @@ public class RandomGraphGenerator {
      */
     private static class HeadComparator implements Comparator<HierarchyEdge> {
 
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final HierarchyEdge edge1, final HierarchyEdge edge2) {
             return edge1.getHead() < edge2.getHead() ? -1
                     : (edge1.getHead() > edge2.getHead() ? 1 : compareId(edge1, edge2));
@@ -1018,9 +1016,7 @@ public class RandomGraphGenerator {
      */
     private static class TailComparator implements Comparator<HierarchyEdge> {
 
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final HierarchyEdge edge1, final HierarchyEdge edge2) {
             return edge1.getTail() < edge2.getTail() ? -1
                     : (edge1.getTail() > edge2.getTail() ? 1 : compareId(edge1, edge2));

--- a/plugins/org.eclipse.elk.core.service/src/org/eclipse/elk/core/service/internal/DefaultModule.java
+++ b/plugins/org.eclipse.elk.core.service/src/org/eclipse/elk/core/service/internal/DefaultModule.java
@@ -21,9 +21,6 @@ import com.google.inject.Module;
  */
 public class DefaultModule implements Module {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void configure(final Binder binder) {
         binder.bind(IGraphLayoutEngine.class).to(RecursiveGraphLayoutEngine.class);

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/ActiveEditorSupportedTester.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/ActiveEditorSupportedTester.java
@@ -20,9 +20,7 @@ import org.eclipse.ui.IWorkbenchPart;
  */
 public class ActiveEditorSupportedTester extends PropertyTester {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean test(final Object receiver, final String property,
             final Object[] args, final Object expectedValue) {
         if (receiver instanceof IWorkbenchPart) {

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/AlgorithmContentProvider.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/AlgorithmContentProvider.java
@@ -35,15 +35,11 @@ public class AlgorithmContentProvider implements ITreeContentProvider {
     /** the current best filter match. */
     private ILayoutMetaData bestFilterMatch;
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void inputChanged(final Viewer viewer, final Object oldInput, final Object newInput) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object[] getElements(final Object inputElement) {
         if (inputElement instanceof LayoutMetaDataService) {
             layoutDataService = (LayoutMetaDataService) inputElement;
@@ -51,9 +47,7 @@ public class AlgorithmContentProvider implements ITreeContentProvider {
         return layoutDataService.getCategoryData().toArray();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object[] getChildren(final Object parentElement) {
         if (parentElement instanceof LayoutCategoryData) {
             LayoutCategoryData typeData = (LayoutCategoryData) parentElement;
@@ -62,9 +56,7 @@ public class AlgorithmContentProvider implements ITreeContentProvider {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object getParent(final Object element) {
         if (element instanceof LayoutAlgorithmData) {
             LayoutAlgorithmData layouterData = (LayoutAlgorithmData) element;
@@ -73,9 +65,7 @@ public class AlgorithmContentProvider implements ITreeContentProvider {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean hasChildren(final Object element) {
         if (element instanceof LayoutCategoryData) {
             return ((LayoutCategoryData) element).getLayouters().size() > 0;
@@ -83,9 +73,7 @@ public class AlgorithmContentProvider implements ITreeContentProvider {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void dispose() {
     }
     

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/AlgorithmSelectionDialog.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/AlgorithmSelectionDialog.java
@@ -92,9 +92,6 @@ public class AlgorithmSelectionDialog extends Dialog {
         this.layouterHint = currentHint;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void configureShell(final Shell shell) {
         super.configureShell(shell);
@@ -127,9 +124,6 @@ public class AlgorithmSelectionDialog extends Dialog {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean close() {
         imageLabel.setImage(null);
@@ -241,9 +235,6 @@ public class AlgorithmSelectionDialog extends Dialog {
         return scaled;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Control createDialogArea(final Composite parent) {
         Composite composite = (Composite) super.createDialogArea(parent);

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/ElkUiPlugin.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/ElkUiPlugin.java
@@ -50,18 +50,12 @@ public class ElkUiPlugin extends AbstractUIPlugin {
         return plugin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void start(final BundleContext context) throws Exception {
         super.start(context);
         plugin = this;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void initializeImageRegistry(final ImageRegistry reg) {
         for (String img : new String[] {IMG_CHOICE, IMG_DOUBLE, IMG_INT, IMG_TEXT, IMG_TRUE, IMG_FALSE}) {
@@ -69,9 +63,6 @@ public class ElkUiPlugin extends AbstractUIPlugin {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void stop(final BundleContext context) throws Exception {
         plugin = null;

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/LayoutHandler.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/LayoutHandler.java
@@ -39,9 +39,7 @@ public class LayoutHandler extends AbstractHandler {
     /** value for selection scope. */
     public static final String VAL_SELECTION = "selection";
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object execute(final ExecutionEvent event) throws ExecutionException {
         ISelection selection = null;
 

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/LayoutOptionLabelProvider.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/LayoutOptionLabelProvider.java
@@ -40,9 +40,6 @@ public class LayoutOptionLabelProvider extends LabelProvider {
         this.optionData = optionData;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Image getImage(final Object element) {
         ImageRegistry registry = ElkUiPlugin.getInstance().getImageRegistry();
@@ -74,9 +71,6 @@ public class LayoutOptionLabelProvider extends LabelProvider {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     @SuppressWarnings("rawtypes")
     public String getText(final Object element) {

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/AlgorithmCellEditor.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/AlgorithmCellEditor.java
@@ -41,9 +41,6 @@ public class AlgorithmCellEditor extends DialogCellEditor {
         labelProvider = new LayoutOptionLabelProvider(algorithmOption);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void fireApplyEditorValue() {
         super.fireApplyEditorValue();
@@ -53,9 +50,6 @@ public class AlgorithmCellEditor extends DialogCellEditor {
         fireCancelEditor();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Control createContents(final Composite cell) {
         Control label = super.createContents(cell);
@@ -77,9 +71,6 @@ public class AlgorithmCellEditor extends DialogCellEditor {
         return label;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void updateContents(final Object value) {
         if (value != null) {
@@ -87,9 +78,6 @@ public class AlgorithmCellEditor extends DialogCellEditor {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object openDialogBox(final Control cellEditorWindow) {
         AlgorithmSelectionDialog dialog = new AlgorithmSelectionDialog(cellEditorWindow.getShell(),

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertyDescriptor.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertyDescriptor.java
@@ -77,9 +77,7 @@ public class LayoutPropertyDescriptor implements IPropertyDescriptor {
         return optionData;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public CellEditor createPropertyEditor(final Composite parent) {
         switch (optionData.getType()) {
         case STRING:
@@ -168,9 +166,7 @@ public class LayoutPropertyDescriptor implements IPropertyDescriptor {
         return choices;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getCategory() {
         // Compute the intersection of the targets registered for the layout option
         // and those determined for the graph element currently in focus.
@@ -199,9 +195,7 @@ public class LayoutPropertyDescriptor implements IPropertyDescriptor {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getDescription() {
         // We only return the first sentence of the description. The longer description
         // can be retrieved by calling getLongDescription.
@@ -225,16 +219,12 @@ public class LayoutPropertyDescriptor implements IPropertyDescriptor {
         return optionData.getDescription();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getDisplayName() {
         return optionData.getName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String[] getFilterFlags() {
         if (optionData.getVisibility() == LayoutOptionData.Visibility.ADVANCED) {
             return new String[] { IPropertySheetEntry.FILTER_ID_EXPERT };
@@ -242,23 +232,17 @@ public class LayoutPropertyDescriptor implements IPropertyDescriptor {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object getHelpContextIds() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object getId() {
         return optionData.getId();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public ILabelProvider getLabelProvider() {
         if (labelProvider == null) {
             labelProvider = new LayoutOptionLabelProvider(optionData);
@@ -266,9 +250,7 @@ public class LayoutPropertyDescriptor implements IPropertyDescriptor {
         return labelProvider;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean isCompatibleWith(final IPropertyDescriptor anotherProperty) {
         return anotherProperty instanceof LayoutPropertyDescriptor
                 && this.optionData.getId().equals(anotherProperty.getId());

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertySource.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertySource.java
@@ -81,9 +81,7 @@ public class LayoutPropertySource implements IPropertySource {
         return layoutConfig;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public IPropertyDescriptor[] getPropertyDescriptors() {
         if (propertyDescriptors == null) {
             Set<LayoutOptionData> optionData = configManager.getSupportedOptions(layoutConfig);
@@ -147,9 +145,7 @@ public class LayoutPropertySource implements IPropertySource {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object getPropertyValue(final Object id) {
         LayoutMetaDataService layoutServices = LayoutMetaDataService.getInstance();
         LayoutOptionData optionData = layoutServices.getOptionData((String) id);
@@ -221,9 +217,7 @@ public class LayoutPropertySource implements IPropertySource {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void setPropertyValue(final Object id, final Object thevalue) {
         final LayoutOptionData optionData = LayoutMetaDataService.getInstance()
                 .getOptionData((String) id);
@@ -286,24 +280,18 @@ public class LayoutPropertySource implements IPropertySource {
         return layoutOptionValidator.checkProperty(optionData, value, null);
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object getEditableValue() {
         // this feature is currently not required (see interface documentation)
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean isPropertySet(final Object id) {
         return layoutConfig.getOptionValue((String) id) != null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void resetPropertyValue(final Object id) {
         Runnable modelChange = new Runnable() {
             public void run() {

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertySourceProvider.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutPropertySourceProvider.java
@@ -92,9 +92,7 @@ public class LayoutPropertySourceProvider implements IPropertySourceProvider {
         return configManager;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public IPropertySource getPropertySource(final Object object) {
         if (configurationStoreProvider != null) {
             ILayoutConfigurationStore config = configurationStoreProvider.get(workbenchPart, object);

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutViewPart.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/LayoutViewPart.java
@@ -158,9 +158,6 @@ public class LayoutViewPart extends ViewPart {
     /** position for bottom attachment. */
     private static final int FORM_BOTTOM = 100;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void createPartControl(final Composite parent) {
         // GUI code needs magic numbers
@@ -227,9 +224,6 @@ public class LayoutViewPart extends ViewPart {
         workbenchWindow.getPartService().addPartListener(partListener);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setFocus() {
         page.setFocus();
@@ -244,9 +238,6 @@ public class LayoutViewPart extends ViewPart {
         return page.getControl();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void dispose() {
         // Store the current status of the categories button

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/ShowLayoutViewHandler.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/ShowLayoutViewHandler.java
@@ -27,9 +27,7 @@ import org.eclipse.ui.statushandlers.StatusManager;
  */
 public class ShowLayoutViewHandler extends AbstractHandler {
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object execute(final ExecutionEvent event) throws ExecutionException {
         IWorkbenchWindow workbenchWindow = HandlerUtil.getActiveWorkbenchWindow(event);
         if (workbenchWindow != null) {

--- a/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/ValidatingPropertySheetEntry.java
+++ b/plugins/org.eclipse.elk.core.ui/src/org/eclipse/elk/core/ui/views/ValidatingPropertySheetEntry.java
@@ -28,9 +28,6 @@ import org.eclipse.ui.views.properties.PropertySheetEntry;
  */
 public class ValidatingPropertySheetEntry extends PropertySheetEntry {
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected PropertySheetEntry createChildEntry() {
         return new ValidatingPropertySheetEntry();
@@ -72,9 +69,6 @@ public class ValidatingPropertySheetEntry extends PropertySheetEntry {
         return Collections.emptyList();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Image getImage() {
         Image image = super.getImage();
@@ -95,9 +89,6 @@ public class ValidatingPropertySheetEntry extends PropertySheetEntry {
         return null;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getDescription() {
         String description =  super.getDescription();

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacer.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacer.java
@@ -58,9 +58,6 @@ public class DeprecatedLayoutOptionReplacer implements IGraphElementVisitor {
                 CoreOptions.NODE_SIZE_OPTIONS, SPACE_EFFICIENT
             );
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void visit(final ElkGraphElement element) {
         RULES.forEach((option, replacer) -> {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutAlgorithmData.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutAlgorithmData.java
@@ -73,9 +73,7 @@ public final class LayoutAlgorithmData implements ILayoutMetaData {
         this.validatorClass = builder.validatorClass;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean equals(final Object obj) {
         if (obj instanceof LayoutAlgorithmData) {
             return this.id.equals(((LayoutAlgorithmData) obj).id);
@@ -83,16 +81,11 @@ public final class LayoutAlgorithmData implements ILayoutMetaData {
         return false;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int hashCode() {
         return id.hashCode();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "Layout Algorithm: " + id;
@@ -175,23 +168,17 @@ public final class LayoutAlgorithmData implements ILayoutMetaData {
         return supportedFeatures;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getId() {
         return id;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getName() {
         return name;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getDescription() {
         return description;
     }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutCategoryData.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutCategoryData.java
@@ -40,9 +40,7 @@ public final class LayoutCategoryData implements ILayoutMetaData {
         this.description = builder.description;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean equals(final Object obj) {
         if (obj instanceof LayoutCategoryData) {
             return this.id.equals(((LayoutCategoryData) obj).id);
@@ -50,16 +48,11 @@ public final class LayoutCategoryData implements ILayoutMetaData {
         return false;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int hashCode() {
         return id.hashCode();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "Layout Type: " + id;

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutOptionData.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutOptionData.java
@@ -158,9 +158,7 @@ public final class LayoutOptionData implements ILayoutMetaData, IProperty<Object
         return (IDataObject) instance;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean equals(final Object obj) {
         if (obj instanceof LayoutOptionData) {
             return this.id.equals(((LayoutOptionData) obj).id);
@@ -171,23 +169,16 @@ public final class LayoutOptionData implements ILayoutMetaData, IProperty<Object
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int hashCode() {
         return id.hashCode();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int compareTo(final IProperty<?> other) {
         return id.compareTo(other.getId());
     }
 
-     /**
-      * {@inheritDoc}
-      */
      @Override
     public String toString() {
         return "Layout Option: " + id;
@@ -477,9 +468,7 @@ public final class LayoutOptionData implements ILayoutMetaData, IProperty<Object
         return dependencies;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getId() {
         return id;
     }
@@ -543,9 +532,7 @@ public final class LayoutOptionData implements ILayoutMetaData, IProperty<Object
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     @SuppressWarnings("unchecked")
     public Comparable<? super Object> getLowerBound() {
         if (lowerBound instanceof Comparable<?>) {
@@ -563,9 +550,7 @@ public final class LayoutOptionData implements ILayoutMetaData, IProperty<Object
         this.lowerBound = lowerBound;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     @SuppressWarnings("unchecked")
     public Comparable<? super Object> getUpperBound() {
         if (upperBound instanceof Comparable<?>) {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/BezierSpline.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/BezierSpline.java
@@ -174,9 +174,6 @@ public class BezierSpline {
         return curves;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         StringBuilder s = new StringBuilder();

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/CubicSplineInterpolator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/CubicSplineInterpolator.java
@@ -182,31 +182,23 @@ public class CubicSplineInterpolator implements ISplineInterpolator {
         return spline;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public BezierSpline interpolatePoints(final KVector[] points) {
         return calculateOpenBezierSpline(points);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public BezierSpline interpolatePoints(final LinkedList<KVector> points) {
         return calculateOpenBezierSpline(points.toArray(new KVector[points.size()]));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public BezierSpline interpolatePoints(final KVector[] points, final KVector startVec,
             final KVector endVec, final boolean tangendScale) {
         return calculateOpenBezierSpline(points, startVec, endVec, tangendScale);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public BezierSpline interpolatePoints(final LinkedList<KVector> points, final KVector startVec,
             final KVector endVec, final boolean tangendScale) {
         return calculateOpenBezierSpline(points.toArray(new KVector[points.size()]), startVec,

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkMargin.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkMargin.java
@@ -73,9 +73,6 @@ public class ElkMargin extends Spacing {
         super(other.top, other.right, other.bottom, other.left);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     // elkjs-exclude-start
     @Override
     // elkjs-exclude-end

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkPadding.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkPadding.java
@@ -73,9 +73,6 @@ public class ElkPadding extends Spacing {
         super(other.top, other.right, other.bottom, other.left);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     // elkjs-exclude-start
     @Override
     // elkjs-exclude-end

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkRectangle.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkRectangle.java
@@ -172,17 +172,11 @@ public class ElkRectangle {
         y += offset.y;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "Rect[x=" + x + ",y=" + y + ",w=" + width + ",h=" + height + "]";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj == null || !(obj instanceof ElkRectangle)) {
@@ -193,9 +187,6 @@ public class ElkRectangle {
                 && Objects.equals(width, other.width) && Objects.equals(height, other.height);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         return Objects.hash(x, y, width, height);

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/KVector.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/KVector.java
@@ -103,17 +103,11 @@ public final class KVector implements IDataObject, Cloneable {
         return new KVector(x, y);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "(" + x + "," + y + ")";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof KVector) {
@@ -151,9 +145,6 @@ public final class KVector implements IDataObject, Cloneable {
                 && Math.abs(this.y - other.y) <= fuzzyness;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         return Double.valueOf(x).hashCode() + Integer.reverse(Double.valueOf(y).hashCode());
@@ -489,9 +480,7 @@ public final class KVector implements IDataObject, Cloneable {
         return Double.isInfinite(x) || Double.isInfinite(y);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void parse(final String string) {
         int start = 0;
         while (start < string.length() && isdelim(string.charAt(start), "([{\"' \t\r\n")) {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/KVectorChain.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/KVectorChain.java
@@ -55,9 +55,6 @@ public final class KVectorChain extends LinkedList<KVector> implements IDataObje
         addAll(vectors);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder("(");
@@ -72,9 +69,6 @@ public final class KVectorChain extends LinkedList<KVector> implements IDataObje
         return builder.append(")").toString();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public KVector[] toArray() {
         int i = 0;
@@ -106,9 +100,7 @@ public final class KVectorChain extends LinkedList<KVector> implements IDataObje
         return result;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void parse(final String string) {
         String[] tokens = string.split(",|;|\\(|\\)|\\[|\\]|\\{|\\}| |\t|\n");
         // String::split may contain empty strings whenever two delimiters follow each other

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/Spacing.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/Spacing.java
@@ -175,9 +175,6 @@ public abstract class Spacing implements IDataObject, Cloneable {
         return this.getTop() + this.getBottom(); 
     } 
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Spacing) {
@@ -189,9 +186,6 @@ public abstract class Spacing implements IDataObject, Cloneable {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         // I don't care very much to define explicit constants for this calculation.
@@ -208,17 +202,12 @@ public abstract class Spacing implements IDataObject, Cloneable {
         // CHECKSTYLEON MagicNumber
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "[top=" + top + ",left=" + left + ",bottom=" + bottom + ",right=" + right + "]";
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void parse(final String string) {
         int start = 0;
         while (start < string.length() && isdelim(string.charAt(start), "([{\"' \t\r\n")) {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/AlgorithmFactory.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/AlgorithmFactory.java
@@ -41,9 +41,7 @@ public class AlgorithmFactory implements IFactory<AbstractLayoutProvider> {
         this.parameter = theparameter;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public AbstractLayoutProvider create() {
         try {
             AbstractLayoutProvider algorithm = clazz.newInstance();
@@ -56,9 +54,7 @@ public class AlgorithmFactory implements IFactory<AbstractLayoutProvider> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void destroy(final AbstractLayoutProvider obj) {
         obj.dispose();
     }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/DefaultFactory.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/DefaultFactory.java
@@ -29,9 +29,7 @@ public final class DefaultFactory<T> implements IFactory<T> {
         this.clazz = theclazz;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public T create() {
         try {
             return clazz.newInstance();
@@ -42,9 +40,7 @@ public final class DefaultFactory<T> implements IFactory<T> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void destroy(final T obj) {
         // do nothing by default, override in subclasses
     }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/Maybe.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/Maybe.java
@@ -85,9 +85,6 @@ public final class Maybe<T> implements Iterable<T> {
         this.object = theobject;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Maybe<?>) {
@@ -99,9 +96,6 @@ public final class Maybe<T> implements Iterable<T> {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         if (object == null) {
@@ -111,9 +105,6 @@ public final class Maybe<T> implements Iterable<T> {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (object == null) {
@@ -141,9 +132,7 @@ public final class Maybe<T> implements Iterable<T> {
         return object;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Iterator<T> iterator() {
         return new Iterator<T>() {
             private boolean visited = false;

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/Pair.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/Pair.java
@@ -89,9 +89,7 @@ public final class Pair<F, S> implements Iterable<Object> {
             Serializable {
         private static final long serialVersionUID = 1;
 
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final Pair<F, S> o1, final Pair<F, S> o2) {
             return o1.first.compareTo(o2.first);
         }
@@ -107,9 +105,7 @@ public final class Pair<F, S> implements Iterable<Object> {
             Serializable {
         private static final long serialVersionUID = 1;
 
-        /**
-         * {@inheritDoc}
-         */
+        @Override
         public int compare(final Pair<F, S> o1, final Pair<F, S> o2) {
             return o1.second.compareTo(o2.second);
         }
@@ -147,9 +143,6 @@ public final class Pair<F, S> implements Iterable<Object> {
         this.second = entry.getValue();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Pair<?, ?>) {
@@ -168,9 +161,6 @@ public final class Pair<F, S> implements Iterable<Object> {
     private static final int MASK1 = (1 << HALF_WORD) - 1;
     private static final int MASK2 = ~MASK1;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         int firstCode = first == null ? 0 : first.hashCode();
@@ -183,9 +173,6 @@ public final class Pair<F, S> implements Iterable<Object> {
                 | (first2 ^ (second1 << HALF_WORD));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         if (first == null && second == null) {
@@ -235,9 +222,7 @@ public final class Pair<F, S> implements Iterable<Object> {
         return second;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Iterator<Object> iterator() {
         return new Iterator<Object>() {
             private boolean visitedFirst = false;

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/RandomLayoutProvider.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/RandomLayoutProvider.java
@@ -40,9 +40,6 @@ import com.google.common.collect.Iterables;
  */
 public class RandomLayoutProvider extends AbstractLayoutProvider {
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void layout(final ElkNode parentNode, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Random Layout", 1);

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/selection/DefaultSelectionIterator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/selection/DefaultSelectionIterator.java
@@ -55,9 +55,6 @@ public class DefaultSelectionIterator extends SelectionIterator {
         this.followEdgeDirection = followEdgeDirection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Iterator<? extends ElkGraphElement> getChildren(final Object object) {
         // Ensure that the visited set is properly initialized

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/GraphIssue.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/GraphIssue.java
@@ -88,9 +88,6 @@ public class GraphIssue {
         return severity;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof GraphIssue) {
@@ -102,17 +99,11 @@ public class GraphIssue {
         return false;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int hashCode() {
         return element.hashCode() ^ message.hashCode() ^ severity.hashCode();
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder();

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/GraphValidator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/GraphValidator.java
@@ -139,9 +139,6 @@ public class GraphValidator implements IValidatingGraphElementVisitor {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<GraphIssue> getIssues() {
         if (algorithmSpecificValidators.isEmpty()) {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/LayoutOptionValidator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/validation/LayoutOptionValidator.java
@@ -109,9 +109,6 @@ public class LayoutOptionValidator implements IValidatingGraphElementVisitor {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<GraphIssue> getIssues() {
         return issues;

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/MapPropertyHolder.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/MapPropertyHolder.java
@@ -29,9 +29,6 @@ public class MapPropertyHolder implements IPropertyHolder, Serializable {
     /** map of property identifiers to their values. */
     private HashMap<IProperty<?>, Object> propertyMap;
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public <T> MapPropertyHolder setProperty(final IProperty<? super T> property, final T value) {
         if (value == null) {
@@ -43,9 +40,6 @@ public class MapPropertyHolder implements IPropertyHolder, Serializable {
         return this;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getProperty(final IProperty<T> property) {
@@ -74,17 +68,11 @@ public class MapPropertyHolder implements IPropertyHolder, Serializable {
         return defaultValue;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean hasProperty(final IProperty<?> property) {
         return propertyMap != null && propertyMap.containsKey(property);
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public MapPropertyHolder copyProperties(final IPropertyHolder other) {
         if (other == null) {
@@ -103,9 +91,6 @@ public class MapPropertyHolder implements IPropertyHolder, Serializable {
         return this;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Map<IProperty<?>, Object> getAllProperties() {
         if (propertyMap == null) {

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/Property.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/Property.java
@@ -93,9 +93,7 @@ public class Property<T> implements IProperty<T>, Comparable<IProperty<?>> {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean equals(final Object obj) {
         if (obj instanceof IProperty<?>) {
             return this.id.equals(((IProperty<?>) obj).getId());
@@ -104,16 +102,12 @@ public class Property<T> implements IProperty<T>, Comparable<IProperty<?>> {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int hashCode() {
         return id.hashCode();
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String toString() {
         return id;
     }
@@ -144,30 +138,22 @@ public class Property<T> implements IProperty<T>, Comparable<IProperty<?>> {
         }
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String getId() {
         return id;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Comparable<? super T> getLowerBound() {
         return lowerBound;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Comparable<? super T> getUpperBound() {
         return upperBound;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int compareTo(final IProperty<?> other) {
         return id.compareTo((String) other.getId());
     }

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/PropertyHolderComparator.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/PropertyHolderComparator.java
@@ -44,9 +44,7 @@ public final class PropertyHolderComparator<T extends Comparable<T>>
         this.property = property;
     }
     
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int compare(final IPropertyHolder ph1, final IPropertyHolder ph2) {
         T p1 = ph1.getProperty(property);
         T p2 = ph2.getProperty(property);

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/ElkGraphUtil.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/ElkGraphUtil.java
@@ -708,9 +708,6 @@ public final class ElkGraphUtil {
         private static final long serialVersionUID = 1L;
 
 
-        /**
-         * {@inheritDoc}.
-         */
         PropertiesSkippingTreeIterator(final Object object, final boolean includeRoot) {
             super(object, includeRoot);
         }

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/compaction/CompactionTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/compaction/CompactionTest.java
@@ -587,9 +587,6 @@ public class CompactionTest {
             return hitbox.x;
         }
         
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public String toString() {
             return ""; // dont spam the debug output


### PR DESCRIPTION
Ran the following:
```
find . -name "*.java" -exec perl -i -0777 -pe 's/\/\*\*(\ |\t)*\s{1,2}(\ |\t)*\*(\ |\t)*\{\@inheritDoc\}\.?\s{1,2}(\ |\t)*\*\/(\ |\t)*(\s{1,2}(\ |\t)*\@Override)?/\@Override/sg' {} \;
```