### PR TITLE
[PR] Prevent repeated registration of layout options during PlainJavaInitialization

### DIFF
--- a/test/org.eclipse.elk.alg.test/src/org/eclipse/elk/alg/test/PlainJavaInitialization.java
+++ b/test/org.eclipse.elk.alg.test/src/org/eclipse/elk/alg/test/PlainJavaInitialization.java
@@ -51,11 +51,23 @@ public final class PlainJavaInitialization {
     private PlainJavaInitialization() {
     }
     
+    /**
+     * Avoid registering layout options and EMF stuff multiple times.
+     * <p>
+     * Note that the {@link #initializePlainJavaLayout()} method is likely to be called from several JUnit tests for
+     * them to be self-contained (i.e., for them to be run individually). As soon as all tests of a test plugin are
+     * executed, during the CI build, for instance, the registration would thus be invoked many times.
+     */
+    private static boolean initialized = false;
 
     /**
      * Setup everything to work outside of Eclipse.
      */
     public static void initializePlainJavaLayout() {
+        if (initialized) {
+            return;
+        }
+        
         // Register all meta data providers with the layout meta data service. This should usually happen automatically,
         // but the tycho-surefire test harness seems to interfere.
         LayoutMetaDataService service = LayoutMetaDataService.getInstance();
@@ -67,6 +79,8 @@ public final class PlainJavaInitialization {
         ElkGraphStandaloneSetup.doSetup();
         Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("elkg", new ElkGraphResourceFactory());
         ElkGraphPackage.eINSTANCE.eClass();
+        
+        initialized = true;
     }
 
 }

--- a/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/ExportTest.xtend
+++ b/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/ExportTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Kiel University and others.
+ * Copyright (c) 2017, 2020 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,13 +9,13 @@
  *******************************************************************************/
 package org.eclipse.elk.graph.json.test
 
-import org.eclipse.elk.core.data.LayoutMetaDataService
+import org.eclipse.elk.alg.test.PlainJavaInitialization
 import org.eclipse.elk.core.options.CoreOptions
 import org.eclipse.elk.core.options.Direction
 import org.eclipse.elk.graph.json.ElkGraphJson
 import org.eclipse.elk.graph.json.JsonExporter
 import org.eclipse.elk.graph.properties.Property
-import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 
 import static org.eclipse.elk.graph.util.ElkGraphUtil.*
@@ -26,9 +26,9 @@ import static org.junit.Assert.*
  */
 class ExportTest {
  
-  @Before
-  def void setup() {
-      LayoutMetaDataService.instance
+  @BeforeClass
+  static def void init() {
+    PlainJavaInitialization.initializePlainJavaLayout
   }
   
   @Test

--- a/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/GraphTest.xtend
+++ b/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/GraphTest.xtend
@@ -15,7 +15,7 @@ import org.eclipse.elk.core.options.CoreOptions
 import org.eclipse.elk.core.options.Direction
 import org.eclipse.elk.graph.json.ElkGraphJson
 import org.eclipse.elk.graph.json.JsonImportException
-import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 
 import static org.junit.Assert.*
@@ -24,10 +24,10 @@ import static org.junit.Assert.*
  */
 class GraphTest {
     
-    @Before
-    def void init() {
+    @BeforeClass
+    static def void init() {
         PlainJavaInitialization.initializePlainJavaLayout
-    } 
+    }
     
     @Test 
     def void graphMustBeObjectTest() {

--- a/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/IndividualSpacingsTest.xtend
+++ b/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/IndividualSpacingsTest.xtend
@@ -15,6 +15,7 @@ import org.eclipse.elk.core.options.CoreOptions
 import org.eclipse.elk.core.util.IndividualSpacings
 import org.eclipse.elk.core.util.NullElkProgressMonitor
 import org.eclipse.elk.graph.json.ElkGraphJson
+import org.junit.BeforeClass
 import org.junit.Test
 
 import static org.eclipse.elk.graph.util.ElkGraphUtil.*
@@ -27,6 +28,11 @@ class IndividualSpacingsTest {
     
     static val DOUBLE_EQ = 0.001d
         
+    @BeforeClass
+    static def void init() {
+        PlainJavaInitialization.initializePlainJavaLayout
+    }
+    
     @Test
     def void importIndividualSpacingsTest() {
         val graph = '''
@@ -88,7 +94,6 @@ class IndividualSpacingsTest {
         assertFalse(i1.hasProperty(CoreOptions.SPACING_INDIVIDUAL))
         assertTrue(i2.hasProperty(CoreOptions.SPACING_INDIVIDUAL))
         
-        PlainJavaInitialization.initializePlainJavaLayout    
         new RecursiveGraphLayoutEngine().layout(root, new NullElkProgressMonitor())
         val l1 = i1.labels.head
         val l2 = i2.labels.head

--- a/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/LayoutOptionsTest.xtend
+++ b/test/org.eclipse.elk.graph.json.test/src/org/eclipse/elk/graph/json/test/LayoutOptionsTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Kiel University and others.
+ * Copyright (c) 2017, 2020 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,23 +9,23 @@
  *******************************************************************************/
 package org.eclipse.elk.graph.json.test
 
+import com.google.common.base.CharMatcher
+import org.eclipse.elk.alg.test.PlainJavaInitialization
+import org.eclipse.elk.core.options.CoreOptions
+import org.eclipse.elk.core.options.Direction
 import org.eclipse.elk.graph.json.ElkGraphJson
+import org.eclipse.elk.graph.util.ElkGraphUtil
+import org.junit.BeforeClass
 import org.junit.Test
 
 import static org.junit.Assert.*
-import org.eclipse.elk.core.options.CoreOptions
-import org.eclipse.elk.core.options.Direction
-import org.eclipse.elk.graph.util.ElkGraphUtil
-import com.google.common.base.CharMatcher
-import org.junit.Before
-import org.eclipse.elk.alg.test.PlainJavaInitialization
 
 /**
  */
 class LayoutOptionsTest {
     
-    @Before
-    def void init() {
+    @BeforeClass
+    static def void init() {
         PlainJavaInitialization.initializePlainJavaLayout
     }
     


### PR DESCRIPTION
One test in `graph.json.test` failed after, for unknown reasons, the execution order of the unit tests during CI changed. 

The issue seemed to be that `LayeredOptions` had not been registered properly at the point of failure. 

So far I'm not aware of the root cause. However, I cleaned the tests a bit to prevent registering the layout options over and over again, which seems to fix the tests again (for now 🙄). 