### PR TITLE
Don't set edge placement during JsonImport if undefined

### DIFF
--- a/plugins/org.eclipse.elk.graph.json/src/org/eclipse/elk/graph/json/JsonImporter.xtend
+++ b/plugins/org.eclipse.elk.graph.json/src/org/eclipse/elk/graph/json/JsonImporter.xtend
@@ -462,11 +462,6 @@ final class JsonImporter {
                         
                         jsonLabel.transformProperties(label)
                         jsonLabel.transformShapeLayout(label)
-                        
-                        // by default center the label
-                        if (label.getProperty(CoreOptions.EDGE_LABELS_PLACEMENT) == EdgeLabelPlacement.UNDEFINED) {
-                            label.setProperty(CoreOptions.EDGE_LABELS_PLACEMENT, EdgeLabelPlacement.CENTER)
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Deciding on a default behavior for `edgeLabels.placement` is not really a task the json importer should perform. 


Without specifying anything on a json label itself, the exported elkt node and edge labels get `edgeLabels.placement: CENTER`.

```
{
  "id": "root",
  "children": [
    {
      "id": "B",
      "labels": [ { "text": "B" } ],
      "width": 20,
      "height": 20
    }
  ]
}
```
```
graph root
node B {
	layout [ size: 20, 20 ]
	label "B" {
		edgeLabels.placement: CENTER
	}
}
```