### PR TITLE
Clone properties to avoid sharing mutable values in multiple elements

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkUtil.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkUtil.java
@@ -347,7 +347,7 @@ public final class ElkUtil {
         
         if (sizeConstraint.contains(SizeConstraint.MINIMUM_SIZE)) {
             Set<SizeOptions> sizeOptions = node.getProperty(CoreOptions.NODE_SIZE_OPTIONS);
-            KVector minSize = node.getProperty(CoreOptions.NODE_SIZE_MINIMUM);
+            KVector minSize = new KVector(node.getProperty(CoreOptions.NODE_SIZE_MINIMUM));
 
             // If minimum width or height are not set, maybe default to default values
             if (sizeOptions.contains(SizeOptions.DEFAULT_MINIMUM_SIZE)) {


### PR DESCRIPTION
Fixes #781 in two ways:

 * Always clone property values when applying a `LayoutConfigurator`
 * Clone the `NODE_SIZE_MINIMUM` value so it can be safely modified
 
Both changes independently fix the concrete example given in #781, and in both cases the result looks like this:
![Screen Shot 2021-09-27 at 16 03 46](https://user-images.githubusercontent.com/4067210/134924509-5a72a6ed-d88f-481a-9a06-a0798daebca4.png)

_Note:_ I chose not to throw an exception in case cloning the value fails (cf. `Property#getDefault()`) to avoid potentially breaking existing applications.