### PR TITLE
layered: Added greedy model order cycle breaker.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -229,6 +229,8 @@ class ElkGraphImporter {
                 if ((elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE
                         || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
                             == CycleBreakingStrategy.MODEL_ORDER
+                        || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                            == CycleBreakingStrategy.GREEDY_MODEL_ORDER
                         || elkgraph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)
                         || elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_COMPONENTS) != ComponentOrderingStrategy.NONE)
                     && !child.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_NO_MODEL_ORDER)) {
@@ -246,6 +248,8 @@ class ElkGraphImporter {
             if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE
                     || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
                         == CycleBreakingStrategy.MODEL_ORDER
+                    || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                        == CycleBreakingStrategy.GREEDY_MODEL_ORDER
                     || elkgraph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)
                     || elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_COMPONENTS) != ComponentOrderingStrategy.NONE) {
                 elkedge.setProperty(InternalProperties.MODEL_ORDER, index);
@@ -310,7 +314,9 @@ class ElkGraphImporter {
             
             if ((elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE
                     || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
-                    == CycleBreakingStrategy.MODEL_ORDER
+                        == CycleBreakingStrategy.MODEL_ORDER
+                    || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                        == CycleBreakingStrategy.GREEDY_MODEL_ORDER
                     || elkgraph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)
                     || elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_COMPONENTS) != ComponentOrderingStrategy.NONE)
                 && !elknode.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_NO_MODEL_ORDER)) {
@@ -382,7 +388,9 @@ class ElkGraphImporter {
                 
                 if (elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE
                         || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
-                        == CycleBreakingStrategy.MODEL_ORDER
+                            == CycleBreakingStrategy.MODEL_ORDER
+                        || elkgraph.getProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY)
+                            == CycleBreakingStrategy.GREEDY_MODEL_ORDER
                         || elkgraph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)
                         || elkgraph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_COMPONENTS) != ComponentOrderingStrategy.NONE) {
                     // Assign a model order to the edges as they are read

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CycleBreakingStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/CycleBreakingStrategy.java
@@ -47,7 +47,12 @@ public enum CycleBreakingStrategy implements ILayoutPhaseFactory<LayeredPhases, 
      * Reacts to the input model by respecting the initial ordering in the model file.
      * This ordering is used to identify backwards edges.
      */
-    MODEL_ORDER;
+    MODEL_ORDER,
+    
+    /**
+     * Applies a greedy heuristic to minimize the number of reversed edges but uses the model order as a tie-breaker.
+     */
+    GREEDY_MODEL_ORDER;
     
 
     @Override
@@ -63,6 +68,9 @@ public enum CycleBreakingStrategy implements ILayoutPhaseFactory<LayeredPhases, 
             return new InteractiveCycleBreaker();
             
         case MODEL_ORDER:
+            return new ModelOrderCycleBreaker();
+            
+        case GREEDY_MODEL_ORDER:
             return new ModelOrderCycleBreaker();
             
         default:

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
@@ -54,7 +54,7 @@ import com.google.common.collect.Lists;
  * @see org.eclipse.elk.alg.layered.intermediate.LayerConstraintProcessor
  * @author msp
  */
-public final class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGraph> {
+public class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGraph> {
     
     /** intermediate processing configuration. */
     private static final LayoutProcessorConfiguration<LayeredPhases, LGraph> INTERMEDIATE_PROCESSING_CONFIGURATION =
@@ -71,6 +71,8 @@ public final class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
     private final LinkedList<LNode> sources = Lists.newLinkedList();
     /** list of sink nodes. */
     private final LinkedList<LNode> sinks = Lists.newLinkedList();
+    
+    private Random random;
     
     @Override
     public LayoutProcessorConfiguration<LayeredPhases, LGraph> getLayoutProcessorConfiguration(final LGraph graph) {
@@ -132,7 +134,7 @@ public final class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
 
         // assign marks to all nodes
         List<LNode> maxNodes = Lists.newArrayList();
-        Random random = layeredGraph.getProperty(InternalProperties.RANDOM);
+        random = layeredGraph.getProperty(InternalProperties.RANDOM);
         
         while (unprocessedNodeCount > 0) {
             // sinks are put to the right --> assign negative rank, which is later shifted to positive
@@ -171,7 +173,7 @@ public final class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
                 assert maxOutflow > Integer.MIN_VALUE;
                 
                 // randomly select a node from the ones with maximal outflow and put it left
-                LNode maxNode = maxNodes.get(random.nextInt(maxNodes.size()));
+                LNode maxNode = chooseNodeWithMaxOutflow(maxNodes);
                 mark[maxNode.id] = nextLeft++;
                 updateNeighbors(maxNode);
                 unprocessedNodeCount--;
@@ -205,6 +207,17 @@ public final class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
 
         dispose();
         monitor.done();
+    }
+    
+    /**
+     * Choose a node among all nodes with the same maximum outflow.
+     * In its default implementation this is done randomly.
+     * 
+     * @param nodes All nodes with the same outflow.
+     * @return The chosen node.
+     */
+    protected LNode chooseNodeWithMaxOutflow(final List<LNode> nodes) {
+        return nodes.get(random.nextInt(nodes.size()));
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyModelOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyModelOrderCycleBreaker.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.p1cycles;
+
+import java.util.List;
+
+import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.options.InternalProperties;
+
+/**
+ * Greedy Cycle Breaker that behaves the same as {@link GreedyCycleBreaker} but does not randomly choose an edge to
+ * reverse if multiple candidates exist but does so by model order.
+ */
+public final class GreedyModelOrderCycleBreaker extends GreedyCycleBreaker {
+    
+    /**
+     * Choose the node with the minimum model order.
+     */
+    @Override
+    protected LNode chooseNodeWithMaxOutflow(final List<LNode> nodes) {
+        LNode returnNode = null;
+        int minimumModelOrder = Integer.MAX_VALUE;
+        for (LNode node : nodes) {
+            // In this step nodes without a model order are disregarded.
+            // One could of course think of a different strategy regarding this aspect.
+            // FUTURE WORK: If multiple model order groups exist, one has to chose based on the priority of the groups.
+            if (node.hasProperty(InternalProperties.MODEL_ORDER)
+                    && node.getProperty(InternalProperties.MODEL_ORDER) < minimumModelOrder) {
+                minimumModelOrder = node.getProperty(InternalProperties.MODEL_ORDER);
+                returnNode = node;
+            }
+        }
+        if (returnNode == null) {
+            return super.chooseNodeWithMaxOutflow(nodes);
+        }
+        return returnNode;
+    }
+
+}

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/p1cycles/BasicCycleBreakerTest.java
@@ -73,6 +73,11 @@ public class BasicCycleBreakerTest extends TestGraphCreator {
     }
     
     @ConfiguratorProvider
+    public LayoutConfigurator greedyModelOrderConfigurator() {
+        return configuratorFor(CycleBreakingStrategy.GREEDY_MODEL_ORDER);
+    }
+    
+    @ConfiguratorProvider
     public LayoutConfigurator modelOrderPreferEdgesConfigurator() {
         LayoutConfigurator config = configuratorFor(CycleBreakingStrategy.MODEL_ORDER);
         config.configure(ElkNode.class).setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY,


### PR DESCRIPTION
This fixes the following issue of the Greedy cycle breaker that sometimes just makes randomly wrong decisions, which can be prevented if one takes the model order into account:
Bad:
<img src="https://user-images.githubusercontent.com/6419799/163378016-fd596f08-174e-4a97-bd2a-b824f5d9cf65.png" width="266">
Good:
<img src="https://user-images.githubusercontent.com/6419799/163378200-f5d6ece6-ca7d-4771-a603-42bb4baf493b.png" width="400">



Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>