### PR TITLE
[PR] Change default node label stacking dimension for Direction.UNDEFINED

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/NodeLabelAndSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/NodeLabelAndSizeCalculator.java
@@ -104,8 +104,14 @@ public final class NodeLabelAndSizeCalculator {
          * set the width of the eastern and western ones to the maximum width of the labels they will contain. We can't
          * do that for the northern and southern cells yet because port label placement is more complicated there.
          */
-        NodeLabelCellCreator.createNodeLabelCells(nodeContext, false, 
-                graph == null ? true : graph.getProperty(CoreOptions.DIRECTION).isHorizontal());
+        boolean horizontalLayoutMode = true; 
+        // If the graph is null, no layout direction is specified, or the layout direction is set to undefined, 
+        // use horizontal layout mode (which yields vertically stacked labels).
+        if (graph != null && graph.hasProperty(CoreOptions.DIRECTION)) {
+            final Direction layoutDirection = graph.getProperty(CoreOptions.DIRECTION);
+            horizontalLayoutMode = layoutDirection == Direction.UNDEFINED || layoutDirection.isHorizontal();  
+        }
+        NodeLabelCellCreator.createNodeLabelCells(nodeContext, false, horizontalLayoutMode);
         InsidePortLabelCellCreator.createInsidePortLabelCells(nodeContext);
         
         


### PR DESCRIPTION
Previously, due to the way `Direction#isHorizontal()` and `Direction#isVertically()` are implemented (simply ignoring `UNDEFINED`), an undefined layout direction resulted in a horizontal stacking of labels: left-to-right. 
As I feel vertically stacking is the more natural choice, I changed the behavior for undefined. 

Note that for layered the direction is _always_ right (internally during node label placement). For other layouters it can happen though that the direction is undefined as they do not support the option at all. 
That being said, I tend to suggest to use a different layout option to decide on the stacking dimension than the layout direction. 

![image](https://user-images.githubusercontent.com/7552459/92780081-e88c9400-f3a2-11ea-902f-8749532836ab.png)
