### PR TITLE
layered: Node order violations should only be counted for real nodes.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -311,7 +311,9 @@ public class LayerSweepCrossingMinimizer
                     previousLayer == -1 ? layers[0] : layers[previousLayer], strategy, LongEdgeOrderingStrategy.EQUAL);
             for (int i = 0; i < layer.length; i++) {
                 for (int j = i + 1; j < layer.length; j++) {
-                    if (comp.compare(layer[i], layer[j]) > 0) {
+                    if (layer[i].hasProperty(InternalProperties.MODEL_ORDER)
+                            && layer[j].hasProperty(InternalProperties.MODEL_ORDER)
+                            && comp.compare(layer[i], layer[j]) > 0) {
                         wrongModelOrder++;
                     }
                 }


### PR DESCRIPTION
This means it should only be counted for nodes with a model order.