### PR TITLE
Clear suffix cache when new layout options have been registered

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
@@ -175,6 +175,9 @@ public final class LayoutMetaDataService {
             provider.apply(registry);
             registry.applyDependencies();
         }
+        // As soon as new layout options have been registered, we must clear the suffix cache to ensure unique 
+        // suffixes from now onwards
+        optionSuffixMap.clear();
     }
 
     /**


### PR DESCRIPTION
... otherwise it can happen that suffixes are not unique. 