### PR TITLE
Update Eclipse Setup Download URL

### DIFF
--- a/setups/EclipseLayoutKernel.setup
+++ b/setups/EclipseLayoutKernel.setup
@@ -264,7 +264,7 @@
       <requirement
           name="org.eclipse.elk.sdk.feature.feature.group"/>
       <repository
-          url="http://build.eclipse.org/modeling/elk/updates/nightly/"/>
+          url="https://download.eclipse.org/elk/updates/nightly/"/>
     </setupTask>
     <setupTask
         xsi:type="setup.targlets:TargletTask">


### PR DESCRIPTION
As suggested by @uruuru in #772, this updates the eclipse download URL so that you can set up locally with the Eclipse Installer