### PR TITLE
Port label spacing

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/HorizontalPortPlacementSizeCalculator.java
@@ -263,10 +263,13 @@ public final class HorizontalPortPlacementSizeCalculator {
         
         boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
         boolean alwaysSameSide = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE);
+        boolean alwaysSameSideAbove =
+                nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_OTHER_SAME_SIDE);
         boolean spaceEfficient = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT);
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
         
-        boolean spaceEfficientPortLabels = !alwaysSameSide && (spaceEfficient || portContexts.size() == 2);
+        boolean spaceEfficientPortLabels = !alwaysSameSide && !alwaysSameSideAbove
+                && (spaceEfficient || portContexts.size() == 2);
 
         // Set the horizontal port margins of all ports according to how their labels will be placed. We'll be
         // modifying the margins soon enough.

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/InsidePortLabelCellCreator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/InsidePortLabelCellCreator.java
@@ -78,11 +78,19 @@ public final class InsidePortLabelCellCreator {
         
         switch (portSide) {
         case NORTH:
-            padding.top = nodeContext.portLabelSpacingVertical;
+            // In case of negative port spacing, do not use it as a padding since this would increase the node size.
+            // Needed to ensure that negative label port spacing behaves the same as positive.
+            if (nodeContext.portLabelSpacingVertical >= 0) {
+                padding.top = nodeContext.portLabelSpacingVertical;
+            }
             break;
             
         case SOUTH:
-            padding.bottom = nodeContext.portLabelSpacingVertical;
+            // In case of negative port spacing, do not use it as a padding since this would increase the node size.
+            // Needed to ensure that negative label port spacing behaves the same as positive.
+            if (nodeContext.portLabelSpacingVertical >= 0) {
+                padding.bottom = nodeContext.portLabelSpacingVertical;
+            }
             break;
         }
         

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/NodeLabelAndSizeUtilities.java
@@ -275,7 +275,7 @@ public final class NodeLabelAndSizeUtilities {
                     nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE);
             final boolean spaceEfficient = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT);
 
-            return !firstPort.labelsNextToPort && !alwaysSameSide 
+            return !firstPort.labelsNextToPort && !alwaysSameSide
                     && (portContexts.size() == 2 || spaceEfficient);
         } else {
             return false;

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/PortLabelPlacementCalculator.java
@@ -350,6 +350,8 @@ public final class PortLabelPlacementCalculator {
         boolean placeFirstPortDifferently = NodeLabelAndSizeUtilities.isFirstOutsidePortLabelPlacedDifferently(
                 nodeContext, portSide);
         
+        boolean alwaysAbove = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_OTHER_SAME_SIDE);
+        
         for (PortContext portContext : portContexts) {
             // If the port doesn't have labels, skip
             if (portContext.portLabelCell == null || !portContext.portLabelCell.hasLabels()) {
@@ -372,7 +374,7 @@ public final class PortLabelPlacementCalculator {
                 if (portContext.labelsNextToPort) {
                     portLabelCellRect.x = (portSize.x - portLabelCellRect.width) / 2;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
-                } else if (placeFirstPortDifferently) {
+                } else if (placeFirstPortDifferently || alwaysAbove) {
                     portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacingHorizontal;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 } else {
@@ -387,7 +389,7 @@ public final class PortLabelPlacementCalculator {
                 if (portContext.labelsNextToPort) {
                     portLabelCellRect.x = (portSize.x - portLabelCellRect.width) / 2;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.CENTER);
-                } else if (placeFirstPortDifferently) {
+                } else if (placeFirstPortDifferently || alwaysAbove) {
                     portLabelCellRect.x = -portLabelCellRect.width - nodeContext.portLabelSpacingHorizontal;
                     portLabelCell.setHorizontalAlignment(HorizontalLabelAlignment.RIGHT);
                 } else {
@@ -405,7 +407,7 @@ public final class PortLabelPlacementCalculator {
                             : portLabelCell.getLabels().get(0).getSize().y;
                     portLabelCellRect.y = (portSize.y - labelHeight) / 2;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
-                } else if (placeFirstPortDifferently) {
+                } else if (placeFirstPortDifferently || alwaysAbove) {
                     portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacingVertical;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
                 } else {
@@ -423,7 +425,7 @@ public final class PortLabelPlacementCalculator {
                             : portLabelCell.getLabels().get(0).getSize().y;
                     portLabelCellRect.y = (portSize.y - labelHeight) / 2;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.CENTER);
-                } else if (placeFirstPortDifferently) {
+                } else if (placeFirstPortDifferently || alwaysAbove) {
                     portLabelCellRect.y = -portLabelCellRect.height - nodeContext.portLabelSpacingVertical;
                     portLabelCell.setVerticalAlignment(VerticalLabelAlignment.BOTTOM);
                 } else {

--- a/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
+++ b/plugins/org.eclipse.elk.alg.common/src/org/eclipse/elk/alg/common/nodespacing/internal/algorithm/VerticalPortPlacementSizeCalculator.java
@@ -235,10 +235,13 @@ public final class VerticalPortPlacementSizeCalculator {
 
         boolean portLabelsOutside = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.OUTSIDE);
         boolean alwaysSameSide = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_SAME_SIDE);
+        boolean alwaysSameSideAbove =
+                nodeContext.portLabelsPlacement.contains(PortLabelPlacement.ALWAYS_OTHER_SAME_SIDE);
         boolean spaceEfficient = nodeContext.portLabelsPlacement.contains(PortLabelPlacement.SPACE_EFFICIENT);
         boolean uniformPortSpacing = nodeContext.sizeOptions.contains(SizeOptions.UNIFORM_PORT_SPACING);
 
-        boolean spaceEfficientPortLabels = !alwaysSameSide && (spaceEfficient || portContexts.size() == 2);
+        boolean spaceEfficientPortLabels = !alwaysSameSide && !alwaysSameSideAbove
+                && (spaceEfficient || portContexts.size() == 2);
 
         // Set the vertical port margins of all ports according to how their labels will be placed. We'll be
         // modifying the margins soon enough.

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
@@ -69,6 +69,16 @@ public enum PortLabelPlacement {
     ALWAYS_SAME_SIDE,
 
     /**
+     * The port labels shall always be placed on the same side relative to their corresponding port. For
+     * {@link PortSide#WEST} and {@link PortSide#EAST} this is <i>above</i> the port and for {@link PortSide#NORTH} and
+     * {@link PortSide#SOUTH} it is <i>left</i> of the port.
+     * 
+     * <p>
+     * Note: the option does not apply to inside port labels (unless a hierarchical edge connects).
+     */
+    ALWAYS_OTHER_SAME_SIDE,
+
+    /**
      * Unless there are exactly two ports at a given port side, outside port labels are usually all placed to the same
      * side of their port. For example, if there are three northern ports, all of their labels will be placed to the
      * right of their ports. If this option is active, the leftmost label will be placed to the left of its port while
@@ -120,7 +130,9 @@ public enum PortLabelPlacement {
         }
 
         final Set<PortLabelPlacement> validPosition =
-                EnumSet.of(PortLabelPlacement.ALWAYS_SAME_SIDE, PortLabelPlacement.SPACE_EFFICIENT);
+                EnumSet.of(PortLabelPlacement.ALWAYS_SAME_SIDE,
+                        PortLabelPlacement.ALWAYS_OTHER_SAME_SIDE,
+                        PortLabelPlacement.SPACE_EFFICIENT);
         if (Sets.intersection(validPosition, placement).size() > 1) {
             return false;
         }


### PR DESCRIPTION
See #831

This adds a new port label placement option. Namely `ALWAYS_OTHER_SAME_SIDE` that places all labels above or left instead of below and right compared to `ALWAYS_SAME_SIDE`.
Additionally, it is possible to set negative label port spacing without influencing the position of the port on the node with it.

Before:
- Negative spacing:
![Screenshot from 2022-05-24 10-21-24](https://user-images.githubusercontent.com/6419799/169984694-9034d7ed-334b-442b-835e-612a6ceaef66.png)
- Positive spacing:
![Screenshot from 2022-05-24 10-22-22](https://user-images.githubusercontent.com/6419799/169984745-ea7a9b79-73cc-4c29-a14a-199be666268e.png)

After:
![Screenshot from 2022-05-24 10-22-55](https://user-images.githubusercontent.com/6419799/169984848-844e25fc-ff16-4b74-8eed-b11aa6cbccb9.png)

Model:
```

algorithm: layered
elk.direction: RIGHT
spacing.labelPortVertical: -50
spacing.labelPortHorizontal: 0
portLabels.placement: "ALWAYS_OTHER_SAME_SIDE, OUTSIDE, NEXT_TO_PORT_IF_POSSIBLE"

node n1_1 {
  nodePlacement.strategy: SIMPLE
  elk.direction: RIGHT
  spacing.labelPortVertical: -3.3
  spacing.labelPortHorizontal: 0
  spacing.portPort: 1
  nodeSize.constraints: "NODE_LABELS, PORT_LABELS"
  portLabels.placement: "ALWAYS_OTHER_SAME_SIDE, OUTSIDE, NEXT_TO_PORT_IF_POSSIBLE"
  port p_n1_2 {
    label "p_n1_2"
  }

}
node n1_3 {
  nodeSize.constraints: "NODE_LABELS, PORTS, PORT_LABELS"
  portLabels.placement: "ALWAYS_OTHER_SAME_SIDE, OUTSIDE, NEXT_TO_PORT_IF_POSSIBLE"

  port p1_n1_3 {
    label "p1_n1_3"
  }
}
edge n1_3.p1_n1_3 -> n1_1.p_n1_2

```


