### PR TITLE
layered: Component model order: Port sides do not overrule component order.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroup.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroup.java
@@ -194,7 +194,7 @@ public final class ComponentGroup {
      * @param component the component to be added to the group.
      */
     public ComponentGroup(final LGraph component) {
-        add(component);
+        add(component, null);
     }
 
     
@@ -202,18 +202,39 @@ public final class ComponentGroup {
     // Component Management
     
     /**
+    * Tries to add the given component to the group. Before adding the component, a call to
+    * {@link #canAdd(LGraph)} determines if the component can actually be added to this
+    * group.
+    * 
+    * @param component the component to be added to this group.
+    * @return {@code true} if the component was successfully added, {@code false} otherwise.
+    */
+   public boolean add(final LGraph component) {
+       return this.add(component, null);
+   }
+    
+    /**
      * Tries to add the given component to the group. Before adding the component, a call to
      * {@link #canAdd(LGraph)} determines if the component can actually be added to this
      * group.
      * 
      * @param component the component to be added to this group.
+     * @param lastComponent the last component added needed.
      * @return {@code true} if the component was successfully added, {@code false} otherwise.
      */
-    public boolean add(final LGraph component) {
+    public boolean add(final LGraph component, final LGraph lastComponent) {
         if (canAdd(component)) {
+            // If the last component is not does not have the same port connections create a different group
+            // containing it.
+            if (lastComponent != null && !lastComponent.getProperty(InternalProperties.EXT_PORT_CONNECTIONS)
+                    .equals(component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS))
+                    && components.containsKey(component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS))) {
+                return false;
+            }
             components.put(
-                    component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS),
-                    component);
+                component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS),
+                component);
+            
             return true;
         } else {
             return false;
@@ -241,6 +262,15 @@ public final class ComponentGroup {
         
         // We haven't found any conflicting components
         return true;
+    }
+    
+    /**
+     * Returns all port sides in this component group.
+     * 
+     * @return all port sides in this component group.
+     */
+    public Collection<Set<PortSide>> getPortSides() {
+        return components.keys();
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupGraphPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupGraphPlacer.java
@@ -49,7 +49,7 @@ import com.google.common.collect.Lists;
  * 
  * <p>The target graph must not be contained in the list of components.</p>
  */
-final class ComponentGroupGraphPlacer extends AbstractGraphPlacer {
+class ComponentGroupGraphPlacer extends AbstractGraphPlacer {
     
     ///////////////////////////////////////////////////////////////////////////////
     // Variables
@@ -57,7 +57,7 @@ final class ComponentGroupGraphPlacer extends AbstractGraphPlacer {
     /**
      * List of component groups holding the different components.
      */
-    private final List<ComponentGroup> componentGroups = Lists.newArrayList();
+    protected final List<ComponentGroup> componentGroups = Lists.newArrayList();
     
     
     ///////////////////////////////////////////////////////////////////////////////
@@ -142,7 +142,7 @@ final class ComponentGroupGraphPlacer extends AbstractGraphPlacer {
      * 
      * @param component the component to be placed.
      */
-    private void addComponent(final LGraph component) {
+    protected void addComponent(final LGraph component) {
         // Check if one of the existing component groups has some place left
         for (ComponentGroup group : componentGroups) {
             if (group.add(component)) {
@@ -176,7 +176,7 @@ final class ComponentGroupGraphPlacer extends AbstractGraphPlacer {
      * @param spacing the amount of space to leave between two components.
      * @return the group's size.
      */
-    private KVector placeComponents(final ComponentGroup group, final double spacing) {
+    protected KVector placeComponents(final ComponentGroup group, final double spacing) {
         
         // Determine the spacing between two components
         // Place the different sector components and remember the amount of space their placement uses.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupModelOrderGraphPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupModelOrderGraphPlacer.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.components;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.EdgeRouting;
+import org.eclipse.elk.core.options.PortSide;
+
+/**
+ * A graph placer that tries to place the components of a graph with taking connections to external
+ * ports into account. This graph placer should only be used if the constraints applying to the
+ * external ports are either {@code FREE} or {@code FIXED_SIDES}.
+ * 
+ * <p>This placer assumes t</p>
+ * 
+ * <p>The target graph must not be contained in the list of components.</p>
+ */
+public class ComponentGroupModelOrderGraphPlacer extends ComponentGroupGraphPlacer {
+    
+    private LGraph lastComponent = null;
+    
+    ///////////////////////////////////////////////////////////////////////////////
+    // AbstractGraphPlacer
+
+    @Override
+    public void combine(final List<LGraph> components, final LGraph target) {
+        lastComponent = null;
+        componentGroups.clear();
+        assert !components.contains(target);
+        target.getLayerlessNodes().clear();
+        
+        // Check if there are any components to be placed
+        if (components.isEmpty()) {
+            target.getSize().x = 0;
+            target.getSize().y = 0;
+            return;
+        }
+        
+        // Set the graph properties
+        LGraph firstComponent = components.get(0);
+        target.copyProperties(firstComponent);
+        
+        // Construct component groups
+        for (LGraph component : components) {
+            addComponent(component);
+        }
+        
+        // Place components in each group
+        KVector offset = new KVector();
+        KVector maxSize = new KVector();
+        double componentSpacing = firstComponent.getProperty(LayeredOptions.SPACING_COMPONENT_COMPONENT);
+
+        for (ComponentGroup group : componentGroups) {
+            // Place the components
+            KVector groupSize = placeComponents(group, componentSpacing);
+            offsetGraphs(group.getComponents(), offset.x, offset.y);
+            maxSize.x = Math.max(maxSize.x, groupSize.x + offset.x);
+            maxSize.y = Math.max(maxSize.y, groupSize.y + offset.y);
+            if (target.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_COMPONENTS)) {
+                // Compute the new offset. The previous component might not be in vertical or horizontal conflict.
+                // Normally this cannot occur but here graphs with the same port sides may be in different groups.
+                for (Set<PortSide> side : group.getPortSides()) {
+                    if (side.contains(PortSide.SOUTH)) {
+                        offset.x += groupSize.x;
+                        break;
+                    }
+                }
+                for (Set<PortSide> side : group.getPortSides()) {
+                    if (side.contains(PortSide.EAST)) {
+                        offset.y += groupSize.y;
+                        break;
+                    }
+                }
+            } else {
+                offset.x += groupSize.x;
+                offset.y += groupSize.y;
+            }
+        }
+        
+        // Set the graph's new size (the component group sizes include additional spacing
+        // on the right and bottom sides which we need to subtract at this point)
+        target.getSize().x = maxSize.x - componentSpacing;
+        target.getSize().y = maxSize.y - componentSpacing;
+        
+        // if compaction is desired, do so!cing;
+        if (firstComponent.getProperty(LayeredOptions.COMPACTION_CONNECTED_COMPONENTS)
+                // the compaction only supports orthogonally routed edges
+                && firstComponent.getProperty(LayeredOptions.EDGE_ROUTING) == EdgeRouting.ORTHOGONAL) {
+
+            // apply graph offsets (which we reset later on)
+            // since the compaction works in a common coordinate system
+            for (LGraph h : components) {
+                offsetGraph(h, h.getOffset().x, h.getOffset().y);
+            }
+
+            ComponentsCompactor compactor = new ComponentsCompactor();
+            compactor.compact(components, target.getSize(), componentSpacing);
+
+            // the compaction algorithm places components absolutely,
+            // therefore we have to use the final drawing's offset
+            for (LGraph h : components) {
+                h.getOffset().reset().add(compactor.getOffset());
+            }
+
+            // set the new (compacted) graph size
+            target.getSize().reset().add(compactor.getGraphSize());
+        }
+
+        // finally move the components to the combined graph
+        for (ComponentGroup group : componentGroups) {
+            moveGraphs(target, group.getComponents(), 0, 0);
+        }
+    }
+    
+    
+    ///////////////////////////////////////////////////////////////////////////////
+    // Component Group Building
+    
+    /**
+     * Adds the given component to the first component group that has place for it.
+     * 
+     * @param component the component to be placed.
+     */
+    protected void addComponent(final LGraph component) {
+        // Check if one of the existing component groups has some place left
+        if (this.componentGroups.size() > 0) {
+            ComponentGroup group = this.componentGroups.get(componentGroups.size() - 1);
+            if (group.add(component, lastComponent)) {
+                this.lastComponent = component;
+                return;
+            }
+        }
+        
+        // Create a new component group for the component
+        componentGroups.add(new ComponentGroup(component));
+        this.lastComponent = component;
+    }
+    
+
+}

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsProcessor.java
@@ -65,6 +65,9 @@ public final class ComponentsProcessor {
     
     /** Cached instance of a {@link ComponentGroupGraphPlacer}. */
     private final ComponentGroupGraphPlacer componentGroupGraphPlacer = new ComponentGroupGraphPlacer();
+    /** Cached instance of a {@link ComponentGroupGraphPlacer}. */
+    private final ComponentGroupModelOrderGraphPlacer componentGroupModelOrderGraphPlacer =
+            new ComponentGroupModelOrderGraphPlacer();
     /** Cached instance of a {@link SimpleRowGraphPlacer}. */
     private final SimpleRowGraphPlacer simpleRowGraphPlacer = new SimpleRowGraphPlacer();
     /** Graph placer to be used to combine the different components back into a single graph. */
@@ -135,7 +138,11 @@ public final class ComponentsProcessor {
             if (extPorts) {
                 // With external port connections, we want to use the more complex components
                 // placement algorithm
-                graphPlacer = componentGroupGraphPlacer;
+                if (graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_COMPONENTS)) {
+                    graphPlacer = componentGroupModelOrderGraphPlacer;
+                } else {
+                    graphPlacer = componentGroupGraphPlacer;
+                }
             }
         } else {
             result = Arrays.asList(graph);


### PR DESCRIPTION
Model order was previously only respected among components with the same port sides inside a component group seen below.
![Sleepingbarber03](https://user-images.githubusercontent.com/6419799/161743876-5e74fe4a-4087-407e-a880-7b2556bbfe17.svg)
Here all reactions (numbered) are in the same component group. Since 1 and 4 have the same external port sides they are next to each other.

This could be fixed by eliminating external ports by setting `HIERARCHY_HANDLING` to `INCLUDE_CHILDREN`.
Now the component order is respected even if external ports exist
![Sleepingbarber02](https://user-images.githubusercontent.com/6419799/161744093-51db5271-2e63-4558-9cc7-87f3884a93f8.svg)
Here 1-3 are in the same component group and component 4 is in another component group. Additionally, if the model order is respected by can assume that a component group with no south ports allow that another component group is placed below it. Otherwise, 4 would be placed more to the right to accommodate for potential edges to the south.
