### PR TITLE
Build workaround for broken eclipse.urischeme dependency 

### DIFF
--- a/plugins/org.eclipse.elk.core.service/pom.xml
+++ b/plugins/org.eclipse.elk.core.service/pom.xml
@@ -51,6 +51,10 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.urischeme</artifactId>
+        </exclusion>
       </exclusions>
       <!-- transitively pulls 'org.eclipse.jface', too,
              defining e.g. 'org.eclipse.jface.preference.IPreferenceStore' -->


### PR DESCRIPTION


`org.eclipse.urischeme` depends on `com.sun.jna` in its latest version. The latter is not available on maven central though. 

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=567244