### PR TITLE
Layered: Model order overrules priority of components.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/SimpleRowGraphPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/SimpleRowGraphPlacer.java
@@ -55,32 +55,30 @@ final class SimpleRowGraphPlacer extends AbstractGraphPlacer {
             return;
         }
         assert !components.contains(target);
-        
-        // assign priorities
-        for (LGraph graph : components) {
-            int priority = 0;
-            for (LNode node : graph.getLayerlessNodes()) {
-                priority += node.getProperty(LayeredOptions.PRIORITY);
+        // Sort components
+        if (!target.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_COMPONENTS)) {
+            // assign priorities
+            for (LGraph graph : components) {
+                int priority = 0;
+                for (LNode node : graph.getLayerlessNodes()) {
+                    priority += node.getProperty(LayeredOptions.PRIORITY);
+                }
+                graph.id = priority;
             }
-            graph.id = priority;
-        }
 
-        // sort the components by their priority and size.
-        // If preserve order is set, we do not consider the size.
-        Collections.sort(components, new Comparator<LGraph>() {
-            public int compare(final LGraph graph1, final LGraph graph2) {
-                int prio = graph2.id - graph1.id;
-                if (prio == 0) {
-                    if (graph1.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) == OrderingStrategy.NONE
-                            && !graph1.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)) {
+            // sort the components by their priority and size.
+            Collections.sort(components, new Comparator<LGraph>() {
+                public int compare(final LGraph graph1, final LGraph graph2) {
+                    int prio = graph2.id - graph1.id;
+                    if (prio == 0) {
                         double size1 = graph1.getSize().x * graph1.getSize().y;
                         double size2 = graph2.getSize().x * graph2.getSize().y;
                         return Double.compare(size1, size2);
                     }
+                    return prio;
                 }
-                return prio;
-            }
-        });
+            });
+        }
         
         LGraph firstComponent = components.get(0);
         target.getLayerlessNodes().clear();


### PR DESCRIPTION
Previously components would be ordered by the summed up priority of each
component and if no priority was set or it was equal, they were ordered
by model order. Since a summed up priority requires the user to
calculate the separate components to set this sensibly it is now
overruled by the model order.

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>