### PR TITLE
Handle backward edges to not produce order violations that do not exist.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -62,25 +62,11 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                     // If two edges (of the same node) have the same target node they should be next to each other.
                     // Therefore all ports that connect to the same node should have the same
                     // (their minimal) model order.
-                    Map<LNode, Integer> targetNodeModelOrder = new HashMap<>();
                     // Get minimal model order for target node
-
-                    node.getPorts().stream().filter(p -> !p.getOutgoingEdges().isEmpty()).forEach(p -> {
-                        LNode targetNode = getTargetNode(p);
-                        p.setProperty(InternalProperties.LONG_EDGE_TARGET_NODE, targetNode);
-                        if (targetNode != null) {
-                            int previousOrder = Integer.MAX_VALUE;
-                            if (targetNodeModelOrder.containsKey(targetNode)) {
-                                previousOrder = targetNodeModelOrder.get(targetNode);
-                            }
-                            targetNodeModelOrder.put(targetNode,
-                                    Math.min(p.getOutgoingEdges().get(0).getProperty(InternalProperties.MODEL_ORDER),
-                                            previousOrder));
-                        }
-                    });
-                    node.setProperty(InternalProperties.TARGET_NODE_MODEL_ORDER, targetNodeModelOrder);
+                    
                     Collections.sort(node.getPorts(),
-                            new ModelOrderPortComparator(previousLayer, targetNodeModelOrder));
+                            new ModelOrderPortComparator(previousLayer, 
+                                    longEdgeTargetNodePreprocessing(node)));
                 }
             }
             // Sort nodes.
@@ -90,6 +76,36 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                             graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY)));
             layerIndex++;
         }
+    }
+    
+    /**
+     * Calculate long edge target of port and saves it and adds a map of all long edge targets to the node.
+     * @param node the node
+     * @return A map of all long edge targets of a node
+     */
+    public static Map<LNode, Integer> longEdgeTargetNodePreprocessing(LNode node) {
+        Map<LNode, Integer> targetNodeModelOrder = new HashMap<>();
+        if (node.hasProperty(InternalProperties.TARGET_NODE_MODEL_ORDER)) {
+            return node.getProperty(InternalProperties.TARGET_NODE_MODEL_ORDER);
+        }
+        node.getPorts().stream().filter(p -> !p.getOutgoingEdges().isEmpty()).forEach(p -> {
+            LNode targetNode = getTargetNode(p);
+            p.setProperty(InternalProperties.LONG_EDGE_TARGET_NODE, targetNode);
+            if (targetNode != null) {
+                int previousOrder = Integer.MAX_VALUE;
+                if (targetNodeModelOrder.containsKey(targetNode)) {
+                    previousOrder = targetNodeModelOrder.get(targetNode);
+                }
+                LEdge edge = p.getOutgoingEdges().get(0);
+                if (!edge.getProperty(InternalProperties.REVERSED)) {
+                    targetNodeModelOrder.put(targetNode, Math
+                            .min(edge.getProperty(InternalProperties.MODEL_ORDER), previousOrder));
+                }
+            }
+        });
+        node.setProperty(InternalProperties.TARGET_NODE_MODEL_ORDER, targetNodeModelOrder);
+        return targetNodeModelOrder;
+        
     }
 
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -12,9 +12,7 @@ package org.eclipse.elk.alg.layered.intermediate.preserveorder;
 import java.util.Comparator;
 import java.util.Map;
 
-import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
-import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.graph.Layer;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
@@ -85,10 +83,25 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
         if (!p1.getOutgoingEdges().isEmpty() && !p2.getOutgoingEdges().isEmpty()) {
             LNode p1TargetNode = p1.getProperty(InternalProperties.LONG_EDGE_TARGET_NODE);
             LNode p2TargetNode = p2.getProperty(InternalProperties.LONG_EDGE_TARGET_NODE);
-            int p1Order = p1.getOutgoingEdges().get(0).getProperty(InternalProperties.MODEL_ORDER);
-            int p2Order = p2.getOutgoingEdges().get(0).getProperty(InternalProperties.MODEL_ORDER);
+            int p1Order = 0;
+            int p2Order = 0;
+            if (p1.getOutgoingEdges().get(0).hasProperty(InternalProperties.MODEL_ORDER)) {
+                p1Order = p1.getOutgoingEdges().get(0).getProperty(InternalProperties.MODEL_ORDER);
+            }
+            if (p2.getOutgoingEdges().get(0).hasProperty(InternalProperties.MODEL_ORDER)) {
+                p2Order = p1.getOutgoingEdges().get(0).getProperty(InternalProperties.MODEL_ORDER);
+            }
             
+            // Same target node
             if (p1TargetNode != null && p1TargetNode.equals(p2TargetNode)) {
+                // Backward edges below
+                if (p1.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)
+                        && !p2.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)) {
+                    return 1;
+                } else if (!p1.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)
+                        && p2.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)) {
+                    return -1;
+                }
                 return Integer.compare(p1Order, p2Order);
             }
             if (targetNodeModelOrder != null) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -24,11 +24,12 @@ import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.intermediate.IntermediateProcessorStrategy;
+import org.eclipse.elk.alg.layered.intermediate.SortByInputModelProcessor;
 import org.eclipse.elk.alg.layered.intermediate.preserveorder.ModelOrderNodeComparator;
 import org.eclipse.elk.alg.layered.intermediate.preserveorder.ModelOrderPortComparator;
-import org.eclipse.elk.alg.layered.options.LongEdgeOrderingStrategy;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.LongEdgeOrderingStrategy;
 import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.alg.layered.p3order.counting.CrossMinUtil;
 import org.eclipse.elk.core.alg.ILayoutPhase;
@@ -333,7 +334,7 @@ public class LayerSweepCrossingMinimizer
             for (LNode lNode : layer) {
                 Comparator<LPort> comp = new ModelOrderPortComparator(
                         previousLayer == -1 ? layers[0] : layers[previousLayer],
-                                lNode.getProperty(InternalProperties.TARGET_NODE_MODEL_ORDER));
+                                SortByInputModelProcessor.longEdgeTargetNodePreprocessing(lNode));
                 for (int i = 0; i < lNode.getPorts().size(); i++) {
                     for (int j = i + 1; j < lNode.getPorts().size(); j++) {
                         if (comp.compare(lNode.getPorts().get(i), lNode.getPorts().get(j)) > 0) {


### PR DESCRIPTION
When comparing ports, backward edges are always ordered below and are not taken into account for order inheritance, which only focuses on the "real" outgoing edges of the current node.

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>