### PR TITLE
layered: Added model order cycle breaker.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -25,6 +25,7 @@ import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LPadding;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.options.CrossingMinimizationStrategy;
+import org.eclipse.elk.alg.layered.options.CycleBreakingStrategy;
 import org.eclipse.elk.alg.layered.options.GraphProperties;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
@@ -224,7 +225,9 @@ class ElkGraphImporter {
         int index = 0;
         for (ElkNode child : elkgraph.getChildren()) {
             if (!child.getProperty(LayeredOptions.NO_LAYOUT)) {
-                if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
+                if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE
+                        || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                            == CycleBreakingStrategy.MODEL_ORDER) {
                     child.setProperty(InternalProperties.MODEL_ORDER, index);
                     index++;
                 }
@@ -236,7 +239,9 @@ class ElkGraphImporter {
         // (this is not part of the previous loop since all children must have already been transformed)
         index = 0;
         for (ElkEdge elkedge : elkgraph.getContainedEdges()) {
-            if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
+            if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE
+                    || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                        == CycleBreakingStrategy.MODEL_ORDER) {
                 elkedge.setProperty(InternalProperties.MODEL_ORDER, index);
                 index++;
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -57,7 +57,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             Layer previousLayer = graph.getLayers().get(previousLayerIndex);
             for (LNode node : layer.getNodes()) {
                 if (node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_ORDER
-                        || node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_POS) {
+                        && node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_POS) {
                     // Special case:
                     // If two edges (of the same node) have the same target node they should be next to each other.
                     // Therefore all ports that connect to the same node should have the same
@@ -80,7 +80,6 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                     });
                     Collections.sort(node.getPorts(),
                             new ModelOrderPortComparator(previousLayer, targetNodeModelOrder));
-                    node.cachePortSides();
                 }
             }
             // Sort nodes.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
@@ -185,21 +185,21 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
     private void updateBiggerAndSmallerAssociations(final LNode bigger, final LNode smaller) {
         HashSet<LNode> biggerNodeBiggerThan = biggerThan.get(bigger);
         HashSet<LNode> smallerNodeBiggerThan = biggerThan.get(smaller);
+        HashSet<LNode> biggerNodeSmallerThan = smallerThan.get(bigger);
+        HashSet<LNode> smallerNodeSmallerThan = smallerThan.get(smaller);
         biggerNodeBiggerThan.add(smaller);
-        for (LNode node : smallerNodeBiggerThan) {
-            if (!biggerNodeBiggerThan.contains(node)) {
-                updateBiggerAndSmallerAssociations(bigger, node);
-            }
+        smallerNodeSmallerThan.add(bigger);
+        for (LNode verySmall : smallerNodeBiggerThan) {
+            biggerNodeBiggerThan.add(verySmall);
+            smallerThan.get(verySmall).add(bigger);
+            smallerThan.get(verySmall).addAll(biggerNodeSmallerThan);
         }
         
 
-        HashSet<LNode> biggerNodeSmallerThan = smallerThan.get(bigger);
-        HashSet<LNode> smallerNodeSmallerThan = smallerThan.get(smaller);
-        smallerNodeSmallerThan.add(bigger);
-        for (LNode node : biggerNodeSmallerThan) {
-            if (!smallerNodeSmallerThan.contains(node)) {
-                updateBiggerAndSmallerAssociations(node, smaller);
-            }
+        for (LNode veryBig : biggerNodeSmallerThan) {
+            smallerNodeSmallerThan.add(veryBig);
+            biggerThan.get(veryBig).add(smaller);
+            biggerThan.get(veryBig).addAll(smallerNodeBiggerThan);
         }
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CycleBreakingStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CycleBreakingStrategy.java
@@ -14,6 +14,7 @@ import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.p1cycles.DepthFirstCycleBreaker;
 import org.eclipse.elk.alg.layered.p1cycles.GreedyCycleBreaker;
 import org.eclipse.elk.alg.layered.p1cycles.InteractiveCycleBreaker;
+import org.eclipse.elk.alg.layered.p1cycles.ModelOrderCycleBreaker;
 import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.ILayoutPhaseFactory;
 import org.eclipse.elk.graph.properties.AdvancedPropertyValue;
@@ -40,7 +41,13 @@ public enum CycleBreakingStrategy implements ILayoutPhaseFactory<LayeredPhases, 
      * a node, that movement is reflected in the decision which edges to reverse.
      */
     @AdvancedPropertyValue
-    INTERACTIVE;
+    INTERACTIVE,
+    
+    /**
+     * Reacts to the input model by respecting the initial ordering in the model file.
+     * This ordering is used to identify backwards edges.
+     */
+    MODEL_ORDER;
     
 
     @Override
@@ -54,6 +61,9 @@ public enum CycleBreakingStrategy implements ILayoutPhaseFactory<LayeredPhases, 
             
         case INTERACTIVE:
             return new InteractiveCycleBreaker();
+            
+        case MODEL_ORDER:
+            return new ModelOrderCycleBreaker();
             
         default:
             throw new IllegalArgumentException(

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
@@ -21,6 +21,7 @@ import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.alg.layered.options.PortType;
+import org.eclipse.elk.core.UnsupportedConfigurationException;
 import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
@@ -64,7 +65,7 @@ public final class ModelOrderCycleBreaker implements ILayoutPhase<LayeredPhases,
                     for (LEdge edge : port.getOutgoingEdges()) {
                         LNode target = edge.getTarget().getNode();
                         if (target != source) {
-                            int modelOrderTarget = source.getProperty(InternalProperties.MODEL_ORDER);
+                            int modelOrderTarget = target.getProperty(InternalProperties.MODEL_ORDER);
                             if (modelOrderTarget < modelOrderSource) {
                                 revEdges.add(edge);
                             }
@@ -76,11 +77,11 @@ public final class ModelOrderCycleBreaker implements ILayoutPhase<LayeredPhases,
             // reverse the gathered edges
             for (LEdge edge : revEdges) {
                 edge.reverse(layeredGraph, true);
+                layeredGraph.setProperty(InternalProperties.CYCLIC, true);
             }
-            
             revEdges.clear();
         } else {
-            throw new IllegalArgumentException(
+            throw new UnsupportedConfigurationException(
                     "Model order has to be considered to use the model order cycle breaker " + this.toString());
         }
         monitor.done();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.p1cycles;
+
+import java.util.List;
+
+import org.eclipse.elk.alg.layered.LayeredPhases;
+import org.eclipse.elk.alg.layered.graph.LEdge;
+import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.graph.LPort;
+import org.eclipse.elk.alg.layered.intermediate.IntermediateProcessorStrategy;
+import org.eclipse.elk.alg.layered.options.InternalProperties;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.OrderingStrategy;
+import org.eclipse.elk.alg.layered.options.PortType;
+import org.eclipse.elk.core.alg.ILayoutPhase;
+import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+
+import com.google.common.collect.Lists;
+
+/**
+ * A cycle breaker that reverses all edges that go against the model order,
+ * i.e. edges from high model order to low model order.
+ * Requires considerModelOrder to be a non NONE value.
+ * 
+ * <dl>
+ *   <dt>Precondition:</dt><dd>none</dd>
+ *   <dt>Postcondition:</dt><dd>the graph has no cycles</dd>
+ * </dl>
+ * 
+ * @author sdo
+ */
+public final class ModelOrderCycleBreaker implements ILayoutPhase<LayeredPhases, LGraph> {
+
+    /** intermediate processing configuration. */
+    private static final LayoutProcessorConfiguration<LayeredPhases, LGraph> INTERMEDIATE_PROCESSING_CONFIGURATION =
+        LayoutProcessorConfiguration.<LayeredPhases, LGraph>create()
+            .addAfter(LayeredPhases.P5_EDGE_ROUTING, IntermediateProcessorStrategy.REVERSED_EDGE_RESTORER);
+
+    @Override
+    public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
+        return INTERMEDIATE_PROCESSING_CONFIGURATION;
+    }
+
+    @Override
+    public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
+        monitor.begin("Model order cycle breaking", 1);
+        
+        if (layeredGraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) != OrderingStrategy.NONE) {
+            // gather edges that point to the wrong direction
+            List<LEdge> revEdges = Lists.newArrayList();
+            for (LNode source : layeredGraph.getLayerlessNodes()) {
+                int modelOrderSource = source.getProperty(InternalProperties.MODEL_ORDER);
+                for (LPort port : source.getPorts(PortType.OUTPUT)) {
+                    for (LEdge edge : port.getOutgoingEdges()) {
+                        LNode target = edge.getTarget().getNode();
+                        if (target != source) {
+                            int modelOrderTarget = source.getProperty(InternalProperties.MODEL_ORDER);
+                            if (modelOrderTarget < modelOrderSource) {
+                                revEdges.add(edge);
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // reverse the gathered edges
+            for (LEdge edge : revEdges) {
+                edge.reverse(layeredGraph, true);
+            }
+            
+            revEdges.clear();
+        } else {
+            throw new IllegalArgumentException(
+                    "Model order has to be considered to use the model order cycle breaker " + this.toString());
+        }
+        monitor.done();
+    }
+}

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
@@ -19,9 +19,7 @@ import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.intermediate.IntermediateProcessorStrategy;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
-import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.alg.layered.options.PortType;
-import org.eclipse.elk.core.UnsupportedConfigurationException;
 import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
@@ -31,7 +29,6 @@ import com.google.common.collect.Lists;
 /**
  * A cycle breaker that reverses all edges that go against the model order,
  * i.e. edges from high model order to low model order.
- * Requires considerModelOrder to be a non NONE value.
  * 
  * <dl>
  *   <dt>Precondition:</dt>
@@ -63,10 +60,6 @@ public final class ModelOrderCycleBreaker implements ILayoutPhase<LayeredPhases,
         firstSeparateModelOrder = 0;
         lastSeparateModelOrder = 0;
         
-        if (layeredGraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER) == OrderingStrategy.NONE) {
-            throw new UnsupportedConfigurationException(
-                    "Model order has to be considered to use the model order cycle breaker " + this.toString());
-        }
         // gather edges that point to the wrong direction
         List<LEdge> revEdges = Lists.newArrayList();
         

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/BasicConsiderModelOrderTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/BasicConsiderModelOrderTest.java
@@ -19,6 +19,7 @@ import org.eclipse.elk.alg.test.framework.annotations.Algorithm;
 import org.eclipse.elk.alg.test.framework.annotations.ConfiguratorProvider;
 import org.eclipse.elk.alg.test.framework.annotations.DefaultConfiguration;
 import org.eclipse.elk.alg.test.framework.annotations.GraphResourceProvider;
+import org.eclipse.elk.alg.test.framework.annotations.TestAfterProcessor;
 import org.eclipse.elk.alg.test.framework.io.AbstractResourcePath;
 import org.eclipse.elk.alg.test.framework.io.FileExtensionFilter;
 import org.eclipse.elk.alg.test.framework.io.ModelResourcePath;
@@ -73,4 +74,9 @@ public class BasicConsiderModelOrderTest {
     // Tests
     
     // Just check for errors that might occur
+    
+    @TestAfterProcessor(SortByInputModelProcessor.class)
+    public void test(final Object graph) {
+        assert(true);
+    }
 }

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/BasicConsiderModelOrderTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/BasicConsiderModelOrderTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.intermediate;
+
+import java.util.List;
+
+import org.eclipse.elk.alg.layered.options.CrossingMinimizationStrategy;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.OrderingStrategy;
+import org.eclipse.elk.alg.test.framework.LayoutTestRunner;
+import org.eclipse.elk.alg.test.framework.annotations.Algorithm;
+import org.eclipse.elk.alg.test.framework.annotations.ConfiguratorProvider;
+import org.eclipse.elk.alg.test.framework.annotations.DefaultConfiguration;
+import org.eclipse.elk.alg.test.framework.annotations.GraphResourceProvider;
+import org.eclipse.elk.alg.test.framework.io.AbstractResourcePath;
+import org.eclipse.elk.alg.test.framework.io.FileExtensionFilter;
+import org.eclipse.elk.alg.test.framework.io.ModelResourcePath;
+import org.eclipse.elk.core.LayoutConfigurator;
+import org.eclipse.elk.graph.ElkNode;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.Lists;
+
+@RunWith(LayoutTestRunner.class)
+@Algorithm(LayeredOptions.ALGORITHM_ID)
+@DefaultConfiguration()
+public class BasicConsiderModelOrderTest {
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Sources
+
+    @GraphResourceProvider
+    public List<AbstractResourcePath> testGraphs() {
+        return Lists.newArrayList(
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
+    }
+    
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Configuration
+
+    @ConfiguratorProvider
+    public LayoutConfigurator nodesAndEdgesConfigurator() {
+        LayoutConfigurator config = new LayoutConfigurator();
+        config.configure(ElkNode.class).setProperty(
+                LayeredOptions.CROSSING_MINIMIZATION_STRATEGY,
+                CrossingMinimizationStrategy.LAYER_SWEEP);
+        config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER,
+                OrderingStrategy.NODES_AND_EDGES);
+        return config;
+    }
+
+    @ConfiguratorProvider
+    public LayoutConfigurator preferEdgesConfigurator() {
+        LayoutConfigurator config = new LayoutConfigurator();
+        config.configure(ElkNode.class).setProperty(
+                LayeredOptions.CROSSING_MINIMIZATION_STRATEGY,
+                CrossingMinimizationStrategy.LAYER_SWEEP);
+        config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER,
+                OrderingStrategy.PREFER_EDGES);
+        return config;
+    }
+    
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Tests
+    
+    // Just check for errors that might occur
+}

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
@@ -73,17 +73,24 @@ public class BasicCycleBreakerTest extends TestGraphCreator {
     }
     
     @ConfiguratorProvider
-    public LayoutConfigurator modelOrderonfigurator() {
-        return configuratorFor(CycleBreakingStrategy.MODEL_ORDER);
+    public LayoutConfigurator modelOrderPreferEdgesConfigurator() {
+        LayoutConfigurator config = configuratorFor(CycleBreakingStrategy.MODEL_ORDER);
+        config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER,
+                OrderingStrategy.PREFER_EDGES);
+        return config;
+    }
+    
+    @ConfiguratorProvider
+    public LayoutConfigurator modelOrderNodesAndEdgesConfigurator() {
+        LayoutConfigurator config = configuratorFor(CycleBreakingStrategy.MODEL_ORDER);
+        config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER,
+                OrderingStrategy.NODES_AND_EDGES);
+        return config;
     }
     
     private LayoutConfigurator configuratorFor(final CycleBreakingStrategy strategy) {
         LayoutConfigurator config = new LayoutConfigurator();
         config.configure(ElkNode.class).setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, strategy);
-        if (strategy == CycleBreakingStrategy.MODEL_ORDER) {
-            config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER,
-                    OrderingStrategy.PREFER_EDGES);
-        }
         return config;
     }
     
@@ -123,6 +130,7 @@ public class BasicCycleBreakerTest extends TestGraphCreator {
     @TestAfterProcessor(DepthFirstCycleBreaker.class)
     @TestAfterProcessor(GreedyCycleBreaker.class)
     @TestAfterProcessor(InteractiveCycleBreaker.class)
+    @TestAfterProcessor(ModelOrderCycleBreaker.class)
     public void testIsAcyclic(final Object graph) {
         LGraph lGraph = (LGraph) graph;
         

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
@@ -23,6 +23,7 @@ import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.intermediate.greedyswitch.TestGraphCreator;
 import org.eclipse.elk.alg.layered.options.CycleBreakingStrategy;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.alg.test.framework.LayoutTestRunner;
 import org.eclipse.elk.alg.test.framework.annotations.Algorithm;
 import org.eclipse.elk.alg.test.framework.annotations.Configurator;
@@ -71,9 +72,18 @@ public class BasicCycleBreakerTest extends TestGraphCreator {
         return configuratorFor(CycleBreakingStrategy.GREEDY);
     }
     
+    @ConfiguratorProvider
+    public LayoutConfigurator modelOrderonfigurator() {
+        return configuratorFor(CycleBreakingStrategy.MODEL_ORDER);
+    }
+    
     private LayoutConfigurator configuratorFor(final CycleBreakingStrategy strategy) {
         LayoutConfigurator config = new LayoutConfigurator();
         config.configure(ElkNode.class).setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, strategy);
+        if (strategy == CycleBreakingStrategy.MODEL_ORDER) {
+            config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER,
+                    OrderingStrategy.PREFER_EDGES);
+        }
         return config;
     }
     


### PR DESCRIPTION
Added a cycle breaker that reverses edges going against the model order.
Edges should always go from low model order to high model order.

- [x] Using this strategy in a model with layer constraints causes an NPE. One could either ignore these layer constraints and only use the model order or use it additionally to the model order (which might be the better solution).
- [x] Check whether hierarchical and normal graphs cover this cycle breaker via tests

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>