### PR TITLE
rectpacking: Add option to place a node always at the beginning of a new row.

### DIFF
--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPacking.melk
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPacking.melk
@@ -53,6 +53,7 @@ algorithm rectpacking(RectPackingLayoutProvider) {
     supports desiredPosition
     supports currentPosition
     supports targetWidth
+    supports inNewRow
 }
 
 // OPTIONS
@@ -139,4 +140,12 @@ advanced option targetWidth: double {
          horizontal padding."
     targets nodes
     default = -1
+}
+option inNewRow: boolean {
+    label "In new Row"
+    description
+        "If set to true this node begins in a new row. Consequently this node cannot be moved in a previous layer during
+         compaction. Width approximation does does not take this into account."
+    targets nodes
+    default = false
 }

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
@@ -11,6 +11,7 @@ package org.eclipse.elk.alg.rectpacking.seconditeration;
 
 import java.util.List;
 
+import org.eclipse.elk.alg.rectpacking.options.RectPackingOptions;
 import org.eclipse.elk.alg.rectpacking.util.Block;
 import org.eclipse.elk.alg.rectpacking.util.BlockStack;
 import org.eclipse.elk.alg.rectpacking.util.RectRow;
@@ -97,7 +98,8 @@ public final class Compaction {
 
                 // Try to move as many rects as possible from the next block in this block.
                 // First flatten the current block.
-                if (!nextBlock.getChildren().isEmpty()) {
+                if (!nextBlock.getChildren().isEmpty()
+                        && !nextBlock.getChildren().get(0).getProperty(RectPackingOptions.IN_NEW_ROW)) {
                     useRowWidth(block, boundingWidth);
                     // Absorb all rectangles that fit in the current block form the next block if they fit the row.
                     somethingWasChanged |= absorbBlocks(row, block, nextBlock, boundingWidth, nodeNodeSpacing);
@@ -131,7 +133,8 @@ public final class Compaction {
                 // If it could compact the width of the current block and try to fit as much as possible in there
 
                 // Try to fit next block on top of the current block.
-                if (placeBelow(rows, row, block, nextBlock, wasFromNextRow, boundingWidth, nextRowIndex, nodeNodeSpacing)) {
+                if (!nextBlock.getChildren().get(0).getProperty(RectPackingOptions.IN_NEW_ROW)
+                        && placeBelow(rows, row, block, nextBlock, wasFromNextRow, boundingWidth, nextRowIndex, nodeNodeSpacing)) {
                     somethingWasChanged = true;
                     continue;
                 }
@@ -139,7 +142,8 @@ public final class Compaction {
                 if (wasFromNextRow) {
                     // Try to place the next block next to the current one.
                     // Draw the current block as slim as possible.
-                    if (placeBeside(rows, row, block, nextBlock, wasFromNextRow, boundingWidth, nextRowIndex, nodeNodeSpacing)) {
+                    if (!nextBlock.getChildren().get(0).getProperty(RectPackingOptions.IN_NEW_ROW)
+                            && placeBeside(rows, row, block, nextBlock, wasFromNextRow, boundingWidth, nextRowIndex, nodeNodeSpacing)) {
                         somethingWasChanged = true;
                         continue;
                     } else if (useRowHeight(row, block)) {

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/InitialPlacement.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/InitialPlacement.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.rectpacking.seconditeration;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.elk.alg.rectpacking.options.RectPackingOptions;
 import org.eclipse.elk.alg.rectpacking.util.Block;
 import org.eclipse.elk.alg.rectpacking.util.RectRow;
 import org.eclipse.elk.graph.ElkNode;
@@ -51,7 +52,7 @@ public final class InitialPlacement {
             Block block = row.getLastBlock();
             double potentialRowWidth = currentWidth + rect.getWidth() + 
                     (row.getChildren().get(0).getChildren().isEmpty() ? 0 : nodeNodeSpacing);
-            if (potentialRowWidth > boundingWidth) {
+            if (potentialRowWidth > boundingWidth || rect.getProperty(RectPackingOptions.IN_NEW_ROW)) {
                 // Add rect in new block in new row.
                 currentWidth = 0;
                 drawingHeight += row.getHeight() + nodeNodeSpacing;


### PR DESCRIPTION
This allows having more control over the whole drawing if aspect ratio and target width are not enough to control the layout.

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>