### PR TITLE
[PR] Layered: Fix cycles breaking layout partitions. #656

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/GraphConfigurator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/GraphConfigurator.java
@@ -254,6 +254,8 @@ final class GraphConfigurator {
         if (graphProperties.contains(GraphProperties.PARTITIONS)) {
             configuration.addBefore(LayeredPhases.P1_CYCLE_BREAKING,
                     IntermediateProcessorStrategy.PARTITION_PREPROCESSOR);
+            configuration.addBefore(LayeredPhases.P2_LAYERING,
+                    IntermediateProcessorStrategy.PARTITION_MIDPROCESSOR);
             configuration.addBefore(LayeredPhases.P3_NODE_ORDERING,
                     IntermediateProcessorStrategy.PARTITION_POSTPROCESSOR);
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
@@ -42,7 +42,7 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<LGr
     EDGE_AND_LAYER_CONSTRAINT_EDGE_REVERSER,
     /** If one of the phases is set to interactive mode, this processor positions external ports. */
     INTERACTIVE_EXTERNAL_PORT_POSITIONER,
-    /** Add constraint edges to respect partitioning of nodes. */
+    /** Reverse edges that run contrary to layout partitions. */
     PARTITION_PREPROCESSOR,
     
     // Before Phase 2
@@ -53,6 +53,8 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<LGr
     SELF_LOOP_PREPROCESSOR,
     /** Hides {@code FIRST_SEPARATE} and {@code LAST_SEPARATE} nodes. */
     LAYER_CONSTRAINT_PREPROCESSOR,
+    /** Adds edges that force layering algorithms to respect layout partitions. */
+    PARTITION_MIDPROCESSOR,
 
     // Before Phase 3
     
@@ -299,6 +301,9 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<LGr
 
         case ONE_SIDED_GREEDY_SWITCH:
             return new LayerSweepCrossingMinimizer(CrossMinType.ONE_SIDED_GREEDY_SWITCH);
+            
+        case PARTITION_MIDPROCESSOR:
+            return new PartitionMidprocessor();
 
         case PARTITION_POSTPROCESSOR:
             return new PartitionPostprocessor();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
@@ -42,7 +42,7 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<LGr
     EDGE_AND_LAYER_CONSTRAINT_EDGE_REVERSER,
     /** If one of the phases is set to interactive mode, this processor positions external ports. */
     INTERACTIVE_EXTERNAL_PORT_POSITIONER,
-    /** Reverse edges that run contrary to layout partitions. */
+    /** Reverse edges that run from higher-index to lower-index partitions. */
     PARTITION_PREPROCESSOR,
     
     // Before Phase 2

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionMidprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionMidprocessor.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.intermediate;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.elk.alg.layered.graph.LEdge;
+import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.graph.LPort;
+import org.eclipse.elk.alg.layered.options.InternalProperties;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.options.PortSide;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Add constraint edges between partitions that force layering algorithms to adhere to the partitions.
+ * 
+ * <p>
+ * In partitioned graphs, nodes may have an assigned partition. For every such node it must hold that every other node
+ * with a smaller partition is placed left to it. This is accomplished by adding partition constraint edges. For each
+ * node, we add an edge to every node in the next greater partition. During layering, the constraint edges assure the
+ * aforementioned condition. The constraint edges are removed later by the {@link PartitionPostprocessor}.
+ * </p>
+ *
+ * <dl>
+ *   <dt>Precondition:</dt>
+ *     <dd>an unlayered, acyclic graph.</dd>
+ *   <dt>Postcondition:</dt>
+ *     <dd>unlayered graph with partition constraint edges.</dd>
+ *   <dt>Slots:</dt>
+ *     <dd>Before phase 2.</dd>
+ *   <dt>Same-slot dependencies:</dt>
+ *     <dd>None.</dd>
+ * </dl>
+ * 
+ * @see PartitionPreprocessor
+ * @see PartitionPostprocessor
+ */
+public class PartitionMidprocessor implements ILayoutProcessor<LGraph> {
+
+    @Override
+    public void process(final LGraph lGraph, final IElkProgressMonitor monitor) {
+        monitor.begin("Partition midprocessing", 1);
+        
+        // Collect nodes which have a partition set
+        Multimap<Integer, LNode> partitionToNodesMap = HashMultimap.create();
+        
+        // Go through all layerless nodes and collect all partition IDs in use
+        lGraph.getLayerlessNodes().stream()
+            .filter(node -> node.hasProperty(LayeredOptions.PARTITIONING_PARTITION))
+            .forEach(node -> partitionToNodesMap.put(node.getProperty(LayeredOptions.PARTITIONING_PARTITION), node));
+        
+        if (partitionToNodesMap.isEmpty()) {
+            // This shouldn't happen, but if it does, there's nothing to do
+            return;
+        }
+        
+        // Collect a sorted list of partition IDs
+        List<Integer> sortedPartitionIDs = partitionToNodesMap.keySet().stream()
+            .sorted()
+            .collect(Collectors.toList());
+        
+        // For each pair of consecutive partition IDs (a, b), connect all nodes from partition a to partition b
+        Iterator<Integer> idIterator = sortedPartitionIDs.iterator();
+        
+        Integer firstId = idIterator.next();
+        while (idIterator.hasNext()) {
+            Integer secondId = idIterator.next();
+            connectNodes(partitionToNodesMap.get(firstId), partitionToNodesMap.get(secondId));
+            firstId = secondId;
+        }
+        
+        monitor.done();
+    }
+
+    /**
+     * Connects all nodes from the first collection to all nodes from the second collection.
+     */
+    private void connectNodes(final Collection<LNode> firstPartition, final Collection<LNode> secondPartition) {
+        for (LNode node : firstPartition) {
+            LPort sourcePort = new LPort();
+            sourcePort.setNode(node);
+            sourcePort.setSide(PortSide.EAST);
+            sourcePort.setProperty(InternalProperties.PARTITION_DUMMY, true);
+            
+            for (LNode otherNode : secondPartition) {
+                LPort targetPort = new LPort();
+                targetPort.setNode(otherNode);
+                targetPort.setSide(PortSide.WEST);
+                targetPort.setProperty(InternalProperties.PARTITION_DUMMY, true);
+                
+                LEdge edge = new LEdge();
+                edge.setProperty(InternalProperties.PARTITION_DUMMY, true);
+                edge.setSource(sourcePort);
+                edge.setTarget(targetPort);
+            }
+        }
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionMidprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionMidprocessor.java
@@ -75,7 +75,8 @@ public class PartitionMidprocessor implements ILayoutProcessor<LGraph> {
             .sorted()
             .collect(Collectors.toList());
         
-        // For each pair of consecutive partition IDs (a, b), connect all nodes from partition a to partition b
+        // For each pair of consecutive partition IDs (a, b), connect all nodes from partition a to partition b; we use
+        // Integer here to avoid unnecessary unboxing.
         Iterator<Integer> idIterator = sortedPartitionIDs.iterator();
         
         Integer firstId = idIterator.next();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionPostprocessor.java
@@ -36,6 +36,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  * </dl>
  *
  * @see PartitionPreprocessor
+ * @see PartitionMidprocessor
  */
 public class PartitionPostprocessor implements ILayoutProcessor<LGraph> {
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -444,9 +444,11 @@ group partitioning {
     advanced option partition: Integer {
         label "Layout Partition"
         description
-            "Partition to which the node belongs to. If 'layoutPartitions' is true,
-             a pair of nodes with different partition indices is placed such that 
-             the node with lower index is placed to the left of the other node (with left-to-right layout direction)."
+            "Partition to which the node belongs to. If Layout Partitioning is true, a pair of nodes with different
+            partition indices is placed such that the node with lower index is placed to the left of the other node
+            (with left-to-right layout direction). Depending on the layout algorithm, this may only be guaranteed to
+            work if all nodes have a layout partition configured, or at least if edges that cross partitions are not
+            part of a partition-crossing cycle."
         targets parents, nodes
     }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -444,18 +444,21 @@ group partitioning {
     advanced option partition: Integer {
         label "Layout Partition"
         description
-            "Partition to which the node belongs to. If Layout Partitioning is true, a pair of nodes with different
-            partition indices is placed such that the node with lower index is placed to the left of the other node
-            (with left-to-right layout direction). Depending on the layout algorithm, this may only be guaranteed to
-            work if all nodes have a layout partition configured, or at least if edges that cross partitions are not
-            part of a partition-crossing cycle."
+            "Partition to which the node belongs. This requires Layout Partitioning to be active. Nodes with lower
+            partition IDs will appear to the left of nodes with higher partition IDs (assuming a left-to-right layout
+            direction)."
         targets parents, nodes
+        requires activate == true
     }
 
     advanced option activate: Boolean {
         label "Layout Partitioning"
         description
-            "Whether to activate partitioned layout."
+            "Whether to activate partitioned layout. This will allow to group nodes through the Layout Partition option.
+            a pair of nodes with different partition indices is then placed such that the node with lower index is
+            placed to the left of the other node (with left-to-right layout direction). Depending on the layout
+            algorithm, this may only be guaranteed to work if all nodes have a layout partition configured, or at least
+            if edges that cross partitions are not part of a partition-crossing cycle."
         default = false
         targets parents
     }

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PartitionPostProcessorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PartitionPostProcessorTest.java
@@ -42,7 +42,8 @@ public class PartitionPostProcessorTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("tests/layered/partitioning/**/"));
+                new ModelResourcePath("tests/layered/partitioning/**/"),
+                new ModelResourcePath("tickets/layered/656_brokenLayoutPartitions.elkt"));
     }
 
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PartitionTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/PartitionTest.java
@@ -45,7 +45,8 @@ public class PartitionTest {
     @GraphResourceProvider
     public List<AbstractResourcePath> testGraphs() {
         return Lists.newArrayList(
-                new ModelResourcePath("tests/layered/partitioning/**/"));
+                new ModelResourcePath("tests/layered/partitioning/**/"),
+                new ModelResourcePath("tickets/layered/656_brokenLayoutPartitions.elkt"));
     }
 
 


### PR DESCRIPTION
I fixed the problem by making sure before cycle breaking that all edges that cross layout partitions point from lower to higher partitions. Then, before layering, I do what we previously did before cycle breaking: add edges from nodes in lower partitions to nodes in higher partitions. Those edges are immediately removed again after layer assignment, as we already did previously.

This approach does not work with arbitrary graphs that don't assign layout partitions to all nodes. If no partition-crossing edge is part of a cycle with non-partitioned nodes, it should work. Once that property is not satisfied, we might run into cases where cycle breaking reverses edges between partitioned nodes such that those edges point in the wrong direction. While there certainly are ways to fix that, I don't see any easy ones, so that's something we might want to decide to tackle at a later time.