### PR TITLE
Fixed forced model order and added test.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GraphInfoHolder.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GraphInfoHolder.java
@@ -20,6 +20,7 @@ import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.intermediate.greedyswitch.GreedySwitchHeuristic;
 import org.eclipse.elk.alg.layered.options.GraphProperties;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.alg.layered.p3order.LayerSweepCrossingMinimizer.CrossMinType;
 import org.eclipse.elk.alg.layered.p3order.counting.AllCrossingsCounter;
 import org.eclipse.elk.alg.layered.p3order.counting.IInitializable;
@@ -92,12 +93,14 @@ public class GraphInfoHolder implements IInitializable {
         List<IInitializable> initializables =
                 Lists.newArrayList(this, crossingsCounter, layerSweepTypeDecider, portDistributor);
         
-        if (crossMinType == CrossMinType.BARYCENTER) {
+        if (crossMinType == CrossMinType.BARYCENTER
+                && !graph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)) {
             ForsterConstraintResolver constraintResolver = new ForsterConstraintResolver(currentNodeOrder);
             initializables.add(constraintResolver);
             crossMinimizer = new BarycenterHeuristic(constraintResolver, random,
                     (AbstractBarycenterPortDistributor) portDistributor, currentNodeOrder);
-        } else if (crossMinType == CrossMinType.MODEL_ORDER) {
+        } else if (crossMinType == CrossMinType.BARYCENTER
+                && graph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)) {
             ForsterConstraintResolver constraintResolver = new ForsterConstraintResolver(currentNodeOrder);
             initializables.add(constraintResolver);
             crossMinimizer = new ModelOrderBarycenterHeuristic(constraintResolver, random,

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -566,9 +566,6 @@ public class LayerSweepCrossingMinimizer
      * Traverses inclusion breadth-first and initializes each Graph.
      */
     private List<GraphInfoHolder> initialize(final LGraph rootGraph) {
-        if (rootGraph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)) {
-            crossMinType = CrossMinType.MODEL_ORDER;
-        }
         graphInfoHolders = Lists.newArrayList();
         random = rootGraph.getProperty(InternalProperties.RANDOM);
         randomSeed = random.nextLong();
@@ -623,8 +620,6 @@ public class LayerSweepCrossingMinimizer
     public enum CrossMinType {
         /** Use BarycenterHeuristic. */
         BARYCENTER,
-        /** Use ModelOrderBarycenterHeuristic. */
-        MODEL_ORDER,
         /** Use one-sided GreedySwitchHeuristic. */
         ONE_SIDED_GREEDY_SWITCH,
         /** Use two-sided GreedySwitchHeuristic. */

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p3order/ModelOrderBarycenterHeuristicTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p3order/ModelOrderBarycenterHeuristicTest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.p3order;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.graph.Layer;
+import org.eclipse.elk.alg.layered.options.CrossingMinimizationStrategy;
+import org.eclipse.elk.alg.layered.options.GreedySwitchType;
+import org.eclipse.elk.alg.layered.options.InternalProperties;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.OrderingStrategy;
+import org.eclipse.elk.alg.test.framework.LayoutTestRunner;
+import org.eclipse.elk.alg.test.framework.annotations.Algorithm;
+import org.eclipse.elk.alg.test.framework.annotations.ConfiguratorProvider;
+import org.eclipse.elk.alg.test.framework.annotations.DefaultConfiguration;
+import org.eclipse.elk.alg.test.framework.annotations.GraphResourceProvider;
+import org.eclipse.elk.alg.test.framework.annotations.TestAfterProcessor;
+import org.eclipse.elk.alg.test.framework.io.AbstractResourcePath;
+import org.eclipse.elk.alg.test.framework.io.FileExtensionFilter;
+import org.eclipse.elk.alg.test.framework.io.ModelResourcePath;
+import org.eclipse.elk.core.LayoutConfigurator;
+import org.eclipse.elk.graph.ElkNode;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.Lists;
+
+@RunWith(LayoutTestRunner.class)
+@Algorithm(LayeredOptions.ALGORITHM_ID)
+@DefaultConfiguration()
+public class ModelOrderBarycenterHeuristicTest {
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Sources
+
+    @GraphResourceProvider
+    public List<AbstractResourcePath> testGraphs() {
+        return Lists.newArrayList(
+                new ModelResourcePath("realworld/ptolemy/**/").withFilter(new FileExtensionFilter("elkg")));
+    }
+    
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Configuration
+
+    @ConfiguratorProvider
+    public LayoutConfigurator preferEdgesWeightedConfigurator() {
+        LayoutConfigurator config = new LayoutConfigurator();
+        config.configure(ElkNode.class).setProperty(
+                LayeredOptions.CROSSING_MINIMIZATION_STRATEGY,
+                CrossingMinimizationStrategy.LAYER_SWEEP);
+        config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY,
+                OrderingStrategy.NODES_AND_EDGES);
+        config.configure(ElkNode.class).setProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER,
+                true);
+
+        config.configure(ElkNode.class).setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE,
+                GreedySwitchType.OFF);
+        return config;
+    }    
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Tests
+    
+    // Just check for errors that might occur
+
+    @TestAfterProcessor(LayerSweepCrossingMinimizer.class)
+    public void testModelOrderRespected(final Object graph) {
+        for (Layer layer : (LGraph) graph) {
+            // We iterate over the layer's nodes check whether the real nodes (the one with a model order)
+            // are correctly ordered.
+            int modelOrder = -1;
+            for (LNode node : layer) {
+                if (node.hasProperty(InternalProperties.MODEL_ORDER)) {
+                    int newModelOrder = node.getProperty(InternalProperties.MODEL_ORDER);
+                    assertTrue("Node " + node + " has model order " + newModelOrder
+                                    + ", which is smaller than the previous model order of " + modelOrder,
+                            newModelOrder > modelOrder);
+                    modelOrder = newModelOrder;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes the issue that node model order is always enforced after this was activated once.
Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>