### PR TITLE
layered: Center inline edge labels #841.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 
+import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.alg.layered.options.PortType;
 import org.eclipse.elk.core.math.KVector;
@@ -532,6 +533,17 @@ public final class LNode extends LShape {
             return id;
         }
         return Integer.toString(getIndex());
+    }
+
+    
+    /**
+     * Checks if the labels represented by the given this label dummy are to be placed inline.
+     * 
+     * @return True, if the node is a label and also an inline label.
+     */
+    public boolean isInlineEdgeLabel() {        
+        return this.getType() == NodeType.LABEL && this.getProperty(InternalProperties.REPRESENTED_LABELS).stream()
+                .allMatch(label -> label.getProperty(LayeredOptions.EDGE_LABELS_INLINE));
     }
 
     @Override

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemover.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemover.java
@@ -86,7 +86,8 @@ public final class LabelDummyRemover implements ILayoutProcessor<LGraph> {
                     // Calculate the space available for the placement of labels
                     KVector labelSpace = new KVector(
                             node.getSize().x,
-                            node.getSize().y - thickness - edgeLabelSpacing);
+                            node.getSize().y
+                                + (node.isInlineEdgeLabel() ? 0 : -thickness - edgeLabelSpacing));
                     
                     // Place labels
                     List<LLabel> representedLabels = node.getProperty(InternalProperties.REPRESENTED_LABELS);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
@@ -368,7 +368,7 @@ public final class LabelSideSelector implements ILayoutProcessor<LGraph> {
     private void applyLabelSide(final LNode labelDummy, final LabelSide side) {
         // This method only does things to label dummy nodes
         if (labelDummy.getType() == NodeType.LABEL) {
-            LabelSide effectiveSide = areLabelsPlacedInline(labelDummy)
+            LabelSide effectiveSide = labelDummy.isInlineEdgeLabel()
                     ? LabelSide.INLINE
                     : side;
 
@@ -385,8 +385,12 @@ public final class LabelSideSelector implements ILayoutProcessor<LGraph> {
                     portPos = labelDummy.getSize().y - Math.ceil(thickness / 2);
                 } else if (effectiveSide == LabelSide.INLINE) {
                     // The label dummy has a superfluous label-edge spacing
+                    portPos = Math.ceil((labelDummy.getSize().y
+                                - labelDummy.getGraph().getProperty(LayeredOptions.SPACING_EDGE_LABEL)
+                                - thickness))
+                            / 2.0;
                     labelDummy.getSize().y -= labelDummy.getGraph().getProperty(LayeredOptions.SPACING_EDGE_LABEL);
-                    portPos = (labelDummy.getSize().y - Math.ceil(thickness)) / 2;
+                    labelDummy.getSize().y -= thickness;
                 }
                 
                 for (LPort port : labelDummy.getPorts()) {
@@ -412,16 +416,6 @@ public final class LabelSideSelector implements ILayoutProcessor<LGraph> {
         for (LLabel label : labels) {
             label.setProperty(InternalProperties.LABEL_SIDE, side);
         }
-    }
-    
-    /**
-     * Checks if the labels represented by the given label dummy are to be placed inline.
-     */
-    private boolean areLabelsPlacedInline(final LNode labelDummy) {
-        assert labelDummy.getType() == NodeType.LABEL;
-        
-        return labelDummy.getProperty(InternalProperties.REPRESENTED_LABELS).stream()
-                .allMatch(label -> label.getProperty(LayeredOptions.EDGE_LABELS_INLINE));
     }
     
     /**


### PR DESCRIPTION
The spacing between edges and labels should not be used for inline edge labels.

Fixes #841 