### PR TITLE
layered: Assign model order on import of hierarchical graphs. fixes #724

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -297,8 +297,10 @@ class ElkGraphImporter {
         while (!elkGraphQueue.isEmpty()) {
             ElkNode elknode = elkGraphQueue.poll();
             
-            // Assign a model order to the edges as they are read
-            elknode.setProperty(InternalProperties.MODEL_ORDER, index++);
+            if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
+                // Assign a model order to the edges as they are read
+                elknode.setProperty(InternalProperties.MODEL_ORDER, index++);
+            }
             
             // Check if the current node is to be laid out in the first place
             boolean isNodeToBeLaidOut = !elknode.getProperty(LayeredOptions.NO_LAYOUT);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -302,7 +302,9 @@ class ElkGraphImporter {
         while (!elkGraphQueue.isEmpty()) {
             ElkNode elknode = elkGraphQueue.poll();
             
-            if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE) {
+            if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE
+                    || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                    == CycleBreakingStrategy.MODEL_ORDER) {
                 // Assign a model order to the nodes as they are read
                 elknode.setProperty(InternalProperties.MODEL_ORDER, index++);
             }
@@ -369,7 +371,9 @@ class ElkGraphImporter {
                 // We don't support hyperedges
                 checkEdgeValidity(elkedge);
                 
-                if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE) {
+                if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE
+                        || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                        == CycleBreakingStrategy.MODEL_ORDER) {
                     // Assign a model order to the edges as they are read
                     elkedge.setProperty(InternalProperties.MODEL_ORDER, index++);
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -297,7 +297,7 @@ class ElkGraphImporter {
         while (!elkGraphQueue.isEmpty()) {
             ElkNode elknode = elkGraphQueue.poll();
             
-            if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
+            if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE) {
                 // Assign a model order to the nodes as they are read
                 elknode.setProperty(InternalProperties.MODEL_ORDER, index++);
             }
@@ -364,7 +364,7 @@ class ElkGraphImporter {
                 // We don't support hyperedges
                 checkEdgeValidity(elkedge);
                 
-                if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
+                if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE) {
                     // Assign a model order to the edges as they are read
                     elkedge.setProperty(InternalProperties.MODEL_ORDER, index++);
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -290,10 +290,15 @@ class ElkGraphImporter {
         
         Direction parentGraphDirection = lgraph.getProperty(LayeredOptions.DIRECTION);
 
+        // Model order index for nodes
+        int index = 0;
         // Transform the node's children
         elkGraphQueue.addAll(elkgraph.getChildren());
         while (!elkGraphQueue.isEmpty()) {
             ElkNode elknode = elkGraphQueue.poll();
+            
+            // Assign a model order to the edges as they are read
+            elknode.setProperty(InternalProperties.MODEL_ORDER, index++);
             
             // Check if the current node is to be laid out in the first place
             boolean isNodeToBeLaidOut = !elknode.getProperty(LayeredOptions.NO_LAYOUT);
@@ -346,6 +351,8 @@ class ElkGraphImporter {
             }
         }
 
+        // Model order index for edges. 
+        index = 0;
         // Transform the edges
         elkGraphQueue.add(elkgraph);
         while (!elkGraphQueue.isEmpty()) {
@@ -354,6 +361,9 @@ class ElkGraphImporter {
             for (ElkEdge elkedge : elkGraphNode.getContainedEdges()) {
                 // We don't support hyperedges
                 checkEdgeValidity(elkedge);
+                
+                // Assign a model order to the edges as they are read
+                elkedge.setProperty(InternalProperties.MODEL_ORDER, index++);
                 
                 ElkNode sourceNode = ElkGraphUtil.connectableShapeToNode(elkedge.getSources().get(0));
                 ElkNode targetNode = ElkGraphUtil.connectableShapeToNode(elkedge.getTargets().get(0));

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -298,7 +298,7 @@ class ElkGraphImporter {
             ElkNode elknode = elkGraphQueue.poll();
             
             if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
-                // Assign a model order to the edges as they are read
+                // Assign a model order to the nodes as they are read
                 elknode.setProperty(InternalProperties.MODEL_ORDER, index++);
             }
             
@@ -364,8 +364,10 @@ class ElkGraphImporter {
                 // We don't support hyperedges
                 checkEdgeValidity(elkedge);
                 
-                // Assign a model order to the edges as they are read
-                elkedge.setProperty(InternalProperties.MODEL_ORDER, index++);
+                if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
+                    // Assign a model order to the edges as they are read
+                    elkedge.setProperty(InternalProperties.MODEL_ORDER, index++);
+                }
                 
                 ElkNode sourceNode = ElkGraphUtil.connectableShapeToNode(elkedge.getSources().get(0));
                 ElkNode targetNode = ElkGraphUtil.connectableShapeToNode(elkedge.getTargets().get(0));


### PR DESCRIPTION
Simply set the model order when importing a graph (also for hierarchical graphs).

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>