### PR TITLE
Iterative Longest Path Layerer

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/LongestPathLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/LongestPathLayerer.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.p2layers;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Stack;
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/LongestPathLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/LongestPathLayerer.java
@@ -114,6 +114,29 @@ public final class LongestPathLayerer implements ILayoutPhase<LayeredPhases, LGr
         }
     }
     
+    private int visitIterative(final LNode node) {
+        int height = nodeHeights[node.id];
+        if (height >= 0) {
+            return height;
+        } else {
+            int maxHeight = 1;
+            for (LPort port : node.getPorts()) {
+                for (LEdge edge : port.getOutgoingEdges()) {
+                    LNode targetNode = edge.getTarget().getNode();
+                    
+                    if (node != targetNode) {
+                        // recursive call with return
+                        // need to defer the execution with own stack to prevent stackoverflow 
+                        int targetHeight = visit(targetNode);
+                        maxHeight = Math.max(maxHeight, targetHeight + 1);
+                    }
+                }
+            }
+            putNode(node, maxHeight);
+            return maxHeight;
+        }
+    }
+    
     /**
      * Puts the given node into the layered graph, adding new layers as necessary.
      * 


### PR DESCRIPTION
An iterative version of the longest path layerer to adress #872. There is no longer a Stackoverflow exception for the example graph, however, the layout still takes too long with this version. The existing recursive version may be good enough for typical problems.