### PR TITLE
core, layered: Added individual vertical and horizontal label port spacing.

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/NodeContext.java
@@ -80,8 +80,10 @@ public final class NodeContext {
     public final double labelCellSpacing;
     /** Space between a port and another port. */
     public final double portPortSpacing;
-    /** Space between a port and its labels. */
-    public final double portLabelSpacing;
+    /** Horizontal space between a port and its labels. */
+    public final double portLabelSpacingHorizontal;
+    /** Vertical space between a port and its labels. */
+    public final double portLabelSpacingVertical;
     /** Margin to leave around the set of ports on each side. */
     public final ElkMargin surroundingPortMargins;
 
@@ -152,7 +154,10 @@ public final class NodeContext {
         nodeLabelSpacing = IndividualSpacings.getIndividualOrInherited(node, CoreOptions.SPACING_LABEL_NODE);
         labelLabelSpacing = IndividualSpacings.getIndividualOrInherited(node, CoreOptions.SPACING_LABEL_LABEL);
         portPortSpacing = IndividualSpacings.getIndividualOrInherited(node, CoreOptions.SPACING_PORT_PORT);
-        portLabelSpacing = IndividualSpacings.getIndividualOrInherited(node, CoreOptions.SPACING_LABEL_PORT);
+        portLabelSpacingHorizontal =
+                IndividualSpacings.getIndividualOrInherited(node, CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
+        portLabelSpacingVertical =
+                IndividualSpacings.getIndividualOrInherited(node, CoreOptions.SPACING_LABEL_PORT_VERTICAL);
         surroundingPortMargins = IndividualSpacings.getIndividualOrInherited(
                 node, CoreOptions.SPACING_PORTS_SURROUNDING);
         

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
@@ -336,7 +336,7 @@ public final class HorizontalPortPlacementSizeCalculator {
                     // The label is either placed outside (right to the port) or possibly inside, but for a compound
                     // node, which means that it is placed right of the port as well to keep it from overlapping with
                     // inside edges
-                    portContext.portMargin.right = nodeContext.portLabelSpacing + labelWidth;
+                    portContext.portMargin.right = nodeContext.portLabelSpacingHorizontal + labelWidth;
                 }
             } else if (PortLabelPlacement.isFixed(nodeContext.portLabelsPlacement)) {
                 // The fixed port label is not considered with portContext.portLabelCell. Nevertheless, a port margin

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/InsidePortLabelCellCreator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/InsidePortLabelCellCreator.java
@@ -78,11 +78,11 @@ public final class InsidePortLabelCellCreator {
         
         switch (portSide) {
         case NORTH:
-            padding.top = nodeContext.portLabelSpacing;
+            padding.top = nodeContext.portLabelSpacingVertical;
             break;
             
         case SOUTH:
-            padding.bottom = nodeContext.portLabelSpacing;
+            padding.bottom = nodeContext.portLabelSpacingVertical;
             break;
         }
         
@@ -127,11 +127,11 @@ public final class InsidePortLabelCellCreator {
         if (minCellSize.x > 0) {
             switch (portSide) {
             case EAST:
-                theAppropriateCell.getPadding().right = nodeContext.portLabelSpacing;
+                theAppropriateCell.getPadding().right = nodeContext.portLabelSpacingHorizontal;
                 break;
                 
             case WEST:
-                theAppropriateCell.getPadding().left = nodeContext.portLabelSpacing;
+                theAppropriateCell.getPadding().left = nodeContext.portLabelSpacingHorizontal;
                 break;
             }
         }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
@@ -246,9 +246,9 @@ public final class PortLabelPlacementCalculator {
                 nodeContext.nodeLabelSpacing);
         
         // Obtain a rectangle strip overlap remover, which will actually do most of the work
-        RectangleStripOverlapRemover overlapRemover =
-                RectangleStripOverlapRemover.createForDirection(overlapRemovalDirection).withGap(
-                        nodeContext.portLabelSpacingHorizontal, nodeContext.portLabelSpacingVertical);
+        RectangleStripOverlapRemover overlapRemover = RectangleStripOverlapRemover
+                .createForDirection(overlapRemovalDirection)
+                .withGap(nodeContext.portLabelSpacingHorizontal, nodeContext.portLabelSpacingVertical);
         
         // Iterate over our ports and add rectangles to the overlap remover. Also, calculate the start coordinate
         double startCoordinate = portSide == PortSide.NORTH

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
@@ -95,7 +95,8 @@ public final class PortLabelPlacementCalculator {
         
         // Some spacings we may need later
         double labelBorderOffset = portLabelBorderOffsetForPortSide(nodeContext, portSide);
-        double portLabelSpacing = nodeContext.portLabelSpacing;
+        double portLabelSpacingHorizontal = nodeContext.portLabelSpacingHorizontal;
+        double portLabelSpacingVertical = nodeContext.portLabelSpacingVertical;
         
         for (PortContext portContext : nodeContext.portContexts.get(portSide)) {
             // If the port doesn't have labels, skip
@@ -122,7 +123,7 @@ public final class PortLabelPlacementCalculator {
             case NORTH:
                 portLabelCellRect.x = portContext.labelsNextToPort
                         ? (portSize.x - portLabelCellRect.width) / 2
-                        : portSize.x + portLabelSpacing;
+                        : portSize.x + portLabelSpacingHorizontal;
                 portLabelCellRect.y = portSize.y + portBorderOffset + labelBorderOffset;
                 portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
                 portLabelCell.setVerticalAlignment(VerticalLabelAlignment.TOP);
@@ -131,7 +132,7 @@ public final class PortLabelPlacementCalculator {
             case SOUTH:
                 portLabelCellRect.x = portContext.labelsNextToPort
                         ? (portSize.x - portLabelCellRect.width) / 2
-                        : portSize.x + portLabelSpacing;
+                        : portSize.x + portLabelSpacingHorizontal;
                 portLabelCellRect.y = -portBorderOffset - labelBorderOffset - portLabelCellRect.height;
                 portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
                 portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
@@ -145,7 +146,7 @@ public final class PortLabelPlacementCalculator {
                             : portLabelCell.getLabels().get(0).getSize().y;
                     portLabelCellRect.y = (portSize.y - labelHeight) / 2;
                 } else {
-                    portLabelCellRect.y = portSize.y + portLabelSpacing;
+                    portLabelCellRect.y = portSize.y + portLabelSpacingVertical;
                 }
                 portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
@@ -159,7 +160,7 @@ public final class PortLabelPlacementCalculator {
                             : portLabelCell.getLabels().get(0).getSize().y;
                     portLabelCellRect.y = (portSize.y - labelHeight) / 2;
                 } else {
-                    portLabelCellRect.y = portSize.y + portLabelSpacing;
+                    portLabelCellRect.y = portSize.y + portLabelSpacingVertical;
                 }
                 portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.LEFT);
                 portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
@@ -188,16 +189,16 @@ public final class PortLabelPlacementCalculator {
     private static double portLabelBorderOffsetForPortSide(final NodeContext nodeContext, final PortSide portSide) {
         switch (portSide) {
         case NORTH:
-            return nodeContext.nodeContainer.getPadding().top + nodeContext.portLabelSpacing;
+            return nodeContext.nodeContainer.getPadding().top + nodeContext.portLabelSpacingVertical;
 
         case SOUTH:
-            return nodeContext.nodeContainer.getPadding().bottom + nodeContext.portLabelSpacing;
+            return nodeContext.nodeContainer.getPadding().bottom + nodeContext.portLabelSpacingVertical;
 
         case EAST:
-            return nodeContext.nodeContainer.getPadding().right + nodeContext.portLabelSpacing;
+            return nodeContext.nodeContainer.getPadding().right + nodeContext.portLabelSpacingHorizontal;
 
         case WEST:
-            return nodeContext.nodeContainer.getPadding().left + nodeContext.portLabelSpacing;
+            return nodeContext.nodeContainer.getPadding().left + nodeContext.portLabelSpacingHorizontal;
         
         default:
             assert false;
@@ -245,9 +246,9 @@ public final class PortLabelPlacementCalculator {
                 nodeContext.nodeLabelSpacing);
         
         // Obtain a rectangle strip overlap remover, which will actually do most of the work
-        RectangleStripOverlapRemover overlapRemover = RectangleStripOverlapRemover
-                .createForDirection(overlapRemovalDirection)
-                .withGap(nodeContext.portLabelSpacing);
+        RectangleStripOverlapRemover overlapRemover =
+                RectangleStripOverlapRemover.createForDirection(overlapRemovalDirection).withGap(
+                        nodeContext.portLabelSpacingHorizontal, nodeContext.portLabelSpacingVertical);
         
         // Iterate over our ports and add rectangles to the overlap remover. Also, calculate the start coordinate
         double startCoordinate = portSide == PortSide.NORTH
@@ -285,8 +286,8 @@ public final class PortLabelPlacementCalculator {
         
         // The start coordinate needs to be offset by the port-label space
         startCoordinate += portSide == PortSide.NORTH
-                ? nodeContext.portLabelSpacing
-                : -nodeContext.portLabelSpacing;
+                ? nodeContext.portLabelSpacingVertical
+                : -nodeContext.portLabelSpacingVertical;
         
         // Invoke the overlap remover
         double stripHeight = overlapRemover
@@ -372,13 +373,13 @@ public final class PortLabelPlacementCalculator {
                     portLabelCellRect.x = (portSize.x - portLabelCellRect.width) / 2;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
                 } else if (placeFirstPortDifferently) {
-                    portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacing;
+                    portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacingHorizontal;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 } else {
-                    portLabelCellRect.x = portSize.x + nodeContext.portLabelSpacing;
+                    portLabelCellRect.x = portSize.x + nodeContext.portLabelSpacingHorizontal;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.LEFT);
                 }
-                portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacing;
+                portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacingVertical;
                 portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
                 break;
                 
@@ -387,13 +388,13 @@ public final class PortLabelPlacementCalculator {
                     portLabelCellRect.x = (portSize.x - portLabelCellRect.width) / 2;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
                 } else if (placeFirstPortDifferently) {
-                    portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacing;
+                    portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacingHorizontal;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 } else {
-                    portLabelCellRect.x = portSize.x + nodeContext.portLabelSpacing;
+                    portLabelCellRect.x = portSize.x + nodeContext.portLabelSpacingHorizontal;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.LEFT);
                 }
-                portLabelCellRect.y = portSize.y + nodeContext.portLabelSpacing;
+                portLabelCellRect.y = portSize.y + nodeContext.portLabelSpacingVertical;
                 portLabelCell.setVerticalAlignment(VerticalLabelAlignment.TOP);
                 break;
                 
@@ -405,13 +406,13 @@ public final class PortLabelPlacementCalculator {
                     portLabelCellRect.y = (portSize.y - labelHeight) / 2;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
                 } else if (placeFirstPortDifferently) {
-                    portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacing;
+                    portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacingVertical;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
                 } else {
-                    portLabelCellRect.y = portSize.y + nodeContext.portLabelSpacing;
+                    portLabelCellRect.y = portSize.y + nodeContext.portLabelSpacingVertical;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.TOP);
                 }
-                portLabelCellRect.x = portSize.x + nodeContext.portLabelSpacing;
+                portLabelCellRect.x = portSize.x + nodeContext.portLabelSpacingHorizontal;
                 portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.LEFT);
                 break;
                 
@@ -423,13 +424,13 @@ public final class PortLabelPlacementCalculator {
                     portLabelCellRect.y = (portSize.y - labelHeight) / 2;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
                 } else if (placeFirstPortDifferently) {
-                    portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacing;
+                    portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacingVertical;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
                 } else {
-                    portLabelCellRect.y = portSize.y + nodeContext.portLabelSpacing;
+                    portLabelCellRect.y = portSize.y + nodeContext.portLabelSpacingVertical;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.TOP);
                 }
-                portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacing;
+                portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacingHorizontal;
                 portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 break;
             }
@@ -472,7 +473,7 @@ public final class PortLabelPlacementCalculator {
         // Obtain a rectangle strip overlap remover, which will actually do most of the work
         RectangleStripOverlapRemover overlapRemover = RectangleStripOverlapRemover
                 .createForDirection(overlapRemovalDirection)
-                .withGap(nodeContext.portLabelSpacing);
+                .withGap(nodeContext.portLabelSpacingVertical, nodeContext.portLabelSpacingHorizontal);
         
         // Iterate over our ports and add rectangles to the overlap remover. Also, calculate the start coordinate
         double startCoordinate = portSide == PortSide.NORTH
@@ -493,10 +494,11 @@ public final class PortLabelPlacementCalculator {
             portLabelCellRect.width = portLabelCell.getMinimumWidth();
             portLabelCellRect.height = portLabelCell.getMinimumHeight();
             if (portWithSpecialNeeds) {
-                portLabelCellRect.x = portPosition.x - portLabelCell.getMinimumWidth() - nodeContext.portLabelSpacing;
+                portLabelCellRect.x =
+                        portPosition.x - portLabelCell.getMinimumWidth() - nodeContext.portLabelSpacingHorizontal;
                 portWithSpecialNeeds = false;
             } else {
-                portLabelCellRect.x = portPosition.x + portSize.x + nodeContext.portLabelSpacing;
+                portLabelCellRect.x = portPosition.x + portSize.x + nodeContext.portLabelSpacingHorizontal;
             }
             
             portLabelCell.setVerticalAlignment(verticalLabelAlignment);
@@ -513,8 +515,8 @@ public final class PortLabelPlacementCalculator {
         
         // The start coordinate needs to be offset by the port-label space
         startCoordinate += portSide == PortSide.NORTH
-                ? -nodeContext.portLabelSpacing
-                : nodeContext.portLabelSpacing;
+                ? -nodeContext.portLabelSpacingVertical
+                : nodeContext.portLabelSpacingVertical;
         
         // Invoke the overlap remover
         overlapRemover

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
@@ -319,7 +319,7 @@ public final class VerticalPortPlacementSizeCalculator {
                     // The label is either placed outside (below the port) or possibly inside, but for a compound node,
                     // which means that it is placed below the port as well to keep it from overlapping with inside
                     // edges
-                    portContext.portMargin.bottom = nodeContext.portLabelSpacing + labelHeight;
+                    portContext.portMargin.bottom = nodeContext.portLabelSpacingVertical + labelHeight;
                 }
             } else if (PortLabelPlacement.isFixed(nodeContext.portLabelsPlacement)) {
                 // The fixed port label is not considered with portContext.portLabelCell. Nevertheless, a port margin

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/overlaps/GreedyRectangleStripOverlapRemover.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/overlaps/GreedyRectangleStripOverlapRemover.java
@@ -24,7 +24,7 @@ public final class GreedyRectangleStripOverlapRemover implements IRectangleStrip
 
     @Override
     public double removeOverlaps(final RectangleStripOverlapRemover overlapRemover) {
-        final double gap = overlapRemover.getGap();
+        final double verticalGap = overlapRemover.getVerticalGap();
         Set<RectangleNode> alreadyPlacedNodes = Sets.newHashSet();
         double stripSize = 0;
         
@@ -43,10 +43,10 @@ public final class GreedyRectangleStripOverlapRemover implements IRectangleStrip
                     ElkRectangle overlapRect = overlapNode.getRectangle();
                     
                     // Check if the current y coordinate would cause an overlap with the overlap node
-                    if (yPos < overlapRect.y + overlapRect.height + gap
-                            && yPos + currRect.height + gap > overlapRect.y) {
+                    if (yPos < overlapRect.y + overlapRect.height + verticalGap
+                            && yPos + currRect.height + verticalGap > overlapRect.y) {
                         
-                        yPos = overlapRect.y + overlapRect.height + gap;
+                        yPos = overlapRect.y + overlapRect.height + verticalGap;
                     }
                 }
             }

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/overlaps/RectangleStripOverlapRemover.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/overlaps/RectangleStripOverlapRemover.java
@@ -69,8 +69,10 @@ public final class RectangleStripOverlapRemover {
 
     /** The direction in which to move rectangles to remove overlaps. */
     private OverlapRemovalDirection overlapRemovalDirection;
-    /** Gap to be left between labels for them to not be considered overlapping. */
-    private double gap = DEFAULT_GAP;
+    /** Vertical gap to be left between labels for them to not be considered overlapping. */
+    private double gapVertical = DEFAULT_GAP;
+    /** Horizontal gap to be left between labels for them to not be considered overlapping. */
+    private double gapHorizontal = DEFAULT_GAP;
     /** The coordinate where the first rectangles, viewed along the overlap removal direction, are placed. */
     private double startCoordinate = 0;
     /** The overlap strategy to use to actually remove overlaps. */
@@ -102,8 +104,9 @@ public final class RectangleStripOverlapRemover {
     /**
      * Configures the gap to be left between rectangles. Returns this instance to enable method chaining.
      */
-    public RectangleStripOverlapRemover withGap(final double theGap) {
-        gap = theGap;
+    public RectangleStripOverlapRemover withGap(final double theHorizontalGap, final double theVerticalGap) {
+        gapHorizontal = theHorizontalGap;
+        gapVertical = theVerticalGap;
         return this;
     }
     
@@ -141,10 +144,17 @@ public final class RectangleStripOverlapRemover {
     // Getters
     
     /**
-     * Returns the gap to be left between rectangles.
+     * Returns the horizontal gap to be left between rectangles.
      */
-    public double getGap() {
-        return gap;
+    public double getHorizontalGap() {
+        return gapHorizontal;
+    }
+    
+    /**
+     * Returns the horizontal gap to be left between rectangles.
+     */
+    public double getVerticalGap() {
+        return gapVertical;
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -49,7 +49,8 @@ algorithm layered(LayeredLayoutProvider) {
     supports org.eclipse.elk.spacing.edgeLabel
     supports org.eclipse.elk.spacing.edgeNode
     supports org.eclipse.elk.spacing.labelLabel
-    supports org.eclipse.elk.spacing.labelPort
+    supports org.eclipse.elk.spacing.labelPort.horizontal
+    supports org.eclipse.elk.spacing.labelPort.vertical
     supports org.eclipse.elk.spacing.labelNode
     supports org.eclipse.elk.spacing.nodeNode
     supports org.eclipse.elk.spacing.nodeSelfLoop

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -49,8 +49,8 @@ algorithm layered(LayeredLayoutProvider) {
     supports org.eclipse.elk.spacing.edgeLabel
     supports org.eclipse.elk.spacing.edgeNode
     supports org.eclipse.elk.spacing.labelLabel
-    supports org.eclipse.elk.spacing.labelPort.horizontal
-    supports org.eclipse.elk.spacing.labelPort.vertical
+    supports org.eclipse.elk.spacing.labelPortHorizontal
+    supports org.eclipse.elk.spacing.labelPortVertical
     supports org.eclipse.elk.spacing.labelNode
     supports org.eclipse.elk.spacing.nodeNode
     supports org.eclipse.elk.spacing.nodeSelfLoop

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -732,8 +732,10 @@ class ElkGraphImporter {
         
         // Remember the relevant spacings that will apply to the labels here. It's not the spacings in the graph, but
         // in the parent
-        dummy.setProperty(LayeredOptions.SPACING_LABEL_PORT,
-                elkgraph.getParent().getProperty(LayeredOptions.SPACING_LABEL_PORT));
+        dummy.setProperty(LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL,
+                elkgraph.getParent().getProperty(LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL));
+        dummy.setProperty(LayeredOptions.SPACING_LABEL_PORT_VERTICAL,
+                elkgraph.getParent().getProperty(LayeredOptions.SPACING_LABEL_PORT_VERTICAL));
         dummy.setProperty(LayeredOptions.SPACING_LABEL_LABEL,
                 elkgraph.getParent().getProperty(LayeredOptions.SPACING_LABEL_LABEL));
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/EndLabelPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/EndLabelPreprocessor.java
@@ -362,7 +362,7 @@ public final class EndLabelPreprocessor implements ILayoutProcessor<LGraph> {
         
         RectangleStripOverlapRemover overlapRemover = RectangleStripOverlapRemover
                 .createForDirection(portSideToOverlapRemovalDirection(portSide))
-                .withGap(labelLabelSpacing)
+                .withGap(labelLabelSpacing, labelLabelSpacing)
                 .withStartCoordinate(calculateOverlapStartCoordinate(node, portSide, edgeLabelSpacing));
         
         // Gather the rectangles

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
@@ -213,12 +213,13 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
         // are not set acoordingly. That needs to be fixed (if port labels are to be taken into consideration)
         if (graph.getProperty(LayeredOptions.NODE_SIZE_CONSTRAINTS).contains(SizeConstraint.PORT_LABELS)) {
             // The ElkGraphImporter has set the relevant spacings on the dummy node
-            double portLabelSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT);
+            double portLabelSpacingHorizontal = dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL);
+            double portLabelSpacingVertical = dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT_VERTICAL);
             double labelLabelSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_LABEL);
             
             Set<PortLabelPlacement> portLabelPlacement = graph.getProperty(LayeredOptions.PORT_LABELS_PLACEMENT);
             if (portLabelPlacement.contains(PortLabelPlacement.INSIDE)) {
-                double currentY = portLabelSpacing;
+                double currentY = portLabelSpacingVertical;
                 double xCenterRelativeToPort = dummy.getSize().x / 2 - dummyPort.getPosition().x;
                 
                 for (LLabel label : dummyPort.getLabels()) {
@@ -231,7 +232,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
             } else if (portLabelPlacement.contains(PortLabelPlacement.OUTSIDE)) {
                 // Port labels have a vertical size of 0, but we need to set their x coordinate
                 for (LLabel label : dummyPort.getLabels()) {
-                    label.getPosition().x = portLabelSpacing + dummy.getSize().x - dummyPort.getPosition().x;
+                    label.getPosition().x = portLabelSpacingHorizontal + dummy.getSize().x - dummyPort.getPosition().x;
                 }
             }
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelAndNodeSizeProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelAndNodeSizeProcessor.java
@@ -91,7 +91,9 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
     private void placeExternalPortDummyLabels(final LNode dummy, final Set<PortLabelPlacement> graphPortLabelPlacement,
             final boolean placeNextToPortIfPossible, final boolean treatAsGroup) {
     
-        double labelPortSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT);
+        double labelPortSpacingHorizontal = dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL);
+        double labelPortSpacingVertical =
+                dummy.getProperty(LayeredOptions.SPACING_LABEL_PORT_VERTICAL);
         double labelLabelSpacing = dummy.getProperty(LayeredOptions.SPACING_LABEL_LABEL);
         
         KVector dummySize = dummy.getSize();
@@ -112,12 +114,12 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
             switch (dummy.getProperty(InternalProperties.EXT_PORT_SIDE)) {
             case NORTH:
                 portLabelBox.x = (dummySize.x - portLabelBox.width) / 2 - dummyPortPos.x;
-                portLabelBox.y = labelPortSpacing;
+                portLabelBox.y = labelPortSpacingVertical;
                 break;
                 
             case SOUTH:
                 portLabelBox.x = (dummySize.x - portLabelBox.width) / 2 - dummyPortPos.x;
-                portLabelBox.y = -labelPortSpacing - portLabelBox.height;
+                portLabelBox.y = -labelPortSpacingVertical - portLabelBox.height;
                 break;
                 
             case EAST:
@@ -127,9 +129,9 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
                             : dummyPort.getLabels().get(0).getSize().y;
                     portLabelBox.y = (dummySize.y - labelHeight) / 2 - dummyPortPos.y;
                 } else {
-                    portLabelBox.y = dummySize.y + labelPortSpacing - dummyPortPos.y;
+                    portLabelBox.y = dummySize.y + labelPortSpacingVertical - dummyPortPos.y;
                 }
-                portLabelBox.x = -labelPortSpacing - portLabelBox.width;
+                portLabelBox.x = -labelPortSpacingHorizontal - portLabelBox.width;
                 break;
                 
             case WEST:
@@ -139,16 +141,16 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
                             : dummyPort.getLabels().get(0).getSize().y;
                     portLabelBox.y = (dummySize.y - labelHeight) / 2 - dummyPortPos.y;
                 } else {
-                    portLabelBox.y = dummySize.y + labelPortSpacing - dummyPortPos.y;
+                    portLabelBox.y = dummySize.y + labelPortSpacingVertical - dummyPortPos.y;
                 }
-                portLabelBox.x = labelPortSpacing;
+                portLabelBox.x = labelPortSpacingHorizontal;
                 break;
             }
         } else if (graphPortLabelPlacement.contains(PortLabelPlacement.OUTSIDE)) {
             switch (dummy.getProperty(InternalProperties.EXT_PORT_SIDE)) {
             case NORTH:
             case SOUTH:
-                portLabelBox.x = dummyPortPos.x + labelPortSpacing;
+                portLabelBox.x = dummyPortPos.x + labelPortSpacingHorizontal;
                 break;
                 
             case EAST:
@@ -159,7 +161,7 @@ public final class LabelAndNodeSizeProcessor implements ILayoutProcessor<LGraph>
                             : dummyPort.getLabels().get(0).getSize().y;
                     portLabelBox.y = (dummySize.y - labelHeight) / 2 - dummyPortPos.y;
                 } else {
-                    portLabelBox.y = dummyPortPos.y + labelPortSpacing;
+                    portLabelBox.y = dummyPortPos.y + labelPortSpacingVertical;
                 }
                 break;
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeredSpacings.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeredSpacings.java
@@ -65,7 +65,8 @@ public final class LayeredSpacings {
             LayeredOptions.SPACING_EDGE_NODE,
             LayeredOptions.SPACING_LABEL_LABEL,
             LayeredOptions.SPACING_LABEL_NODE,
-            LayeredOptions.SPACING_LABEL_PORT,
+            LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL,
+            LayeredOptions.SPACING_LABEL_PORT_VERTICAL,
             LayeredOptions.SPACING_NODE_SELF_LOOP,
             LayeredOptions.SPACING_PORT_PORT,
             // Introduced by LayeredOptions 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/Spacings.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/Spacings.java
@@ -95,7 +95,7 @@ public final class Spacings {
         nodeTypeSpacing(NodeType.EXTERNAL_PORT, 
                 LayeredOptions.SPACING_PORT_PORT);
         nodeTypeSpacing(NodeType.EXTERNAL_PORT, NodeType.LABEL, 
-                LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL);
+                LayeredOptions.SPACING_LABEL_PORT_VERTICAL, LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL);
         
         // label
         nodeTypeSpacing(NodeType.LABEL,

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/Spacings.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/Spacings.java
@@ -95,7 +95,7 @@ public final class Spacings {
         nodeTypeSpacing(NodeType.EXTERNAL_PORT, 
                 LayeredOptions.SPACING_PORT_PORT);
         nodeTypeSpacing(NodeType.EXTERNAL_PORT, NodeType.LABEL, 
-                LayeredOptions.SPACING_LABEL_PORT);
+                LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL);
         
         // label
         nodeTypeSpacing(NodeType.LABEL,

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -384,24 +384,22 @@ group spacing {
         targets parents
     }
     
-    group labelPort {
-        option horizontal: double {
-            label "Horizontal spacing between Label and Port"
-            description
-                "Horizontal spacing to be preserved between labels and the ports they are associated with.
-                Note that the placement of a label is influenced by the 'portlabels.placement' option."
-            default = 1
-            targets parents
-        }
-        
-        option vertical: double {
-            label "Vertical spacing between Label and Port"
-            description
-                "Vertical spacing to be preserved between labels and the ports they are associated with.
-                Note that the placement of a label is influenced by the 'portlabels.placement' option."
-            default = 1
-            targets parents
-        }
+    option labelPortHorizontal: double {
+        label "Horizontal spacing between Label and Port"
+        description
+            "Horizontal spacing to be preserved between labels and the ports they are associated with.
+            Note that the placement of a label is influenced by the 'portlabels.placement' option."
+        default = 1
+        targets parents
+    }
+    
+    option labelPortVertical: double {
+        label "Vertical spacing between Label and Port"
+        description
+            "Vertical spacing to be preserved between labels and the ports they are associated with.
+            Note that the placement of a label is influenced by the 'portlabels.placement' option."
+        default = 1
+        targets parents
     }
 
     option nodeNode: double {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/Core.melk
@@ -383,15 +383,25 @@ group spacing {
         lowerBound = 0.0
         targets parents
     }
-
-    option labelPort: double {
-        label "Label Port Spacing"
-        description
-            "Spacing to be preserved between labels and the ports they are associated with. 
-            Note that the placement of a label is influenced by the 'portlabels.placement' option."
-        default = 1
-        lowerBound = 0.0
-        targets parents
+    
+    group labelPort {
+        option horizontal: double {
+            label "Horizontal spacing between Label and Port"
+            description
+                "Horizontal spacing to be preserved between labels and the ports they are associated with.
+                Note that the placement of a label is influenced by the 'portlabels.placement' option."
+            default = 1
+            targets parents
+        }
+        
+        option vertical: double {
+            label "Vertical spacing between Label and Port"
+            description
+                "Vertical spacing to be preserved between labels and the ports they are associated with.
+                Note that the placement of a label is influenced by the 'portlabels.placement' option."
+            default = 1
+            targets parents
+        }
     }
 
     option nodeNode: double {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortSide.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortSide.java
@@ -188,4 +188,12 @@ public enum PortSide {
         }
     }
     
+    public static boolean isVertical(final PortSide side) {
+        return side == NORTH || side == SOUTH;
+    }
+    
+    public static boolean isHorizontal(final PortSide side) {
+        return side == WEST || side == EAST;
+    }
+    
 }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkSpacings.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkSpacings.java
@@ -62,7 +62,8 @@ public final class ElkSpacings {
             CoreOptions.SPACING_EDGE_NODE,
             CoreOptions.SPACING_LABEL_LABEL,
             CoreOptions.SPACING_LABEL_NODE,
-            CoreOptions.SPACING_LABEL_PORT,
+            CoreOptions.SPACING_LABEL_PORT_HORIZONTAL,
+            CoreOptions.SPACING_LABEL_PORT_VERTICAL,
             CoreOptions.SPACING_NODE_SELF_LOOP,
             CoreOptions.SPACING_PORT_PORT
         );

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/LayeredSpacingTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/LayeredSpacingTest.java
@@ -66,7 +66,8 @@ public class LayeredSpacingTest {
                 {LayeredOptions.SPACING_EDGE_NODE},
                 {LayeredOptions.SPACING_LABEL_LABEL},
                 {LayeredOptions.SPACING_LABEL_NODE},
-                {LayeredOptions.SPACING_LABEL_PORT},
+                {LayeredOptions.SPACING_LABEL_PORT_HORIZONTAL},
+                {LayeredOptions.SPACING_LABEL_PORT_VERTICAL},
                 {LayeredOptions.SPACING_NODE_SELF_LOOP},
                 {LayeredOptions.SPACING_PORT_PORT},
                 //

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/issues/Issue701Test.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/issues/Issue701Test.java
@@ -157,8 +157,8 @@ public class Issue701Test {
         ElkLabel cont3Port1Label = cont3Port1.getLabels().get(0);
         ElkPort cont3Port2 = GraphTestUtils.getPort(cont3, "P2");
         ElkLabel cont3Port2Label = cont3Port2.getLabels().get(0);
-        double spacingLabelCont3Port1 = cont3Port1.getProperty(CoreOptions.SPACING_LABEL_PORT);
-        double spacingLabelCont3Port2 = cont3Port2.getProperty(CoreOptions.SPACING_LABEL_PORT);
+        double spacingLabelCont3Port1 = cont3Port1.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
+        double spacingLabelCont3Port2 = cont3Port2.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
         double cont3Port1BorderOffset = cont3Port1.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         double cont3Port2BorderOffset = cont3Port2.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         ElkPadding cont3Padding = cont3.getProperty(CoreOptions.PADDING);
@@ -183,8 +183,8 @@ public class Issue701Test {
         ElkLabel cont4Node1Port1Label = cont4Node1Port1.getLabels().get(0);
         ElkPort cont4Port1 = GraphTestUtils.getPort(cont4, "P1");
         ElkLabel cont4Port1Label = cont4Port1.getLabels().get(0);
-        double spacingLabelCont4Node1Port1 = cont4Node1Port1.getProperty(CoreOptions.SPACING_LABEL_PORT);
-        double spacingLabelCont4Port1 = cont4Port1.getProperty(CoreOptions.SPACING_LABEL_PORT);
+        double spacingLabelCont4Node1Port1 = cont4Node1Port1.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
+        double spacingLabelCont4Port1 = cont4Port1.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
         double cont4Node1Port1BorderOffset = cont4Node1Port1.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         double cont4Port1BorderOffset = cont4Port1.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         ElkPadding cont4Padding = cont4.getProperty(CoreOptions.PADDING);
@@ -340,8 +340,8 @@ public class Issue701Test {
         ElkLabel cont3Port1Label = cont3Port1.getLabels().get(0);
         ElkPort cont3Port2 = GraphTestUtils.getPort(cont3, "P2");
         ElkLabel cont3Port2Label = cont3Port2.getLabels().get(0);
-        double spacingLabelCont3Port1 = cont3Port1.getProperty(CoreOptions.SPACING_LABEL_PORT);
-        double spacingLabelCont3Port2 = cont3Port2.getProperty(CoreOptions.SPACING_LABEL_PORT);
+        double spacingLabelCont3Port1 = cont3Port1.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
+        double spacingLabelCont3Port2 = cont3Port2.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
         double cont3Port1BorderOffset = cont3Port1.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         double cont3Port2BorderOffset = cont3Port2.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         ElkPadding cont3Padding = cont3.getProperty(CoreOptions.PADDING);
@@ -368,8 +368,8 @@ public class Issue701Test {
         ElkLabel cont4Node1Port1Label = cont4Node1Port1.getLabels().get(0);
         ElkPort cont4Port1 = GraphTestUtils.getPort(cont4, "P1");
         ElkLabel cont4Port1Label = cont4Port1.getLabels().get(0);
-        double spacingLabelCont4Node1Port1 = cont4Node1Port1.getProperty(CoreOptions.SPACING_LABEL_PORT);
-        double spacingLabelCont4Port1 = cont4Port1.getProperty(CoreOptions.SPACING_LABEL_PORT);
+        double spacingLabelCont4Node1Port1 = cont4Node1Port1.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
+        double spacingLabelCont4Port1 = cont4Port1.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
         double cont4Node1Port1BorderOffset = cont4Node1Port1.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         double cont4Port1BorderOffset = cont4Port1.getProperty(CoreOptions.PORT_BORDER_OFFSET);
         ElkPadding cont4Padding = cont4.getProperty(CoreOptions.PADDING);
@@ -418,9 +418,9 @@ public class Issue701Test {
                     spacingBetweenPort + Math.max(portLabelWidth, oppositePortLabelWidth) + spacingBetweenPort,
                     node.getWidth(), 0);
         } else {
-            double spacingLabelPort = port.getProperty(CoreOptions.SPACING_LABEL_PORT);
+            double spacingLabelPort = port.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
             double spacingLabelOppositePort =
-                    oppositePort == null ? 0 : oppositePort.getProperty(CoreOptions.SPACING_LABEL_PORT);
+                    oppositePort == null ? 0 : oppositePort.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
             double portBorderOffset = port.getProperty(CoreOptions.PORT_BORDER_OFFSET);
             double oppositePortBorderOffset =
                     oppositePort == null ? 0 : oppositePort.getProperty(CoreOptions.PORT_BORDER_OFFSET);
@@ -485,18 +485,20 @@ public class Issue701Test {
             assertEquals("Wrong node label location.", ElkUtil.absolutePosition(node).y + nodeLabelPadding.getTop(),
                     ElkUtil.absolutePosition(nodeLabel).y, 0);
         } else {
-            double spacingLabelPort = port.getProperty(CoreOptions.SPACING_LABEL_PORT);
-            double spacingLabelOppositePort =
-                    oppositePort == null ? 0 : oppositePort.getProperty(CoreOptions.SPACING_LABEL_PORT);
+            double spacingLabelPortHorizontal = port.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
+            double spacingLabelPortVertical = port.getProperty(CoreOptions.SPACING_LABEL_PORT_VERTICAL);
+            double spacingLabelOppositePortHorizontal =
+                    oppositePort == null ? 0 : oppositePort.getProperty(CoreOptions.SPACING_LABEL_PORT_HORIZONTAL);
+            double spacingLabelOppositePortVertical =
+                    oppositePort == null ? 0 : oppositePort.getProperty(CoreOptions.SPACING_LABEL_PORT_VERTICAL);
             double portBorderOffset = port.getProperty(CoreOptions.PORT_BORDER_OFFSET);
             double oppositePortBorderOffset =
                     oppositePort == null ? 0 : oppositePort.getProperty(CoreOptions.PORT_BORDER_OFFSET);
             double expectedHeight = -portBorderOffset;
             expectedHeight += -oppositePortBorderOffset;
             // the label size is added twice for the symmetry
-            expectedHeight +=
-                    Math.max((spacingLabelPort + portLabelHeight), (spacingLabelOppositePort + oppositePortLabelHeight))
-                            * 2;
+            expectedHeight += Math.max((spacingLabelPortVertical + portLabelHeight),
+                    (spacingLabelOppositePortVertical + oppositePortLabelHeight)) * 2;
             expectedHeight += nodeLabelPadding.getTop();
             // A free space equals to the node label height is kept.
             expectedHeight += nodeLabel.getHeight() * 2;
@@ -514,7 +516,7 @@ public class Issue701Test {
                 // The port is on the south side, for symmetry a space is let above node label (same as port label)
                 assertEquals("Wrong node label location.",
                         ElkUtil.absolutePosition(node).y + portLabelHeight
-                                + port.getProperty(CoreOptions.SPACING_LABEL_PORT) + nodeLabelPadding.getTop(),
+                                + port.getProperty(CoreOptions.SPACING_LABEL_PORT_VERTICAL) + nodeLabelPadding.getTop(),
                         ElkUtil.absolutePosition(nodeLabel).y, 0);
             }
         }

--- a/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/alg/SpacingConfigurationTest.java
+++ b/test/org.eclipse.elk.core.test/src/org/eclipse/elk/core/alg/SpacingConfigurationTest.java
@@ -111,8 +111,9 @@ public class SpacingConfigurationTest {
                 { CoreOptions.SPACING_EDGE_LABEL },
                 { CoreOptions.SPACING_EDGE_NODE },
                 { CoreOptions.SPACING_LABEL_LABEL },
-                { CoreOptions.SPACING_LABEL_NODE }, 
-                { CoreOptions.SPACING_LABEL_PORT },
+                { CoreOptions.SPACING_LABEL_NODE },
+                { CoreOptions.SPACING_LABEL_PORT_HORIZONTAL },
+                { CoreOptions.SPACING_LABEL_PORT_VERTICAL },
                 { CoreOptions.SPACING_NODE_SELF_LOOP }, 
                 { CoreOptions.SPACING_PORT_PORT } 
             });


### PR DESCRIPTION
Fixes #575 
Split the label port spacing in vertical spacing and horizontal spacing.
I did consider splitting it in an in-port-direction and orthogonal-to-port-direction spacing. This, however, is not consistent with other spacings and one would have to mentally turn the drawing to calculate that kind of spacing is required.

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>