### PR TITLE
[PR] Fix external port positioning

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
@@ -804,8 +804,8 @@ public final class LGraphUtil {
         dummy.setType(NodeType.EXTERNAL_PORT);
         dummy.setProperty(InternalProperties.EXT_PORT_SIZE, portSize);
         dummy.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_POS);
-        dummy.setProperty(LayeredOptions.PORT_BORDER_OFFSET,
-                propertyHolder.getProperty(LayeredOptions.PORT_BORDER_OFFSET));
+        double portBorderOffset = propertyHolder.getProperty(LayeredOptions.PORT_BORDER_OFFSET);
+        dummy.setProperty(LayeredOptions.PORT_BORDER_OFFSET, portBorderOffset);
         
         LPort dummyPort = new LPort();
         dummyPort.setNode(dummy);
@@ -841,6 +841,9 @@ public final class LGraphUtil {
             dummy.setProperty(LayeredOptions.LAYERING_LAYER_CONSTRAINT, LayerConstraint.FIRST_SEPARATE);
             dummy.setProperty(InternalProperties.EDGE_CONSTRAINT, EdgeConstraint.OUTGOING_ONLY);
             dummy.getSize().y = portSize.y;
+            if (portBorderOffset < 0) {
+                dummy.getSize().x = -portBorderOffset;
+            }
             dummyPort.setSide(PortSide.EAST);
             if (!explicitAnchor) {
                 anchor.x = portSize.x;
@@ -857,6 +860,9 @@ public final class LGraphUtil {
             dummy.setProperty(LayeredOptions.LAYERING_LAYER_CONSTRAINT, LayerConstraint.LAST_SEPARATE);
             dummy.setProperty(InternalProperties.EDGE_CONSTRAINT, EdgeConstraint.INCOMING_ONLY);
             dummy.getSize().y = portSize.y;
+            if (portBorderOffset < 0) {
+                dummy.getSize().x = -portBorderOffset;
+            }
             dummyPort.setSide(PortSide.WEST);
             if (!explicitAnchor) {
                 anchor.x = 0;
@@ -866,15 +872,25 @@ public final class LGraphUtil {
         case NORTH:
             dummy.setProperty(InternalProperties.IN_LAYER_CONSTRAINT, InLayerConstraint.TOP);
             dummy.getSize().x = portSize.x;
+            if (portBorderOffset < 0) {
+                dummy.getSize().y = -portBorderOffset;
+            }
             dummyPort.setSide(PortSide.SOUTH);
             if (!explicitAnchor) {
                 anchor.y = portSize.y;
             }
+            
+            // See comments in case WEST. This partly fixes #680.
+            anchor.y -= portSize.y;
+            
             break;
         
         case SOUTH:
             dummy.setProperty(InternalProperties.IN_LAYER_CONSTRAINT, InLayerConstraint.BOTTOM);
             dummy.getSize().x = portSize.x;
+            if (portBorderOffset < 0) {
+                dummy.getSize().y = -portBorderOffset;
+            }
             dummyPort.setSide(PortSide.NORTH);
             if (!explicitAnchor) {
                 anchor.y = 0;

--- a/test/org.eclipse.elk.alg.layered.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.layered.test/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Require-Bundle: com.google.guava;bundle-version="15.0.0",
  org.eclipse.elk.alg.common,
  org.eclipse.elk.alg.layered,
  org.eclipse.elk.alg.test,
- org.junit;bundle-version="4.12.0"
+ org.junit;bundle-version="4.12.0",
+ org.hamcrest.library
 

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/issues/Issue680Test.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/issues/Issue680Test.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.issues;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.test.PlainJavaInitialization;
+import org.eclipse.elk.core.RecursiveGraphLayoutEngine;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.options.EdgeRouting;
+import org.eclipse.elk.core.util.NullElkProgressMonitor;
+import org.eclipse.elk.core.util.Triple;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.ElkPort;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test for issue 680.
+ */
+public class Issue680Test {
+
+    @BeforeClass
+    public static void init() {
+        PlainJavaInitialization.initializePlainJavaLayout();
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Tests
+
+    public Triple<ElkNode, ElkNode, ElkNode> testGraph() {
+        ElkNode graph = ElkGraphUtil.createGraph();
+        graph.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        graph.setProperty(LayeredOptions.EDGE_ROUTING, EdgeRouting.ORTHOGONAL);
+        graph.setProperty(LayeredOptions.DIRECTION, Direction.DOWN);
+
+        ElkNode parent = ElkGraphUtil.createNode(graph);
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        parent.setProperty(LayeredOptions.EDGE_ROUTING, EdgeRouting.ORTHOGONAL);
+        parent.setProperty(LayeredOptions.DIRECTION, Direction.DOWN);
+        ElkPort p1 = ElkGraphUtil.createPort(parent);
+        p1.setWidth(15);
+        p1.setHeight(165);
+        p1.setProperty(LayeredOptions.PORT_BORDER_OFFSET, -20.0);
+        ElkPort p2 = ElkGraphUtil.createPort(parent);
+        p2.setWidth(15);
+        p2.setHeight(166);
+        p2.setProperty(LayeredOptions.PORT_BORDER_OFFSET, -22.0);
+
+        ElkNode child = ElkGraphUtil.createNode(parent);
+        child.setWidth(40.265625);
+        child.setHeight(75.5);
+        ElkPort childP1 = ElkGraphUtil.createPort(child);
+        childP1.setWidth(15);
+        childP1.setHeight(33);
+        childP1.setProperty(LayeredOptions.PORT_BORDER_OFFSET, -8.0);
+        ElkPort childP2 = ElkGraphUtil.createPort(child);
+        childP2.setWidth(15);
+        childP2.setHeight(34);
+        childP2.setProperty(LayeredOptions.PORT_BORDER_OFFSET, -8.0);
+
+        ElkGraphUtil.createSimpleEdge(p1, childP1);
+        ElkGraphUtil.createSimpleEdge(childP2, p2);
+
+        return new Triple<>(graph, parent, child);
+    }
+
+    private static final double EPSILON = 1e-5;
+
+    @Test
+    public void test() {
+        Triple<ElkNode, ElkNode, ElkNode> nodes = testGraph();
+
+        new RecursiveGraphLayoutEngine().layout(nodes.getFirst(), new NullElkProgressMonitor());
+
+        assertThat(nodes.getSecond().getY(), closeTo(157.0, EPSILON));
+        assertThat(nodes.getThird().getY(), closeTo(57.0, EPSILON));
+    }
+
+}


### PR DESCRIPTION
Fixes #680.

- Enlarge external port dummies when port border offset is negative (i.e. the port reaches into the node)
- Apply symmetric fix from #595 to NORTH side ports