### PR TITLE
rectpacking: Add rectpacking improvement.

### DIFF
--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPacking.melk
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPacking.melk
@@ -47,6 +47,7 @@ algorithm rectpacking(RectPackingLayoutProvider) {
     supports lastPlaceShift
     supports onlyFirstIteration
     supports rowCompaction
+    supports rowHeightReevaluation
     supports expandToAspectRatio
     supports org.eclipse.elk.interactive
     supports org.eclipse.elk.interactiveLayout
@@ -62,7 +63,7 @@ advanced option optimizationGoal: OptimizationGoal {
         "Optimization goal for approximation of the bounding box given by the first iteration. Determines whether layout is 
          sorted by the maximum scaling, aspect ratio, or area. Depending on the strategy the aspect ratio might be nearly ignored."
     documentation "@packingstrategy.md"
-    targets nodes
+    targets parents
     default = OptimizationGoal.MAX_SCALE_DRIVEN
 }
 
@@ -75,7 +76,7 @@ programmatic option lastPlaceShift: boolean {
          iteration and a layout, when using ONLY the first iteration (default not the case), where it is sometimes 
          impossible to implement a size transformation of rectangles that will fill the bounding box and eliminate 
          empty spaces."
-    targets nodes
+    targets parents
     default = true
 }
 
@@ -105,7 +106,7 @@ programmatic option onlyFirstIteration: boolean {
         "If enabled only the width approximation step is executed and the nodes are placed accordingly.
          The nodes are layouted according to the packingStrategy.
          If set to true not expansion of nodes is taking place."
-    targets nodes
+    targets parents
     default = false
 }
 
@@ -115,8 +116,19 @@ programmatic option rowCompaction: boolean {
         "Enables compaction. Compacts blocks if they do not use the full height of the row.
          This option allows to have a smaller drawing.
          If this option is disabled all nodes are placed next to each other in rows."
-    targets nodes
+    targets parents
     default = true
+}
+
+option rowHeightReevaluation: boolean {
+    label "Row Height Reevaluation"
+    description
+        "During the compaction step the height of a row is normally not changed.
+         If this options is set, the blocks of other rows might be added if they exceed the row height.
+         If this is the case the whole row has to be packed again to be optimal regarding the new row height.
+         This option should, therefore, be used with care since it might be computation heavy."
+    targets parents
+    default = false
 }
 
 advanced option expandToAspectRatio: boolean {
@@ -125,7 +137,7 @@ advanced option expandToAspectRatio: boolean {
         "Expands nodes if expandNodes is true to fit the aspect ratio instead of only in their bounds.
          The option is only useful if the used packingStrategy is ASPECT_RATIO_DRIVEN, otherwise this may result
          in unreasonable ndoe expansion."
-    targets nodes
+    targets parents
     default = false
     requires org.eclipse.elk.expandNodes
 }
@@ -137,6 +149,6 @@ advanced option targetWidth: double {
          aspect ratio.
          The padding is not included in this. Meaning a drawing will have width of targetwidth +
          horizontal padding."
-    targets nodes
+    targets parents
     default = -1
 }

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
@@ -119,7 +119,9 @@ public final class Compaction {
                 // From the previous step the next block and the next row might be empty.
                 // Delete all empty blocks and rows.
                 if (nextBlock.getChildren().isEmpty()) {
-                    rows.get(nextRowIndex).removeBlock(nextBlock);
+                    if (rows.size() > nextRowIndex) {
+                        rows.get(nextRowIndex).removeBlock(nextBlock);
+                    }
                     nextBlock = null;
                     while (rows.size() > nextRowIndex && rows.get(nextRowIndex).getChildren().isEmpty()) {
                         rows.remove(rows.get(nextRowIndex));

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
@@ -354,8 +354,21 @@ public final class Compaction {
             return false;
         }
         
+        // If the row height is increased the current row height must be increased to evaluate whether it could potentially fit.
+        // The following might be wrong since it does not for different stacks that might have formed
+        // if the row height was higher.
+        // It does, however, check whether it is possible to draw each stack less wide.
+        if (shouldRowHeigthBeReevalauted) {
+            // Calculate available width for next block.
+            double potentialWidth = 0.0;
+            for (BlockStack stack : row.getStacks()) {
+                potentialWidth += stack.getWidthForFixedHeight(nextBlock.getMinHeight()) + nodeNodeSpacing;
+            }
+            targetWidthOfNextBlock = boundingWidth - potentialWidth;
+        }
+    
         // Check width of next block.
-        if (targetWidthOfNextBlock < nextBlock.getMinWidth() && !shouldRowHeigthBeReevalauted) {
+        if (targetWidthOfNextBlock < nextBlock.getMinWidth()) {
             return false;
         }
         // Handle last layer case

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.eclipse.elk.alg.rectpacking.util.Block;
 import org.eclipse.elk.alg.rectpacking.util.BlockStack;
 import org.eclipse.elk.alg.rectpacking.util.RectRow;
+import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.graph.ElkNode;
 
 /**
@@ -44,8 +45,10 @@ public final class Compaction {
      *            The spacing between two nodes.
      * @return returns true, if at least one compaction was made and false otherwise.
      */
-    protected static boolean compact(final int rowIdx, final List<RectRow> rows, final double boundingWidth, final double nodeNodeSpacing) {
+    protected static Pair<Boolean, Boolean> compact(final int rowIdx, final List<RectRow> rows, final double boundingWidth,
+            final double nodeNodeSpacing, final boolean rowHeightReevaluation) {
         boolean somethingWasChanged = false;
+        boolean compactRowAgain = false;
         int nextRowIndex = rowIdx + 1;
         RectRow row = rows.get(rowIdx);
         List<Block> blocks = row.getChildren();
@@ -139,8 +142,18 @@ public final class Compaction {
                 if (wasFromNextRow) {
                     // Try to place the next block next to the current one.
                     // Draw the current block as slim as possible.
-                    if (placeBeside(rows, row, block, nextBlock, wasFromNextRow, boundingWidth, nextRowIndex, nodeNodeSpacing)) {
+                    double oldRowHeight = row.getHeight();
+                    double nextBlockMinHeight = nextBlock.getMinHeight();
+                    if (placeBeside(rows, row, block, nextBlock, wasFromNextRow, boundingWidth, nextRowIndex,
+                            nodeNodeSpacing, rowHeightReevaluation)) {
                         somethingWasChanged = true;
+                        // The next block was inserted and it dominates the current row height.
+                        // Therefore, the current node has to be repacked to fit the row height better.
+                        if (oldRowHeight < nextBlockMinHeight) {
+                            compactRowAgain = true;
+                            nextBlock.setParentRow(row);
+                            break;
+                        }
                         continue;
                     } else if (useRowHeight(row, block)) {
                             block.setFixed(true);
@@ -174,7 +187,7 @@ public final class Compaction {
             }
         }
 
-        return somethingWasChanged;
+        return new Pair<Boolean, Boolean>(somethingWasChanged, compactRowAgain);
     }
     
     /**
@@ -323,15 +336,17 @@ public final class Compaction {
      */
     private static boolean placeBeside(final List<RectRow> rows, final RectRow row, final Block block,
             final Block nextBlock, final boolean wasFromNextRow,
-            double boundingWidth, int nextRowIndex, double nodeNodeSpacing) {
+            double boundingWidth, int nextRowIndex, double nodeNodeSpacing, boolean rowHeightReevaluation) {
         boolean somethingWasChanged = false;
         // Get minimum width for current stack that would fit the height.
         double currentBlockMinWidth = block.getStack().getWidthForFixedHeight(row.getY() + row.getHeight() - block.getStack().getY());
+        // Row height is reevaluated if the next block will dominate the current row in height.
+        boolean shouldRowHeigthBeReevalauted = nextBlock.getMinHeight() > row.getHeight() && rowHeightReevaluation;
         
         // Get total width of the current stack.
         double targetWidthOfNextBlock = boundingWidth - (block.getStack().getX() + currentBlockMinWidth - nodeNodeSpacing);
         // Check width of next block.
-        if (targetWidthOfNextBlock < nextBlock.getMinWidth()) {
+        if (targetWidthOfNextBlock < nextBlock.getMinWidth() && !shouldRowHeigthBeReevalauted) {
             return false;
         }
         // Handle last layer case
@@ -342,13 +357,16 @@ public final class Compaction {
         // we do not recalculate the last row to fit the new row height (but we could).
         boolean lastRowOptimization = nextRowIndex == rows.size() - 1
                 && targetWidthOfNextBlock >= rows.get(nextRowIndex).getWidth();
-
+        
         // Check height of next block.
         double nextBlockHeight = nextBlock.getHeightForTargetWidth(targetWidthOfNextBlock);
-        if (nextBlockHeight > row.getHeight() && !lastRowOptimization) {
+        // If the next block does not contain a node that would dominate the row height and it would otherwise exceed
+        // the row height if drawn in the available width, it cannot be placed in this row (if it is not the last row).
+        if (!(shouldRowHeigthBeReevalauted)
+                && nextBlockHeight > row.getHeight() && !lastRowOptimization) {
                 return false;
         }
-        if (lastRowOptimization || nextBlockHeight <= row.getHeight()) {
+        if (lastRowOptimization || shouldRowHeigthBeReevalauted || nextBlockHeight <= row.getHeight()) {
             if (lastRowOptimization && nextBlockHeight > row.getHeight()) {
                 block.setHeight(nextBlockHeight);
                 block.placeRectsIn(block.getWidthForTargetHeight(nextBlockHeight));

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/Compaction.java
@@ -345,6 +345,15 @@ public final class Compaction {
         
         // Get total width of the current stack.
         double targetWidthOfNextBlock = boundingWidth - (block.getStack().getX() + currentBlockMinWidth - nodeNodeSpacing);
+        
+        // Get height of next block.
+        double nextBlockHeight = nextBlock.getHeightForTargetWidth(targetWidthOfNextBlock);
+        // If the height to fit in the current row is bigger than the minimum height the next block does not provide
+        // a node that will define the row height by its height.
+        if (shouldRowHeigthBeReevalauted && nextBlockHeight > nextBlock.getMinHeight()) {
+            return false;
+        }
+        
         // Check width of next block.
         if (targetWidthOfNextBlock < nextBlock.getMinWidth() && !shouldRowHeigthBeReevalauted) {
             return false;
@@ -358,8 +367,6 @@ public final class Compaction {
         boolean lastRowOptimization = nextRowIndex == rows.size() - 1
                 && targetWidthOfNextBlock >= rows.get(nextRowIndex).getWidth();
         
-        // Check height of next block.
-        double nextBlockHeight = nextBlock.getHeightForTargetWidth(targetWidthOfNextBlock);
         // If the next block does not contain a node that would dominate the row height and it would otherwise exceed
         // the row height if drawn in the available width, it cannot be placed in this row (if it is not the last row).
         if (!(shouldRowHeigthBeReevalauted)

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/InitialPlacement.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/InitialPlacement.java
@@ -62,8 +62,8 @@ public final class InitialPlacement {
                 currentWidth = 0;
             }
             
-            if (block.getChildren().isEmpty() || isSimilarHeight(block, rect, nodeNodeSpacing)) {
-                // Case add rect in current block to the right of last rect in block.
+            if (block.getChildren().isEmpty()) {
+                // Every rect is before compaction in its own block.
                 block.addChild(rect);
             } else {
                 // Case rect does not fit in block. Add new block to the right of it.

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/InitialPlacement.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/InitialPlacement.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.rectpacking.seconditeration;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.elk.alg.rectpacking.options.RectPackingOptions;
 import org.eclipse.elk.alg.rectpacking.util.Block;
 import org.eclipse.elk.alg.rectpacking.util.RectRow;
 import org.eclipse.elk.graph.ElkNode;
@@ -62,7 +63,9 @@ public final class InitialPlacement {
                 currentWidth = 0;
             }
             
-            if (block.getChildren().isEmpty()) {
+            if (block.getChildren().isEmpty()
+                    || !rect.getParent().getProperty(RectPackingOptions.ROW_HEIGHT_REEVALUATION)
+                        && isSimilarHeight(block, rect, nodeNodeSpacing)) {
                 // Every rect is before compaction in its own block.
                 block.addChild(rect);
             } else {

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/RowFillingAndCompaction.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/seconditeration/RowFillingAndCompaction.java
@@ -90,13 +90,15 @@ public class RowFillingAndCompaction {
                 }
                 Pair<Boolean, Boolean> result = Compaction.compact(rowIdx, rows, maxWidth, nodeNodeSpacing, layoutGraph.getProperty(RectPackingOptions.ROW_HEIGHT_REEVALUATION));
                 if (result.getSecond()) {
-                    // Reset the row such that stacks are removed, blocks are not fixed and the width does not exceed
-                    // the bound.
+                    // Reset the row such that stacks are removed, blocks are not fixed.
                     for (Block block : currentRow.getChildren()) {
                         block.setFixed(false);
                         block.setPositionFixed(false);
+                        // Reset precalculated min/max width/heights.
+                        block.resetBlock();
                     }
                     currentRow.resetStacks();
+                    currentRow.setWidth(maxWidth);
                     rowIdx--;
                 } else {
                     adjustWidthAndHeight(currentRow);

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/util/Block.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/util/Block.java
@@ -45,7 +45,7 @@ public class Block {
     /** Rectangles contained in this block. */
     private final List<ElkNode> children = new ArrayList<ElkNode>();
     /** The rectangles in children assigned to rows. */
-    private final List<BlockRow> rows = new ArrayList<BlockRow>();
+    private List<BlockRow> rows = new ArrayList<BlockRow>();
     /** X coordinate of this block. */
     private double x;
     /** Y coordinate of this block. */
@@ -578,5 +578,12 @@ public class Block {
      */
     public void setSmallestRectWidth(double smallestRectWidth) {
         this.smallestRectWidth = smallestRectWidth;
+    }
+
+    /**
+     * Recalculates the size of this block.
+     */
+    public void resetBlock() {
+        adjustSizeAfterRemove();
     }
 }

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/util/RectRow.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/util/RectRow.java
@@ -33,7 +33,7 @@ public class RectRow {
      * This row's stacks of blocks. 
      * Used during the compaction step for better handling and during the stuffing (expansion) process.
      */
-    private final List<BlockStack> stacks = new ArrayList<BlockStack>();
+    private List<BlockStack> stacks = new ArrayList<BlockStack>();
 
     //////////////////////////////////////////////////////////////////
     // Constructors.
@@ -217,5 +217,13 @@ public class RectRow {
      */
     public List<BlockStack> getStacks() {
         return stacks;
+    }
+
+    /**
+     * Removes all created stacks. Should only be used when reevaluating the packing in a row.
+     */
+    public void resetStacks() {
+        this.stacks = new ArrayList<BlockStack>();
+        
     }
 }


### PR DESCRIPTION
Adds an option to move a node from the next row that is higher than the current row inside
it during compaction, which requires repacking the current row. This eliminates one ONO case by giving more control over the
drawing via aspect ratio or target width.

Signed-off-by: Soeren Domroes <sdo@informatik.uni-kiel.de>