### PR TITLE
[PR] Rename options *ID -> *Id

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -179,8 +179,8 @@ algorithm layered(LayeredLayoutProvider) {
     supports layering.layerChoiceConstraint
     supports crossingMinimization.positionChoiceConstraint
     supports org.eclipse.elk.interactiveLayout
-    supports layering.layerID
-    supports crossingMinimization.positionID
+    supports layering.layerId
+    supports crossingMinimization.positionId
 }
 
 /* ------------------------
@@ -234,7 +234,7 @@ group layering {
         targets nodes
     }
 
-    output option layerID: int {
+    output option layerId: int {
         label "Layer ID"
         description
             "Layer identifier that was calculated by ELK Layered for a node"
@@ -378,7 +378,7 @@ group crossingMinimization {
         targets nodes
     }
 
-    output option positionID: int {
+    output option positionId: int {
         label "Position ID"
         description
             "Position within a layer that was determined by ELK Layered for a node."

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
@@ -155,10 +155,10 @@ class ElkGraphLayoutTransferrer {
         
         
         // Apply the nodeID and layerId that were set on the LGraph on the ElkGraph
-        final int nodeID = lnode.getProperty(LayeredOptions.CROSSING_MINIMIZATION_POSITION_I_D);
-        final int layerID = lnode.getProperty(LayeredOptions.LAYERING_LAYER_I_D);
-        elknode.setProperty(LayeredOptions.CROSSING_MINIMIZATION_POSITION_I_D, nodeID);
-        elknode.setProperty(LayeredOptions.LAYERING_LAYER_I_D, layerID);
+        final int nodeID = lnode.getProperty(LayeredOptions.CROSSING_MINIMIZATION_POSITION_ID);
+        final int layerID = lnode.getProperty(LayeredOptions.LAYERING_LAYER_ID);
+        elknode.setProperty(LayeredOptions.CROSSING_MINIMIZATION_POSITION_ID, nodeID);
+        elknode.setProperty(LayeredOptions.LAYERING_LAYER_ID, layerID);
         
         // Set the node position
         elknode.setX(lnode.getPosition().x + offset.x);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ConstraintsPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ConstraintsPostprocessor.java
@@ -10,7 +10,6 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import org.eclipse.elk.alg.layered.DebugUtil;
-import org.eclipse.elk.alg.layered.JsonDebugUtil;
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
@@ -18,7 +17,6 @@ import org.eclipse.elk.alg.layered.graph.Layer;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
-import org.eclipse.elk.core.util.LoggedGraph;
 
 /**
  * Adds to each LNode the layerID and positionID that has been computed by ELK Layered.
@@ -43,8 +41,8 @@ public final class ConstraintsPostprocessor implements ILayoutProcessor<LGraph> 
 
             for (LNode currentNode : layer.getNodes()) {
                 if (currentNode.getType() == NodeType.NORMAL) {
-                    currentNode.setProperty(LayeredOptions.LAYERING_LAYER_I_D, layerIndex);
-                    currentNode.setProperty(LayeredOptions.CROSSING_MINIMIZATION_POSITION_I_D, posIndex);
+                    currentNode.setProperty(LayeredOptions.LAYERING_LAYER_ID, layerIndex);
+                    currentNode.setProperty(LayeredOptions.CROSSING_MINIMIZATION_POSITION_ID, posIndex);
                     posIndex++;
                 }
             }


### PR DESCRIPTION
Usually the naming convention during camel case is to capitilize only
the first letter of things such as "ID" etc.
Also, it fits the melk code generator better.

(The removed imports seem to have been relicts)