### PR TITLE
[PR] Core: Node label padding now targets parents instead of nodes. #684

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -487,7 +487,7 @@ group nodeLabels {
         description
             "Define padding for node labels that are placed inside of a node."
         default = new ElkPadding(5)
-        targets nodes
+        targets parents
     }
 
     option placement: EnumSet<NodeLabelPlacement> {


### PR DESCRIPTION
Signed-off-by: le-cds <zephanya@web.de>