### PR TITLE
[PR] Alg: Fix negative node margins. #616

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/NodeMarginCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/NodeMarginCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 Kiel University and others.
+ * Copyright (c) 2010, 2020 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,8 +35,6 @@ import org.eclipse.elk.core.util.adapters.GraphAdapters.PortAdapter;
  * </dl>
  *
  * @see LabelAndNodeSizeProcessor
- * @author cds
- * @author uru
  */
 public final class NodeMarginCalculator  {
 
@@ -210,12 +208,13 @@ public final class NodeMarginCalculator  {
                     node, null, null, labelSpacing);
         }
         
-        // Reset the margin
+        // Reset the margin (guard against very small double precision errors which can cause the results to be small
+        // negative values, which doesn't make sense -- see #616)
         ElkMargin margin = new ElkMargin(node.getMargin());
-        margin.top = node.getPosition().y - boundingBox.y;
-        margin.bottom = boundingBox.y + boundingBox.height - (node.getPosition().y + node.getSize().y);
-        margin.left = node.getPosition().x - boundingBox.x;
-        margin.right = boundingBox.x + boundingBox.width - (node.getPosition().x + node.getSize().x);
+        margin.top = Math.max(0, node.getPosition().y - boundingBox.y);
+        margin.bottom = Math.max(0, boundingBox.y + boundingBox.height - (node.getPosition().y + node.getSize().y));
+        margin.left = Math.max(0, node.getPosition().x - boundingBox.x);
+        margin.right = Math.max(0, boundingBox.x + boundingBox.width - (node.getPosition().x + node.getSize().x));
         node.setMargin(margin);
     }
     

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodeMarginCalculatorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/NodeMarginCalculatorTest.java
@@ -51,15 +51,31 @@ public class NodeMarginCalculatorTest {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Tests
     
-    /**
-     * This method could be split into several, one for each processor. We could then check whether the margins are
-     * correct.
-     */
+    // There is one method for each intermediate processor that computes node margins. The idea is to make it
+    // clear which processor failed the test. Another way to solve this would be to extend the test framework
+    // to list a method triggered after several processors once for each such processor.
+    
     @TestAfterProcessor(InnermostNodeMarginCalculator.class)
+    public void testNodeMarginsAfterInnermostNodeMarginCalculator(final Object graph) {
+        testNodeMargins(graph);
+    }
+    
     @TestAfterProcessor(SelfLoopRouter.class)
+    public void testNodeMarginsAfterSelfLoopRouter(final Object graph) {
+        testNodeMargins(graph);
+    }
+    
     @TestAfterProcessor(CommentNodeMarginCalculator.class)
+    public void testNodeMarginsAfterCommentNodeMarginCalculator(final Object graph) {
+        testNodeMargins(graph);
+    }
+    
     @TestAfterProcessor(EndLabelPreprocessor.class)
-    public void testNodeMargins(final Object graph) {
+    public void testNodeMarginsAfterEndLabelPreprocessor(final Object graph) {
+        testNodeMargins(graph);
+    }
+    
+    private void testNodeMargins(final Object graph) {
         LGraph lGraph = (LGraph) graph;
         
         for (Layer layer : lGraph) {


### PR DESCRIPTION
When I looked into #616, I noticed that the culprit was always the `InnermostNodeMarginCalculator`, which in turn calls the `NodeMarginCalculator`. I thus fixed the issue there. If you feel like we should add the same fix to the other node margin code, I can do that as well.