### PR TITLE
Layered: Fix component model order.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupModelOrderGraphPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupModelOrderGraphPlacer.java
@@ -98,12 +98,12 @@ public class ComponentGroupModelOrderGraphPlacer extends ComponentGroupGraphPlac
             }
             for (Set<PortSide> side : group.getPortSides()) {
                 if (target.getProperty(CoreOptions.DIRECTION).isHorizontal()) {
-                    if (side.contains(PortSide.WEST)) {
+                    if (side.contains(PortSide.WEST) || side.isEmpty()) {
                         offset.y += groupSize.y;
                         break;
                     }
                 } else if (target.getProperty(CoreOptions.DIRECTION).isVertical()) {
-                    if (side.contains(PortSide.NORTH)) {
+                    if (side.contains(PortSide.NORTH) || side.isEmpty()) {
                         offset.x += groupSize.x;
                         break;
                     }


### PR DESCRIPTION
A component with no external ports has still a size we have to take into
account.