### PR TITLE
Interactive MrTree

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/InteractiveLayeredGraphVisitor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/InteractiveLayeredGraphVisitor.java
@@ -175,10 +175,10 @@ public class InteractiveLayeredGraphVisitor implements IGraphElementVisitor {
         List<List<ElkNode>> layerNodes = initialLayers(nodesWithoutC);
 
         // Assign layers to nodes with constraints.
-        assignLayersToNodesWithProperty(nodesWithLayerConstraint, layerNodes);
+        int diff = assignLayersToNodesWithProperty(nodesWithLayerConstraint, layerNodes);
 
         // add nodes with rC to the correct layer
-        assignLayersToNodesWithRC(nodesWithRC, layerNodes, nodes);
+        assignLayersToNodesWithRC(nodesWithRC, layerNodes, nodes, diff);
 
         return layerNodes;
     }
@@ -244,7 +244,7 @@ public class InteractiveLayeredGraphVisitor implements IGraphElementVisitor {
      *          All nodes of the graph.
      */
     private void assignLayersToNodesWithRC(final List<ElkNode> nodesWithRC, final List<List<ElkNode>> layering, 
-            final List<ElkNode> allNodes) {
+            final List<ElkNode> allNodes, final int diff) {
         for (int i = 0; i < nodesWithRC.size(); i++) {
             ElkNode node = nodesWithRC.get(i);
             ElkNode succNode = null;
@@ -295,10 +295,10 @@ public class InteractiveLayeredGraphVisitor implements IGraphElementVisitor {
                 
                 // update layer id of the current node
                 int val = succVal > predVal ? succVal : predVal;
-                node.setProperty(LayeredOptions.LAYERING_LAYER_ID, val);
-                shiftOtherNodes(node, val, layering, true);
-                shiftOtherNodes(node, val, layering, false);
-                layering.get(val).add(node);
+                node.setProperty(LayeredOptions.LAYERING_LAYER_ID, val - diff);
+                shiftOtherNodes(node, val - diff, layering, true);
+                shiftOtherNodes(node, val - diff, layering, false);
+                layering.get(val - diff).add(node);
             }
         }
     }
@@ -311,7 +311,7 @@ public class InteractiveLayeredGraphVisitor implements IGraphElementVisitor {
      * @param layering
      *            List that contains the layers with their corresponding nodes.
      */
-    private void assignLayersToNodesWithProperty(final List<ElkNode> nodesWithLayerConstraint,
+    private int assignLayersToNodesWithProperty(final List<ElkNode> nodesWithLayerConstraint,
             final List<List<ElkNode>> layering) {
         // Sort nodes with constraint based on their layer.
         nodesWithLayerConstraint.sort((ElkNode a, ElkNode b) -> {
@@ -341,6 +341,7 @@ public class InteractiveLayeredGraphVisitor implements IGraphElementVisitor {
                 layering.add(new ArrayList<>(Arrays.asList(node)));
             }
         }
+        return diff;
     }
 
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -181,6 +181,8 @@ algorithm layered(LayeredLayoutProvider) {
     supports directionCongruency
     supports portSortingStrategy
     supports edgeRouting.polyline.slopedEdgeZoneWidth
+    supports crossingMinimization.inLayerPredOf
+    supports crossingMinimization.inLayerSuccOf
     supports layering.layerChoiceConstraint
     supports crossingMinimization.positionChoiceConstraint
     supports org.eclipse.elk.interactiveLayout
@@ -234,7 +236,7 @@ group layering {
         targets nodes
     }
 
-    advanced option layerChoiceConstraint: int {
+    advanced option layerChoiceConstraint: Integer {
         label "Layer Choice Constraint"
         description
             "Allows to set a constraint regarding the layer placement of a node. 
@@ -245,7 +247,7 @@ group layering {
              Note that this option is not part of any of ELK Layered's default configurations 
              but is only evaluated as part of the `InteractiveLayeredGraphVisitor`,
              which must be applied manually or used via the `DiagramLayoutEngine."
-        default = -1
+        default = null
         lowerBound = -1
         targets nodes
     }
@@ -412,9 +414,29 @@ group crossingMinimization {
         default = false
         targets parents
         requires crossingMinimization.strategy == CrossingMinimizationStrategy.LAYER_SWEEP
+    }    
+    
+    option inLayerPredOf: String {
+        label "In Layer Predecessor of"
+        description 
+            "Allows to set a constraint which specifies of which node 
+             the current node is the predecessor.
+             If set to 's' then the node is the predecessor of 's' and is in the same layer"
+        default = null
+        targets nodes
+    }
+    
+    advanced option inLayerSuccOf: String {
+        label "In Layer Successor of"
+        description 
+            "Allows to set a constraint which specifies of which node 
+             the current node is the successor.
+             If set to 's' then the node is the successor of 's' and is in the same layer"
+        default = null
+        targets nodes
     }
 
-    advanced option positionChoiceConstraint: int {
+    advanced option positionChoiceConstraint: Integer {
         label "Position Choice Constraint"
         description
             "Allows to set a constraint regarding the position placement of a node in a layer. 
@@ -425,7 +447,7 @@ group crossingMinimization {
              Note that this option is not part of any of ELK Layered's default configurations 
              but is only evaluated as part of the `InteractiveLayeredGraphVisitor`,
              which must be applied manually or used via the `DiagramLayoutEngine. "
-        default = -1
+        default = null
         lowerBound = -1
         targets nodes
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ConstraintsPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/ConstraintsPostprocessor.java
@@ -20,6 +20,14 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
 
 /**
  * Adds to each LNode the layerID and positionID that has been computed by ELK Layered.
+ * <dl>
+ *   <dt>Precondition:</dt>
+ *      <dd>none</dd>
+ *   <dt>Postcondition:</dt>
+ *      <dd>Nodes have a layer and position id based on the layout.</dd>
+ *   <dt>Slots:</dt>
+ *      <dd>After phase 5.</dd>
+ * </dl>
  */
 public final class ConstraintsPostprocessor implements ILayoutProcessor<LGraph> {
 
@@ -38,16 +46,20 @@ public final class ConstraintsPostprocessor implements ILayoutProcessor<LGraph> 
 
         for (Layer layer : graph.getLayers()) {
             int posIndex = 0;
-
+            
+            boolean nodeLayer = false;
             for (LNode currentNode : layer.getNodes()) {
                 if (currentNode.getType() == NodeType.NORMAL) {
+                    nodeLayer = true;
                     currentNode.setProperty(LayeredOptions.LAYERING_LAYER_ID, layerIndex);
                     currentNode.setProperty(LayeredOptions.CROSSING_MINIMIZATION_POSITION_ID, posIndex);
                     posIndex++;
                 }
             }
-
-            layerIndex++;
+            // layers with no nodes in it should not increase the layer id
+            if (nodeLayer) {
+                layerIndex++;
+            }
         }
         // elkjs-exclude-start
         if (progressMonitor.isLoggingEnabled()) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/InteractiveLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/InteractiveLayerer.java
@@ -9,8 +9,11 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.p2layers;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -120,7 +123,14 @@ public final class InteractiveLayerer implements ILayoutPhase<LayeredPhases, LGr
         // correct the layering respecting the graph topology, so edges point from left to right
         for (LNode node : layeredGraph.getLayerlessNodes()) {
             if (node.id == 0) {
-                checkNode(node, layeredGraph);
+                LinkedHashSet<LNode> shiftedNodes = checkNode(node, layeredGraph);
+                // Since shiftedNodes might require other nodes to be shifted, do it again until all shiftedNodes
+                // do no longer require another shift.
+                while (!shiftedNodes.isEmpty()) {
+                    LNode nodeToCheck = shiftedNodes.iterator().next();
+                    shiftedNodes.remove(nodeToCheck);
+                    shiftedNodes.addAll(checkNode(nodeToCheck, layeredGraph));
+                } 
             }
         }
         
@@ -143,9 +153,10 @@ public final class InteractiveLayerer implements ILayoutPhase<LayeredPhases, LGr
      * @param node1 a node
      * @param graph the layered graph
      */
-    private void checkNode(final LNode node1, final LGraph graph) {
+    private LinkedHashSet<LNode> checkNode(final LNode node1, final LGraph graph) {
         node1.id = 1;
         Layer layer1 = node1.getLayer();
+        LinkedHashSet<LNode> shiftNodes = new LinkedHashSet<>();
         for (LPort port : node1.getPorts(PortType.OUTPUT)) {
             for (LEdge edge : port.getOutgoingEdges()) {
                 LNode node2 = edge.getTarget().getNode();
@@ -163,11 +174,11 @@ public final class InteractiveLayerer implements ILayoutPhase<LayeredPhases, LGr
                             Layer newLayer = graph.getLayers().get(newIndex);
                             node2.setLayer(newLayer);
                         }
-                        checkNode(node2, graph);
+                        shiftNodes.add(node2);
                     }
                 }
             }
         }
+        return shiftNodes;
     }
-
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.mrtree/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.elk.alg.common,
  org.eclipse.elk.core,
- org.eclipse.elk.graph
+ org.eclipse.elk.graph,
+ org.eclipse.xtext.xbase.lib
 Export-Package: org.eclipse.elk.alg.mrtree,
  org.eclipse.elk.alg.mrtree.options
 Import-Package: com.google.common.collect

--- a/plugins/org.eclipse.elk.alg.mrtree/build.properties
+++ b/plugins/org.eclipse.elk.alg.mrtree/build.properties
@@ -15,4 +15,3 @@ bin.includes = META-INF/,\
                about.html,\
                images/
 src.includes = about.html
-additional.bundles = org.eclipse.xtext.xbase.lib

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/ComponentsProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/ComponentsProcessor.java
@@ -301,7 +301,6 @@ public class ComponentsProcessor {
             destGraph.getNodes().add(node);
         }
 
-        // FIXME why is this necessary instead of only getEdges?
         for (TEdge edge : sourceGraph.getEdges().stream().distinct().collect(Collectors.toList())) {
             for (KVector bendpoint : edge.getBendPoints()) {
                 bendpoint.add(graphOffset);

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/InteractiveMrTreeGraphVisitor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/InteractiveMrTreeGraphVisitor.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0  
+ *******************************************************************************/
+package org.eclipse.elk.alg.mrtree;
+
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.alg.mrtree.options.OrderWeighting;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.util.IGraphElementVisitor;
+import org.eclipse.elk.graph.ElkGraphElement;
+import org.eclipse.elk.graph.ElkNode;
+
+/**
+ * Graph visitor which visits only the root node and recursively steps through the graph
+ * to set interactive options for the mrtree algorithm.
+ * The mrtree algorithm needs {@code Interactive} to be set to true in all root nodes.
+ */
+public class InteractiveMrTreeGraphVisitor implements IGraphElementVisitor {
+
+    /* (non-Javadoc)
+     * @see org.eclipse.elk.core.util.IGraphElementVisitor#visit(org.eclipse.elk.graph.ElkGraphElement)
+     */
+    @Override
+    public void visit(final ElkGraphElement element) {
+        // Only apply to root of the graph
+        if (element instanceof ElkNode) {
+            ElkNode root = (ElkNode) element;
+            setInteractiveOptions(root);
+        }
+    }
+    
+    /**
+     * Sets the required options for the interactive layout run with the {@code rectpacking} algorithm.
+     */
+    public void setInteractiveOptions(final ElkNode root) {
+        String algorithm = root.getProperty(CoreOptions.ALGORITHM);
+        if (algorithm != null && MrTreeOptions.ALGORITHM_ID.endsWith(algorithm) && !root.getChildren().isEmpty()) {
+            root.setProperty(CoreOptions.INTERACTIVE, true);
+            root.setProperty(MrTreeOptions.WEIGHTING, OrderWeighting.CONSTRAINT);
+        }
+        return;
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/MrTree.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/MrTree.java
@@ -68,11 +68,13 @@ public final class MrTree {
      */
     public TGraph doLayout(final TGraph tgraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Tree layout", 1);
-        
+
+        // elkjs-exclude-start
         if (tgraph.getProperty(MrTreeOptions.DEBUG_MODE)) {
-            System.out.println("MrTree! called at "
+            progressMonitor.log("MrTree! called at "
                     + LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")));
         }
+        // elkjs-exclude-end
         
         // set up the phases and processors depending on user options
         updateModules(tgraph);
@@ -169,17 +171,18 @@ public final class MrTree {
             monitor = new BasicProgressMonitor();
         }
         monitor.begin("Layout", algorithm.size());
-        
+
+        // elkjs-exclude-start
         if (graph.getProperty(MrTreeOptions.DEBUG_MODE)) {
             // Debug Mode!
             // Prints the algorithm configuration and outputs the whole graph to a file
             // before each slot execution
-
-            System.out.println("ELK MrTree uses the following " + algorithm.size() + " modules:");
+            themonitor.log("ELK MrTree uses the following " + algorithm.size() + " modules:");
             for (int i = 0; i < algorithm.size(); i++) {
-                System.out.println("   Slot " + i + ": " + algorithm.get(i).getClass().getName());
+                themonitor.log("   Slot " + i + ": " + algorithm.get(i).getClass().getName());
             }
         }
+        // elkjs-exclude-end
         // invoke each layout processor
         for (ILayoutProcessor<TGraph> processor : algorithm) {
             if (monitor.isCanceled()) {

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/MrTree.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/MrTree.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
@@ -38,6 +40,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  * 
  * @author sor
  * @author sgu
+ * @author sdo
  */
 public final class MrTree {
 
@@ -65,7 +68,12 @@ public final class MrTree {
      */
     public TGraph doLayout(final TGraph tgraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Tree layout", 1);
-
+        
+        if (tgraph.getProperty(MrTreeOptions.DEBUG_MODE)) {
+            System.out.println("MrTree! called at "
+                    + LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")));
+        }
+        
         // set up the phases and processors depending on user options
         updateModules(tgraph);
 
@@ -161,7 +169,7 @@ public final class MrTree {
             monitor = new BasicProgressMonitor();
         }
         monitor.begin("Layout", algorithm.size());
-
+        
         if (graph.getProperty(MrTreeOptions.DEBUG_MODE)) {
             // Debug Mode!
             // Prints the algorithm configuration and outputs the whole graph to a file
@@ -169,8 +177,7 @@ public final class MrTree {
 
             System.out.println("ELK MrTree uses the following " + algorithm.size() + " modules:");
             for (int i = 0; i < algorithm.size(); i++) {
-                String slot = (i < 10 ? "0" : "") + (i++); // SUPPRESS CHECKSTYLE MagicNumber
-                System.out.println("   Slot " + slot + ": " + algorithm.get(i).getClass().getName());
+                System.out.println("   Slot " + i + ": " + algorithm.get(i).getClass().getName());
             }
         }
         // invoke each layout processor

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Kiel University and others.
+ * Copyright (c) 2015 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +10,10 @@
 package org.eclipse.elk.alg.mrtree
 
 import org.eclipse.elk.alg.mrtree.TreeLayoutProvider
+import org.eclipse.elk.alg.mrtree.options.OrderWeighting
+import org.eclipse.elk.alg.mrtree.options.TreeifyingOrder
 import org.eclipse.elk.core.math.ElkPadding
+import org.eclipse.elk.core.options.Direction
 
 /**
  * Declarations for the ELK Tree layout algorithm.
@@ -22,7 +25,7 @@ bundle {
 
 algorithm mrtree(TreeLayoutProvider) {
     label "ELK Mr. Tree"
-    description
+    description 
         "Tree-based algorithm provided by the Eclipse Layout Kernel. Computes a spanning tree of
         the input graph and arranges all nodes according to the resulting parent-children
         hierarchy. I pity the fool who doesn't use Mr. Tree Layout."
@@ -32,37 +35,76 @@ algorithm mrtree(TreeLayoutProvider) {
     preview images/mrtree_layout.png
     supports org.eclipse.elk.padding = new ElkPadding(20)
     supports org.eclipse.elk.spacing.nodeNode = 20
+    supports org.eclipse.elk.spacing.edgeNode = 3
     supports org.eclipse.elk.aspectRatio = 1.6f
     supports org.eclipse.elk.priority = 1
-    documentation "Priorities set on nodes determine the order in which connected components are placed:
+       documentation 
+           "Priorities set on nodes determine the order in which connected components are placed:
             components with a higher sum of node priorities will end up
             before components with a lower sum."
-    supports org.eclipse.elk.separateConnectedComponents = true
+    supports org.eclipse.elk.separateConnectedComponents = true 
     supports org.eclipse.elk.debugMode
-    // Common node micro layout
-    supports org.eclipse.elk.nodeSize.constraints
-    supports org.eclipse.elk.nodeSize.fixedGraphSize
-    supports org.eclipse.elk.nodeSize.minimum
-    supports org.eclipse.elk.nodeSize.options
-    supports org.eclipse.elk.nodeLabels.placement
-    supports org.eclipse.elk.omitNodeMicroLayout
-    supports org.eclipse.elk.portLabels.placement
+    supports org.eclipse.elk.direction = Direction.UNDEFINED
+    supports org.eclipse.elk.interactive
+    supports org.eclipse.elk.interactiveLayout
     supports weighting
     supports searchOrder
+    supports positionConstraint
+    supports edgeRoutingMode
+    supports treeLevel
+    supports compaction
+    supports edgeEndTextureLength
+}
+
+option compaction: boolean {
+    label "Position Constraint"
+    description "Turns on Tree compaction which decreases the size of the whole tree by placing nodes of multiple 
+        levels in one large level"
+    default = false
+    targets parents
+}
+
+option edgeEndTextureLength: double {
+    label "Edge End Texture Length"
+    description "Should be set to the length of the texture at the end of an edge. 
+        This value can be used to improve the Edge Routing."
+    default = 7
+    targets parents
+}
+
+output option treeLevel: int {
+    label "Tree Level"
+    description "The index for the tree level the node is in"
+    default = 0
+    lowerBound = 0
+    targets nodes
+}
+
+option positionConstraint: int {
+    label "Position Constraint"
+    description "When set to a positive number this option will force the algorithm to place the node to the 
+        specified position within the trees layer if weighting is set to constraint"
+    default = -1
+    targets nodes
 }
 
 option weighting: OrderWeighting {
     label "Weighting of Nodes"
-    description
-        "Which weighting to use when computing a node order."
-    default = OrderWeighting.DESCENDANTS
+    description "Which weighting to use when computing a node order."
+    default = OrderWeighting.CONSTRAINT
+    targets parents
+}
+
+option edgeRoutingMode: EdgeRoutingMode {
+    label "Edge Routing Mode"
+    description "Chooses an Edge Routing algorithm."
+    default = EdgeRoutingMode.AvoidOverlap
     targets parents
 }
 
 option searchOrder: TreeifyingOrder {
     label "Search Order"
-    description
-        "Which search order to use when computing a spanning tree."
+    description "Which search order to use when computing a spanning tree."
     default = TreeifyingOrder.DFS
     targets parents
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
@@ -42,11 +42,19 @@ algorithm mrtree(TreeLayoutProvider) {
            "Priorities set on nodes determine the order in which connected components are placed:
             components with a higher sum of node priorities will end up
             before components with a lower sum."
-    supports org.eclipse.elk.separateConnectedComponents = true 
+    supports org.eclipse.elk.separateConnectedComponents = true
     supports org.eclipse.elk.debugMode
     supports org.eclipse.elk.direction = Direction.UNDEFINED
     supports org.eclipse.elk.interactive
     supports org.eclipse.elk.interactiveLayout
+    // Common node micro layout
+    supports org.eclipse.elk.nodeSize.constraints
+    supports org.eclipse.elk.nodeSize.fixedGraphSize
+    supports org.eclipse.elk.nodeSize.minimum
+    supports org.eclipse.elk.nodeSize.options
+    supports org.eclipse.elk.nodeLabels.placement
+    supports org.eclipse.elk.omitNodeMicroLayout
+    supports org.eclipse.elk.portLabels.placement
     supports weighting
     supports searchOrder
     supports positionConstraint

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/Tree.melk
@@ -25,7 +25,7 @@ bundle {
 
 algorithm mrtree(TreeLayoutProvider) {
     label "ELK Mr. Tree"
-    description 
+    description
         "Tree-based algorithm provided by the Eclipse Layout Kernel. Computes a spanning tree of
         the input graph and arranges all nodes according to the resulting parent-children
         hierarchy. I pity the fool who doesn't use Mr. Tree Layout."
@@ -99,14 +99,14 @@ option positionConstraint: int {
 option weighting: OrderWeighting {
     label "Weighting of Nodes"
     description "Which weighting to use when computing a node order."
-    default = OrderWeighting.CONSTRAINT
+    default = OrderWeighting.MODEL_ORDER
     targets parents
 }
 
 option edgeRoutingMode: EdgeRoutingMode {
     label "Edge Routing Mode"
     description "Chooses an Edge Routing algorithm."
-    default = EdgeRoutingMode.AvoidOverlap
+    default = EdgeRoutingMode.AVOID_OVERLAP
     targets parents
 }
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeLayoutProvider.java
@@ -11,7 +11,9 @@ package org.eclipse.elk.alg.mrtree;
 
 import java.util.List;
 
+import org.eclipse.elk.alg.common.NodeMicroLayout;
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
 import org.eclipse.elk.core.AbstractLayoutProvider;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.graph.ElkNode;
@@ -43,12 +45,18 @@ public class TreeLayoutProvider extends AbstractLayoutProvider {
      * {@inheritDoc}
      */
     @Override
-    public void layout(final ElkNode kgraph, final IElkProgressMonitor progressMonitor) {
+    public void layout(final ElkNode layoutGraph, final IElkProgressMonitor progressMonitor) {
+        
+        // If requested, compute nodes's dimensions, place node labels, ports, port labels, etc.
+        if (!layoutGraph.getProperty(MrTreeOptions.OMIT_NODE_MICRO_LAYOUT)) {
+            NodeMicroLayout.forGraph(layoutGraph)
+                           .execute();
+        }
         // build tGraph
         IElkProgressMonitor pm = progressMonitor.subTask(defaultWork);
         pm.begin("build tGraph", 1);
         IGraphImporter<ElkNode> graphImporter = new ElkGraphImporter();
-        TGraph tGraph = graphImporter.importGraph(kgraph);
+        TGraph tGraph = graphImporter.importGraph(layoutGraph);
         pm.done();
 
         // split the input graph into components

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeLayoutProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,9 +11,7 @@ package org.eclipse.elk.alg.mrtree;
 
 import java.util.List;
 
-import org.eclipse.elk.alg.common.NodeMicroLayout;
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
-import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
 import org.eclipse.elk.core.AbstractLayoutProvider;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.graph.ElkNode;
@@ -21,6 +19,10 @@ import org.eclipse.elk.graph.ElkNode;
 /**
  * Layout provider to connect the tree layouter to the Eclipse based layout services and orchestrate
  * the pre layout processing.
+ * 
+ * @author sor
+ * @author sgu
+ * @author sdo
  */
 public class TreeLayoutProvider extends AbstractLayoutProvider {
 
@@ -31,36 +33,46 @@ public class TreeLayoutProvider extends AbstractLayoutProvider {
     private MrTree klayTree = new MrTree();
     /** connected components processor. */
     private ComponentsProcessor componentsProcessor = new ComponentsProcessor();
+    
+    private final float defaultWork = 0.1f;
 
     // /////////////////////////////////////////////////////////////////////////////
     // Regular Layout
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void layout(final ElkNode layoutGraph, final IElkProgressMonitor progressMonitor) {
-        
-        // if requested, compute nodes's dimensions, place node labels, ports, port labels, etc.
-        if (!layoutGraph.getProperty(MrTreeOptions.OMIT_NODE_MICRO_LAYOUT)) {
-            NodeMicroLayout.forGraph(layoutGraph)
-                           .execute();
-        }
-        
+    public void layout(final ElkNode kgraph, final IElkProgressMonitor progressMonitor) {
         // build tGraph
+        IElkProgressMonitor pm = progressMonitor.subTask(defaultWork);
+        pm.begin("build tGraph", 1);
         IGraphImporter<ElkNode> graphImporter = new ElkGraphImporter();
-        TGraph tGraph = graphImporter.importGraph(layoutGraph);
+        TGraph tGraph = graphImporter.importGraph(kgraph);
+        pm.done();
 
         // split the input graph into components
+        pm = progressMonitor.subTask(defaultWork);
+        pm.begin("Split graph", 1);
         List<TGraph> components = componentsProcessor.split(tGraph);
+        pm.done();
 
         // perform the actual layout on the components
         for (TGraph comp : components) {
-            klayTree.doLayout(comp, progressMonitor.subTask(1.0f / components.size()));
+            klayTree.doLayout(comp, progressMonitor.subTask((1.0f - defaultWork * 4) / components.size()));
         }
 
         // pack the components back into one graph
+        pm = progressMonitor.subTask(defaultWork);
+        pm.begin("Pack components", 1);
         tGraph = componentsProcessor.pack(components);
+        pm.done();
 
         // apply the layout results to the original graph
+        pm = progressMonitor.subTask(defaultWork);
+        pm.begin("Apply layout results", 1);
         graphImporter.applyLayout(tGraph);
+        pm.done();
     }
 
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeUtil.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/TreeUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,10 +9,20 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.eclipse.elk.alg.mrtree.graph.TEdge;
+import org.eclipse.elk.alg.mrtree.graph.TGraph;
 import org.eclipse.elk.alg.mrtree.graph.TNode;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.Direction;
 
 import com.google.common.collect.Iterables;
 
@@ -20,6 +30,7 @@ import com.google.common.collect.Iterables;
  * Utility class for Mr Tree.
  * 
  * @author sgu
+ * @author sdo
  */
 public final class TreeUtil {
 
@@ -27,6 +38,337 @@ public final class TreeUtil {
      * Hidden constructor to avoid instantiation.
      */
     private TreeUtil() {
+    }
+    
+    /**
+     * Gets the root of the graph.
+     * @param tGraph the graph
+     * @return the root
+     */
+    public static TNode getRoot(final TGraph tGraph) {
+        return tGraph.getNodes().stream().
+                filter(x -> x.getProperty(InternalProperties.ROOT)).
+                findFirst().get();
+    }
+    
+    /**
+     * Gets the depth of the tree.
+     * @param root the root
+     * @return the depth of the elk tree
+     */
+    public static int depth(final TNode root) {
+        List<TNode> childs = getChildren(root);
+        if (childs.size() == 0) {
+            return 1;
+        } else {
+            return childs.stream().map(x -> depth(x)).max(Integer::compare).get() + 1;
+        }
+    }
+    
+    /**
+     * Gets the child nodes of n within a tree.
+     * @param n the n
+     * @return the child nodes of n within a tree
+     */
+    public static List<TNode> getChildren(final TNode n) {
+        List<TNode> re = new ArrayList<TNode>();
+        for (TEdge out : n.getOutgoingEdges()) {
+            re.add(out.getTarget());
+        }
+        re = re.stream().distinct().collect(Collectors.toList());
+        return re;
+    }
+    
+    /**
+     * Gets the distance from n to the root in a tree.
+     * @param n the n
+     * @param root the root
+     * @return the distance from n to the root in an elk tree
+     */
+    public static int rootDistance(final TNode n, final TNode root) {
+        if (n == root) {
+            return 0;
+        }
+        // We should be in a tree so we assume that there is only one parent
+        TNode p = (TNode) n.getIncomingEdges().get(0).getSource(); 
+        return rootDistance(p, root) + 1;
+    }
+    
+    /**
+     * Gets all edges from a graph with n as their target.
+     * The difference between this method and n.getIncomingEdges() is that the latter may in some cases be outdated
+     * and not contain certain edges.
+     * @param n the node we want the incoming edges from
+     * @param graph the graph the edges are in
+     * @return all the edges that go into n
+     */
+    public static List<TEdge> getAllIncomingEdges(final TNode n, final TGraph graph) {
+        List<TEdge> re = new ArrayList<TEdge>(); 
+        
+        for (TEdge e : graph.getEdges()) {
+            if (e.getTarget().id == n.id 
+                    && e.getSource().getProperty(MrTreeOptions.TREE_LEVEL) 
+                    != e.getTarget().getProperty(MrTreeOptions.TREE_LEVEL) 
+                    && !re.stream().anyMatch(x -> x.toString().equals(e.toString()))) {
+                re.add(e);
+            }
+        }
+        
+        re.sort((x, y) -> Double.compare(x.getSource().getPosition().x, y.getSource().getPosition().x));
+        return re;
+    }
+    
+    /**
+     * Returns all nodes including n of the subtree which has n as its root.
+     * 
+     * @param n The root node of the subtree
+     * @return All nodes of the subtree
+     */
+    public static List<TNode> getSubtree(final TNode n) {
+        if (TreeUtil.getChildren(n).size() == 0) {
+            List<TNode> re = new ArrayList<TNode>();
+            re.add(n);
+            return re;
+        }
+        
+        List<TNode> re = TreeUtil.getChildren(n).stream().map(x -> getSubtree(x)).reduce((x, y) -> {
+            List<TNode> ree = new ArrayList<TNode>();
+            ree.addAll(x);
+            ree.addAll(y);
+            return ree;
+        }).get();
+        re.add(n);
+        return re;
+    }
+    
+    /**
+     * Gets all edges from a graph with n as their source.
+     * The difference between this method and n.getOutgoingEdges() is that the latter may in some cases be outdated
+     * and not contain certain edges.
+     * 
+     * @param n the node we want the outgoing edges of
+     * @param graph the graph the edges are in
+     * @return all the edges that come out of n
+     */
+    public static List<TEdge> getAllOutgoingEdges(final TNode n, final TGraph graph) {
+        List<TEdge> re = new ArrayList<TEdge>();
+        
+        for (TEdge e : graph.getEdges()) {
+            if (e.getSource().id == n.id && !e.getSource().getLabel().equals("SUPER_ROOT") 
+                    && e.getSource().getProperty(MrTreeOptions.TREE_LEVEL) 
+                        != e.getTarget().getProperty(MrTreeOptions.TREE_LEVEL)
+                    && !re.stream().anyMatch(x -> x.toString().equals(e.toString()))) {
+                re.add(e);
+            }
+        }
+        
+        re.sort((x, y) -> Double.compare(x.getTarget().getPosition().x, y.getTarget().getPosition().x));
+        return re;
+    }
+    
+    /**
+     * Gets the first point the edge will currently be routed towards.
+     * 
+     * @param e the edge
+     * @return the first point the edge will currently be routed towards
+     */
+    public static KVector getFirstPoint(final TEdge e) {
+        if (e.getBendPoints().size() == 0) {
+            return new KVector(e.getTarget().getPosition().x, 
+                    e.getTarget().getPosition().y);
+        } else {
+            return e.getBendPoints().getFirst();
+        }
+    }
+    
+    /**
+     * Gets the last point the edge will currently be routed towards.
+     * 
+     * @param e the edge
+     * @return the last point the edge will currently be routed towards
+     */
+    public static KVector getLastPoint(final TEdge e) {
+        if (e.getBendPoints().size() == 0) {
+            return new KVector(e.getSource().getPosition().x, 
+                    e.getSource().getPosition().y);
+        } else {
+            return e.getBendPoints().getLast();
+        }
+    }
+    
+    /**
+     * Gets the layout direction of the graph.
+     * 
+     * @param g the graph
+     * @return the first point the edge will currently be routed towards
+     */
+    public static Direction getDirection(final TGraph g) {
+        return g.getProperty(MrTreeOptions.DIRECTION);
+    }
+    
+    /**
+     * Gets the unit vector facing the specified direction.
+     * @param d the direction
+     * @return the unit vector facing the specified direction
+     */
+    public static KVector getDirectionVector(final Direction d) {
+        switch (d) {
+        case UP:
+            return new KVector(0, -1);
+        case RIGHT:
+            return new KVector(1, 0);
+        case LEFT:
+            return new KVector(-1, 0);
+        default:
+            return new KVector(0, 1);
+        }
+    }
+    
+    /**
+     * Returns the node size from the middle of the node in the specified Direction.
+     * 
+     * @param n the node
+     * @param d the direction
+     * @return the node size in the specified Direction
+     */
+    public static double getNodeSizeInDirection(final TNode n, final Direction d) {
+        if (d == Direction.LEFT) {
+            return -n.getSize().x / 2;
+        } else if (d == Direction.UP) {
+            return -n.getSize().y / 2;
+        } else if (d == Direction.RIGHT) {
+            return n.getSize().x / 2;
+        } else {
+            return n.getSize().y / 2;
+        }
+    }
+    
+    /**
+     * Returns the node size vector from the middle of the node in the specified Direction.
+     * 
+     * @param n the node
+     * @param d the direction
+     * @return the node size vector in the specified Direction
+     */
+    public static KVector getNodeSizeVectorInDirection(final TNode n, final Direction d) {
+        if (d == Direction.LEFT) {
+            return new KVector(-n.getSize().x / 2, 0);
+        } else if (d == Direction.UP) {
+            return new KVector(0, -n.getSize().y / 2);
+        } else if (d == Direction.RIGHT) {
+            return new KVector(n.getSize().x / 2, 0);
+        } else {
+            return new KVector(0, n.getSize().y / 2);
+        }
+    }
+    
+    /**
+     * Returns the Direction which is 90 degrees right of d.
+     * 
+     * @param d the input direction
+     * @return the Direction which is 90 degrees right of d
+     */
+    public static Direction turnRight(final Direction d) {
+        if (d == Direction.LEFT) {
+            return Direction.UP;
+        } else if (d == Direction.UP) {
+            return Direction.RIGHT;
+        } else if (d == Direction.RIGHT) {
+            return Direction.DOWN;
+        } else {
+            return Direction.LEFT;
+        }
+    }
+    
+    /**
+     * Returns the Direction which is 90 degrees left of d.
+     * 
+     * @param d the input direction
+     * @return the Direction which is 90 degrees left of d
+     */
+    public static Direction turnLeft(final Direction d) {
+        if (d == Direction.RIGHT) {
+            return Direction.UP;
+        } else if (d == Direction.UP) {
+            return Direction.LEFT;
+        } else if (d == Direction.LEFT) {
+            return Direction.DOWN;
+        } else {
+            return Direction.RIGHT;
+        }
+    } 
+    
+    /**
+     * Sets center outside of the Node.
+     * 
+     * @param center The Vector to mutate
+     * @param next The next bendpoint after center
+     * @param size The size of the node
+     */
+    public static void toNodeBorder(final KVector center, final KVector next, final KVector size) {
+        double wh = size.x / 2, hh = size.y / 2;
+        double absx = Math.abs(next.x - center.x), absy = Math.abs(next.y - center.y);
+        double xscale = 1, yscale = 1;
+        if (absx > wh) {
+            xscale = wh / absx;
+        }
+        if (absy > hh) {
+            yscale = hh / absy;
+        }
+        double scale = Math.min(xscale, yscale);
+        center.x += scale * (next.x - center.x);
+        center.y += scale * (next.y - center.y);
+    }
+    
+    /**
+     * Checks whether the edge induces a cycle into the graph.
+     * 
+     * @param g the graph
+     * @param e the edge
+     * @return true if the edge goes against the layout direction
+     */
+    public static boolean isCycleInducing(final TEdge e, final TGraph g) {
+        return getDirectionVector(getDirection(g)).
+                dotProduct(new KVector(e.getTarget().getPosition().x - e.getSource().getPosition().x, 
+                        e.getTarget().getPosition().y - e.getSource().getPosition().y)) <= 0;
+    }
+    
+    /**
+     * Returns a unique long for two integers by placing their bits after each other into the long.
+     * 
+     * @param a the first 32 bit number
+     * @param b the second 32 bit number
+     * @return the unique key
+     */
+    public static long getUniqueLong(final int a, final int b) {
+        return (long) a << 32 | b & 0xFFFFFFFFL; // SUPPRESS CHECKSTYLE MagicNumber
+    }
+    
+    /**
+     * Gets the lowest parent of the graph. 
+     * Low is in this context defined as a coordinate with a high dot product with the direction vector of the graph.
+     * 
+     * @param n the node to get the parent of
+     * @param g the graph the parent is in
+     * @return the parent
+     */
+    public static TNode getLowestParent(final TNode n, final TGraph g) {
+        KVector dirVec = getDirectionVector(getDirection(g));
+        if (n.getIncomingEdges().size() == 0) {
+            return null;
+        }
+        List<TNode> sources = n.getIncomingEdges().stream().map(x -> x.getSource()).collect(Collectors.toList());
+        List<TNode> parents = g.getNodes().stream().filter(x -> sources.contains(x)).collect(Collectors.toList());
+        Double lowestParentPos = parents.stream().
+            map(x -> new KVector(x.getPosition().x + x.getSize().x / 2, 
+                    x.getPosition().y + x.getSize().y / 2).dotProduct(dirVec)).
+            max(Comparator.naturalOrder()).get();
+        TNode lowestParent = parents.stream().
+            filter(x -> new KVector(x.getPosition().x + x.getSize().x / 2, x.getPosition().y + x.getSize().y / 2).
+                    dotProduct(dirVec) == lowestParentPos).
+            findFirst().get();
+            
+        return lowestParent;
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/CompactionProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/CompactionProcessor.java
@@ -1,0 +1,338 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.intermediate;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.eclipse.elk.alg.mrtree.TreeUtil;
+import org.eclipse.elk.alg.mrtree.graph.TEdge;
+import org.eclipse.elk.alg.mrtree.graph.TGraph;
+import org.eclipse.elk.alg.mrtree.graph.TNode;
+import org.eclipse.elk.alg.mrtree.options.CompactionMode;
+import org.eclipse.elk.alg.mrtree.options.EdgeRoutingMode;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.core.util.Pair;
+import org.eclipse.elk.core.util.Triple;
+
+/**
+ * Applies one dimensional compaction to the graph.
+ * 
+ * @author jnc, sdo
+ */
+public class CompactionProcessor implements ILayoutProcessor<TGraph> {
+    private List<Pair<Double, Double>> levels;
+    
+    /**
+     * {@inheritDoc}
+     */
+    public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Process compaction", 1);
+        
+        if (!tGraph.getProperty(MrTreeOptions.COMPACTION)) {
+            return; // leave if option is not set
+        }
+        
+        Direction dir = tGraph.getProperty(MrTreeOptions.DIRECTION);
+        double nodeNodeSpacing = tGraph.getProperty(MrTreeOptions.SPACING_NODE_NODE);
+        
+        setUpLevels(tGraph, dir);
+        
+        computeNodeConstraints(tGraph, nodeNodeSpacing / 2 / 2);
+        
+        // Simple one dimensional compaction \w level preservation
+        List<TNode> nodes = tGraph.getNodes();
+        nodes.sort((x, y) -> Double.compare(
+                TreeUtil.getDirectionVector(dir).dotProduct(new KVector(x.getPosition().x, x.getPosition().y)), 
+                TreeUtil.getDirectionVector(dir).dotProduct(new KVector(y.getPosition().x, y.getPosition().y))));
+        for (TNode n : nodes) {
+            // Root nodes aren't compactable
+            if (!n.getProperty(InternalProperties.ROOT)) {
+                TNode d = getLowestDependentNode(n, dir);
+                TNode p = TreeUtil.getLowestParent(n, tGraph);
+                double newPos = 0, newPosSize = 0;
+                if (d != null) {
+                    // n has a dependent node
+                    KVector pos = d.getPosition();
+                    switch (dir) {
+                    case LEFT:
+                        newPos = pos.x - nodeNodeSpacing - n.getSize().x;
+                        if (p.getPosition().x - nodeNodeSpacing - n.getSize().x < newPos) {
+                            newPos = p.getPosition().x - nodeNodeSpacing - n.getSize().x;
+                        }
+                        newPosSize = newPos + n.getSize().x;
+                        break;
+                    case RIGHT:
+                        newPos = pos.x + d.getSize().x + nodeNodeSpacing;
+                        if (p.getPosition().x + nodeNodeSpacing > newPos) {
+                            newPos = p.getPosition().x + p.getSize().x + nodeNodeSpacing;
+                        }
+                        newPosSize = newPos + n.getSize().x;
+                        break;
+                    case UP:
+                        newPos = pos.y - nodeNodeSpacing - n.getSize().y;
+                        if (p.getPosition().y - nodeNodeSpacing - n.getSize().y < newPos) {
+                            newPos = p.getPosition().y - nodeNodeSpacing - n.getSize().y;
+                        }
+                        newPosSize = newPos + n.getSize().y;
+                        break;
+                    case DOWN:
+                        newPos = pos.y + d.getSize().y + nodeNodeSpacing;
+                        if (p.getPosition().y + nodeNodeSpacing > newPos) {
+                            newPos = p.getPosition().y + p.getSize().y + nodeNodeSpacing;
+                        }
+                        newPosSize = newPos + n.getSize().y;
+                        break;
+                    }
+                } else if (p != null) { 
+                    // n does not have a dependent node but a parent
+                    switch (dir) {
+                    case LEFT:
+                        newPos = p.getPosition().x - nodeNodeSpacing - n.getSize().x;
+                        newPosSize = newPos + n.getSize().x;
+                        break;
+                    case RIGHT:
+                        newPos = p.getPosition().x + p.getSize().x + nodeNodeSpacing;
+                        newPosSize = newPos + n.getSize().x;
+                        break;
+                    case UP:
+                        newPos = p.getPosition().y - nodeNodeSpacing - n.getSize().y;
+                        newPosSize = newPos + n.getSize().y;
+                        break;
+                    case DOWN:
+                        newPos = p.getPosition().y + p.getSize().y + nodeNodeSpacing;
+                        newPosSize = newPos + n.getSize().y;
+                        break;
+                    }
+                }
+                
+                if (tGraph.getProperty(MrTreeOptions.EDGE_ROUTING_MODE) == EdgeRoutingMode.AvoidOverlap) {
+                    final double finalNewPos = newPos, finalNewPosSize = newPosSize;
+                    Optional<Pair<Double, Double>> level = levels.stream().
+                            filter(x -> x.getFirst() <= finalNewPos && x.getSecond() >= finalNewPosSize).
+                            findFirst();
+                    if (level.isPresent()) { 
+                        // The Node ended up within a level
+                        if (dir.isHorizontal()) {
+                            n.getPosition().x = newPos;
+                        } else {
+                            n.getPosition().y = newPos;
+                        }
+                    } else {
+                        if (dir == Direction.LEFT || dir == Direction.UP) {
+                            // Skip the first level as it only contains the SUPER_ROOT here
+                            level = levels.stream().skip(1).
+                                    filter(x -> x.getFirst() <= finalNewPos).findFirst();
+                        } else {
+                            // Skip the first level as it only contains the SUPER_ROOT here
+                            level = levels.stream().skip(1).
+                                    filter(x -> x.getFirst() >= finalNewPos).findFirst();
+                        }
+                        
+                        // Force n into the found level
+                        if (level.isPresent()) {
+                            if (dir.isHorizontal()) {
+                                n.getPosition().x = level.get().getFirst();
+                            } else {
+                                n.getPosition().y = level.get().getFirst();
+                            }
+                        }
+                    }
+                    
+                    // Update Tree Level of node
+                    if (level.isPresent()) {
+                        int newIndex = levels.indexOf(level.get());
+                        if (newIndex > 0 && newIndex != n.getProperty(MrTreeOptions.TREE_LEVEL)) {
+                            n.setProperty(InternalProperties.COMPACT_LEVEL_ASCENSION, true);
+                            n.setProperty(MrTreeOptions.TREE_LEVEL, newIndex);
+                        }
+                    }
+                } else {
+                    // In case of Aggressive Compaction just set the parameters
+                    if (dir.isHorizontal()) {
+                        n.getPosition().x = newPos;
+                    } else {
+                        n.getPosition().y = newPos;
+                    }
+                }
+            }
+        }
+        progressMonitor.done();
+    }
+    
+    /**
+     * Sets up the bounds for each level.
+     * 
+     * @param tGraph the Graph the levels are in
+     * @param dir the graphs layout direction
+     */
+    void setUpLevels(final TGraph tGraph, final Direction dir) {
+        levels = new ArrayList<Pair<Double, Double>>();
+        
+        for (TNode n : tGraph.getNodes()) {
+            // Adapt levels size to the current level
+            while (n.getProperty(MrTreeOptions.TREE_LEVEL) > levels.size() - 1) {
+                levels.add(new Pair<>(Double.MAX_VALUE, -Double.MAX_VALUE));
+            }
+            
+            // Update level bounds
+            int curLevel = n.getProperty(MrTreeOptions.TREE_LEVEL);
+            if (dir.isHorizontal()) {
+                if (n.getPosition().x < levels.get(curLevel).getFirst()) {
+                    levels.get(curLevel).setFirst(n.getPosition().x);
+                }
+                if (n.getPosition().x + n.getSize().x > levels.get(curLevel).getSecond()) {
+                    levels.get(curLevel).setSecond(n.getPosition().x + n.getSize().x);
+                }
+            } else {
+                if (n.getPosition().y < levels.get(curLevel).getFirst()) {
+                    levels.get(curLevel).setFirst(n.getPosition().y);
+                }
+                if (n.getPosition().y + n.getSize().y > levels.get(curLevel).getSecond()) {
+                    levels.get(curLevel).setSecond(n.getPosition().y + n.getSize().y);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Compute constrains using scanline algorithm.
+     * 
+     * @param tGraph the Graph to work on
+     */
+    void computeNodeConstraints(final TGraph tGraph, final double nodeNodeSpacing) {
+        Direction d = tGraph.getProperty(MrTreeOptions.DIRECTION);
+        Direction right = d.isHorizontal() ? Direction.DOWN : Direction.RIGHT;
+        
+        // Get a filtered list of all relevant nodes
+        List<TNode> actualNodes = tGraph.getNodes().stream().filter(x -> !x.getLabel().contains("SUPER_ROOT")).
+                collect(Collectors.toList());
+        // Build the point list by adding the upper left node edges, then the lower left ones and sorting all of them
+        List<Triple<TNode, KVector, Boolean>> points = actualNodes.stream().
+                map(x -> new Triple<TNode, KVector, Boolean>(x, x.getPosition().clone().
+                        sub(nodeNodeSpacing, nodeNodeSpacing), true)).
+                collect(Collectors.toList());
+        points.addAll(actualNodes.stream().
+                map(x -> new Triple<TNode, KVector, Boolean>(
+                        x, x.getPosition().clone().add(x.getSize().x + nodeNodeSpacing, 
+                                x.getSize().y + nodeNodeSpacing), false)).
+                collect(Collectors.toList()));
+        points.sort((x, y) -> Double.compare(
+                TreeUtil.getDirectionVector(right).dotProduct(x.getSecond().clone()), 
+                TreeUtil.getDirectionVector(right).dotProduct(y.getSecond().clone())));
+        
+        // Set up set sorted by the node positions projections onto a 1D space given by the direction vector
+        SortedSet<TNode> s = new TreeSet<TNode>((x, y) -> Double.compare(
+                TreeUtil.getDirectionVector(d).dotProduct(x.getPosition().clone()), 
+                TreeUtil.getDirectionVector(d).dotProduct(y.getPosition().clone())));
+        
+        HashMap<TNode, TNode> cand = new HashMap<TNode, TNode>();
+        
+        // Scanline
+        for (Triple<TNode, KVector, Boolean> p : points) {
+            TNode r = p.getFirst();
+            if (p.getThird()) { 
+                s.add(r);
+                if (s.headSet(r).size() > 0) {
+                    cand.put(r, s.headSet(r).last());
+                }
+                if (s.tailSet(r).size() > 1) {
+                    cand.put(getRightElement(s, r), r);
+                }
+            } else {
+                // This deviates a bit from the proposed pseudo code but we need to check if right and left even exist
+                if (s.headSet(r).size() > 0) {
+                    TNode leftNode = s.headSet(r).last();
+                    if (leftNode == cand.get(r)) {
+                        r.getProperty(InternalProperties.COMPACT_CONSTRAINTS).add(leftNode); 
+                    }
+                }
+                if (s.tailSet(r).size() > 1) {
+                    TNode rightNode = getRightElement(s, r);
+                    if (cand.get(rightNode) == r) {
+                        rightNode.getProperty(InternalProperties.COMPACT_CONSTRAINTS).add(r);
+                    }
+                }
+                s.remove(r);
+            }
+        }
+    }
+    
+    /**
+     * Gets the right element of n in the sorted set s.
+     * 
+     * @param s the sorted set
+     * @param n the current node
+     * @return the right element of n
+     */
+    TNode getRightElement(final SortedSet<TNode> s, final TNode n) {
+        SortedSet<TNode> tailSet = s.tailSet(n);
+        if (tailSet.size() <= 1) {
+            throw new NullPointerException();
+        }
+        // Get the second element of the set using the iterator 
+        Iterator<TNode> i = tailSet.iterator();
+        i.next(); 
+        return i.next();
+    }
+    
+    /**
+     * Returns the lowest Node in the graph in the given layout direction that is dependent on n.
+     * 
+     * @param n the current node
+     * @return the lowest Node in the graph in the given layout direction that is dependent on n
+     */
+    TNode getLowestDependentNode(final TNode n, final Direction d) {
+        List<TNode> cons = n.getProperty(InternalProperties.COMPACT_CONSTRAINTS);
+        if (cons == null || cons.size() < 1) {
+            return null;
+        } else if (cons.size() == 1) {
+            return cons.get(0);
+        }
+        
+        TNode lowestCons = null;
+        switch (d) {
+        case LEFT:
+            lowestCons = cons.stream().min((x, y) -> Double.compare(
+                    x.getPosition().x, 
+                    y.getPosition().x)).get();
+            break;
+        case RIGHT:
+            lowestCons = cons.stream().max((x, y) -> Double.compare(
+                    x.getPosition().x + x.getSize().x, 
+                    y.getPosition().x + y.getSize().x)).get();
+            break;
+        case UP:
+            lowestCons = cons.stream().min((x, y) -> Double.compare(
+                    x.getPosition().y, 
+                    y.getPosition().y)).get();
+            break;
+        case DOWN:
+            lowestCons = cons.stream().max((x, y) -> Double.compare(
+                    x.getPosition().y + x.getSize().y, 
+                    y.getPosition().y + y.getSize().y)).get();
+            break;
+        }
+        
+        return lowestCons;
+    }
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/CompactionProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/CompactionProcessor.java
@@ -125,7 +125,7 @@ public class CompactionProcessor implements ILayoutProcessor<TGraph> {
                     }
                 }
                 
-                if (tGraph.getProperty(MrTreeOptions.EDGE_ROUTING_MODE) == EdgeRoutingMode.AvoidOverlap) {
+                if (tGraph.getProperty(MrTreeOptions.EDGE_ROUTING_MODE) == EdgeRoutingMode.AVOID_OVERLAP) {
                     final double finalNewPos = newPos, finalNewPosSize = newPosSize;
                     Optional<Pair<Double, Double>> level = levels.stream().
                             filter(x -> x.getFirst() <= finalNewPos && x.getSecond() >= finalNewPosSize).

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/DirectionProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/DirectionProcessor.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.intermediate;
+
+import org.eclipse.elk.alg.mrtree.graph.TGraph;
+import org.eclipse.elk.alg.mrtree.graph.TNode;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+
+/**
+ * @author sdo
+ *
+ */
+public class DirectionProcessor implements ILayoutProcessor<TGraph> {
+    /**
+     * {@inheritDoc}
+     */
+    public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Process directions", 1);
+        Direction d = tGraph.getProperty(MrTreeOptions.DIRECTION);
+        
+        /**
+         * Swap coordinates for Direction option
+         * Because this modifies the coordinate values it has to be used between Phase 3 and the NodePositionProcessor
+         * to work.
+         * Modifying those values is easier here because they are at the center of where the nodes will be and we want 
+         * to rotate the nodes around their centers
+         */
+        if (d != Direction.DOWN) {
+            for (TNode n : tGraph.getNodes()) {
+                int x = n.getProperty(InternalProperties.XCOOR);
+                int y = n.getProperty(InternalProperties.YCOOR);
+                
+                switch (d) {
+                case UP:
+                    y *= -1;
+                    break;
+                case RIGHT:
+                    int tmp = x;
+                    x = y;
+                    y = tmp;
+                    break;
+                case LEFT:
+                    int tmp2 = x;
+                    x = -y;
+                    y = tmp2;
+                    break;
+                }
+                
+                n.setProperty(InternalProperties.XCOOR, x);
+                n.setProperty(InternalProperties.YCOOR, y);
+            }
+        }
+        
+        progressMonitor.done();
+    }
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/GraphBoundsProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/GraphBoundsProcessor.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.intermediate;
+
+import org.eclipse.elk.alg.mrtree.graph.TGraph;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+
+/**
+ * Sets the graphs x/y max/min properties.
+ * 
+ * @author jnc, sdo
+ */
+public class GraphBoundsProcessor implements ILayoutProcessor<TGraph> {
+    /**
+     * {@inheritDoc}
+     */
+    public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Process graph bounds", 1);
+        
+        tGraph.setProperty(InternalProperties.GRAPH_XMIN, 
+                tGraph.getNodes().stream().mapToDouble(x -> x.getPosition().x).min().getAsDouble());
+        tGraph.setProperty(InternalProperties.GRAPH_YMIN, 
+                tGraph.getNodes().stream().mapToDouble(x -> x.getPosition().y).min().getAsDouble());
+        tGraph.setProperty(InternalProperties.GRAPH_XMAX, 
+                tGraph.getNodes().stream().mapToDouble(x -> x.getPosition().x + x.getSize().x).max().getAsDouble());
+        tGraph.setProperty(InternalProperties.GRAPH_YMAX, 
+                tGraph.getNodes().stream().mapToDouble(x -> x.getPosition().y + x.getSize().y).max().getAsDouble());
+        
+        progressMonitor.done();
+    }
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/IntermediateProcessorStrategy.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/IntermediateProcessorStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,18 +14,18 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.alg.ILayoutProcessorFactory;
 
 /**
- * Definition of available intermediate layout processors for the tree layouter. This enumeration
- * also serves as a factory for intermediate layout processors.
+ * Definition of available intermediate layout processors for the tree layouter. This enumeration also serves as a
+ * factory for intermediate layout processors.
  * 
  * @author sor
  * @author sgu
+ * @author sdo
  */
 public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<TGraph> {
 
     /**
-     * In this enumeration, intermediate layout processors are listed by the earliest slot in which
-     * they can sensibly be used. The order in which they are listed is determined by the
-     * dependencies on other processors.
+     * In this enumeration, intermediate layout processors are listed by the earliest slot in which they can sensibly be
+     * used. The order in which they are listed is determined by the dependencies on other processors.
      */
 
     // Before Phase 2
@@ -33,7 +33,9 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<TGr
     ROOT_PROC,
     /** Compute the fanout of each node in a given graph. */
     FAN_PROC,
-    
+    /** Compute the level of each node in a given graph. */
+    LEVEL_PROC,
+
     // Before Phase 2 and 3
     /** Determine the local neighbors of each node in a given graph. */
     NEIGHBORS_PROC,
@@ -43,9 +45,17 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<TGr
     LEVEL_HEIGHT,
 
     // Before Phase 4
+    /** Applies the layout direction. */
+    DIRECTION_PROC,
     /** Set the coordinates for each node in a given graph. */
     NODE_POSITION_PROC,
-    
+    /** Applies compaction post processing to the graph. */
+    COMPACTION_PROC,
+    /** Determine the height of each level in the given graph. */
+    LEVEL_COORDS,
+    /** Sets the graphs x/y max/min properties. */
+    GRAPH_BOUNDS_PROC,
+
     // After Phase 4
     /** Reinsert edges that were removed for treeifying. */
     DETREEIFYING_PROC;
@@ -65,15 +75,30 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<TGr
         case FAN_PROC:
             return new FanProcessor();
 
+        case LEVEL_PROC:
+            return new LevelProcessor();
+
         case NEIGHBORS_PROC:
             return new NeighborsProcessor();
 
         case LEVEL_HEIGHT:
             return new LevelHeightProcessor();
 
+        case LEVEL_COORDS:
+            return new LevelCoordinatesProcessor();
+
+        case DIRECTION_PROC:
+            return new DirectionProcessor();
+
         case NODE_POSITION_PROC:
             return new NodePositionProcessor();
             
+        case COMPACTION_PROC:
+            return new CompactionProcessor();
+
+        case GRAPH_BOUNDS_PROC:
+            return new GraphBoundsProcessor();
+
         case DETREEIFYING_PROC:
             return new Untreeifyer();
 

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelCoordinatesProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelCoordinatesProcessor.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0  *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.intermediate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.elk.alg.mrtree.graph.TGraph;
+import org.eclipse.elk.alg.mrtree.graph.TNode;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.core.util.Pair;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+/**
+ * A processor that computes the start and end coordinates for each levels nodes.
+ * The used coordinates depend on the layout direction of the graph.
+ * 
+ * @author jnc, sdo
+ */
+public class LevelCoordinatesProcessor implements ILayoutProcessor<TGraph> {
+    /**
+     * {@inheritDoc}
+     */
+    public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Processor determine the coords for each level", 1f);
+
+        List<Pair<Double, Double>> levels = new ArrayList<Pair<Double, Double>>();
+        
+        // Set up levels
+        for (TNode n : tGraph.getNodes()) {
+            while (n.getProperty(MrTreeOptions.TREE_LEVEL) > levels.size() - 1) {
+                levels.add(new Pair<>(Double.MAX_VALUE, -Double.MAX_VALUE));
+            }
+            
+            int curLevel = n.getProperty(MrTreeOptions.TREE_LEVEL);
+            if (tGraph.getProperty(MrTreeOptions.DIRECTION).isHorizontal()) {
+                if (n.getPosition().x < levels.get(curLevel).getFirst()) {
+                    levels.get(curLevel).setFirst(n.getPosition().x);
+                }
+                if (n.getPosition().x + n.getSize().x > levels.get(curLevel).getSecond()) {
+                    levels.get(curLevel).setSecond(n.getPosition().x + n.getSize().x);
+                }
+            } else {
+                if (n.getPosition().y < levels.get(curLevel).getFirst()) {
+                    levels.get(curLevel).setFirst(n.getPosition().y);
+                }
+                if (n.getPosition().y + n.getSize().y > levels.get(curLevel).getSecond()) {
+                    levels.get(curLevel).setSecond(n.getPosition().y + n.getSize().y);
+                }
+            }
+        }
+        
+        // Set node properties
+        for (TNode n : tGraph.getNodes()) {
+            int curLevel = n.getProperty(MrTreeOptions.TREE_LEVEL);
+            n.setProperty(InternalProperties.LEVELMIN, levels.get(curLevel).getFirst());
+            n.setProperty(InternalProperties.LEVELMAX, levels.get(curLevel).getSecond());
+        }
+        
+        progressMonitor.done();
+    }
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/LevelProcessor.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.intermediate;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.elk.alg.mrtree.graph.TGraph;
+import org.eclipse.elk.alg.mrtree.graph.TNode;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+
+/**
+ * A processor that computes the treeLevel property for each node.
+ * 
+ * @author jnc, sdo
+ */
+public class LevelProcessor implements ILayoutProcessor<TGraph> {
+    /** this map temporarily contains the level of each node in the given graph. */
+    private Map<Integer, Integer> gloLevelMap = new HashMap<Integer, Integer>();
+    
+    /**
+     * {@inheritDoc}
+     */
+    public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Processor compute fanout", 1);
+        
+        List<TNode> roots = tGraph.getNodes().stream().
+                filter(x -> x.getProperty(InternalProperties.ROOT)).
+                collect(Collectors.toList());
+        
+        setLevel(roots, 0);
+        
+        for (TNode tNode : tGraph.getNodes()) {
+            int level = gloLevelMap.get(tNode.id) != null ? gloLevelMap.get(tNode.id) : 0;
+            tNode.setProperty(MrTreeOptions.TREE_LEVEL, level);
+        }
+
+        progressMonitor.done();
+    }
+
+    /**
+     * Sets the level for all nodes.
+     *  
+     * @param currentLevel the level we are currently in
+     * @param level the level index
+     */
+    private void setLevel(final List<TNode> currentLevel, final int level) {
+        if (!currentLevel.isEmpty()) {
+            LinkedList<TNode> nextLevel = new LinkedList<TNode>();
+            
+            for (TNode tNode : currentLevel) {
+                gloLevelMap.put(tNode.id, level);
+                for (TNode tChild : tNode.getChildren()) {
+                    nextLevel.add(tChild);
+                }
+            }
+            
+            setLevel(nextLevel, level + 1);
+        }
+    }
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NeighborsProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/NeighborsProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,19 +21,22 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
 import com.google.common.collect.Iterables;
 
 /**
- * A processor which determine the neighbors and siblings for all nodes in the graph. A neighbor is
+ * A processor which determines the neighbors and siblings for all nodes in the graph. A neighbor is
  * the current node's nearest node, at the same level. A siblings is a neighbor with the same
  * parent.
  * 
  * @author sor
  * @author sgu
+ * @author sdo
  */
 public class NeighborsProcessor implements ILayoutProcessor<TGraph> {
 
     /** the number of nodes in the given graph. */
     private int numberOfNodes;
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor set neighbors", 1f);
 
@@ -56,12 +59,11 @@ public class NeighborsProcessor implements ILayoutProcessor<TGraph> {
         }
 
         progressMonitor.done();
-
     }
 
     /**
      * Set the neighbors of each node in the current level and for their children. A neighbor is the
-     * current node's nearest node, at the same level. A siblings is a neighbor with the same
+     * current node's nearest node, at the same level. A sibling is a neighbor with the same
      * parent.
      * 
      * @param currentLevel

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/RootProcessor.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/RootProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,13 +23,17 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  * 
  * @author sor
  * @author sgu
+ * @author sdo
  */
 public class RootProcessor implements ILayoutProcessor<TGraph> {
 
     private ArrayList<TNode> roots = new ArrayList<TNode>();
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Find roots", 1);
 
         /** clear list of roots if processor is reused */
         roots.clear();
@@ -70,5 +74,7 @@ public class RootProcessor implements ILayoutProcessor<TGraph> {
             tGraph.getNodes().add(superRoot);
             break;
         }
+        
+        progressMonitor.done();
     }
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/Untreeifyer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/intermediate/Untreeifyer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,14 +27,19 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  */
 public class Untreeifyer implements ILayoutProcessor<TGraph> {
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
-        List<TEdge>  edges = tGraph.getProperty(InternalProperties.REMOVABLE_EDGES);
+        progressMonitor.begin("Untreeify", 1);
+        
+        List<TEdge> edges = tGraph.getProperty(InternalProperties.REMOVABLE_EDGES);
 
         for (TEdge tEdge : edges) {
             tEdge.getSource().getOutgoingEdges().add(tEdge);
             tEdge.getTarget().getIncomingEdges().add(tEdge);
         }
+        
+        progressMonitor.done();
     }
-    
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/CompactionMode.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/CompactionMode.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.options;
+
+/**
+ * 
+ * @author jnc, sdo
+ */
+public enum CompactionMode {
+    /** No Compaction. */
+    None,
+    /** One dimensional Compaction that preserves the spacings between levels. */
+    LevelPreserving,
+    /** One dimensional Compaction that does not preserve the spacings between levels. 
+     * WARNING: Do not use with EdgeRoutingMode AvoidOverlap */
+    Aggressive
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/CompactionMode.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/CompactionMode.java
@@ -15,10 +15,10 @@ package org.eclipse.elk.alg.mrtree.options;
  */
 public enum CompactionMode {
     /** No Compaction. */
-    None,
+    NONE,
     /** One dimensional Compaction that preserves the spacings between levels. */
-    LevelPreserving,
+    LEVEL_PRESERVING,
     /** One dimensional Compaction that does not preserve the spacings between levels. 
      * WARNING: Do not use with EdgeRoutingMode AvoidOverlap */
-    Aggressive
+    AGGRESSIVE
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/EdgeRoutingMode.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/EdgeRoutingMode.java
@@ -15,9 +15,9 @@ package org.eclipse.elk.alg.mrtree.options;
  */
 public enum EdgeRoutingMode {
     /** Does nothing. */
-    None,
+    NONE,
     /** Routes edges from node middle to node middle. */
-    MiddleToMiddle,
+    MIDDLE_TO_MIDDLE,
     /** Similar to MiddleToMiddle but avoids edge node overlaps. */
-    AvoidOverlap
+    AVOID_OVERLAP
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/EdgeRoutingMode.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/EdgeRoutingMode.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.options;
+
+/**
+ * 
+ * @author jnc, sdo
+ */
+public enum EdgeRoutingMode {
+    /** Does nothing. */
+    None,
+    /** Routes edges from node middle to node middle. */
+    MiddleToMiddle,
+    /** Similar to MiddleToMiddle but avoids edge node overlaps. */
+    AvoidOverlap
+}

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/InternalProperties.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/InternalProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree.options;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -24,6 +25,8 @@ import org.eclipse.elk.graph.properties.Property;
  * 
  * @author sor
  * @author sgu
+ * @author jnc
+ * @author sdo
  */
 public final class InternalProperties {
 
@@ -75,6 +78,32 @@ public final class InternalProperties {
 
     /** The y height of the nodes level. */
     public static final IProperty<Double> LEVELHEIGHT = new Property<Double>("LEVELHEIGHT", 0d);
+    
+    /** The min position of the nodes level in the current layout direction. */
+    public static final IProperty<Double> LEVELMIN = new Property<Double>("LEVELMIN", 0d);
+    
+    /** The max position of the nodes level in the current layout direction. */
+    public static final IProperty<Double> LEVELMAX = new Property<Double>("LEVELMAX", 0d);
+    
+    /** The min x position of the nodes within this graph. */
+    public static final IProperty<Double> GRAPH_XMIN = new Property<Double>("GRAPH_XMIN", 0d);
+    
+    /** The min y position of the nodes within this graph. */
+    public static final IProperty<Double> GRAPH_YMIN = new Property<Double>("GRAPH_YMIN", 0d);
+    
+    /** The maximum x coordinate any nodes reaches with its position and size within this graph. */
+    public static final IProperty<Double> GRAPH_XMAX = new Property<Double>("GRAPH_XMAX", 0d);
+    
+    /** The maximum y coordinate any nodes reaches with its position and size within this graph. */
+    public static final IProperty<Double> GRAPH_YMAX = new Property<Double>("GRAPH_YMAX", 0d);
+    
+    /** Is set to true by the compaction processor if the nodes level changed. */
+    public static final IProperty<Boolean> COMPACT_LEVEL_ASCENSION = 
+            new Property<Boolean>("COMPACT_LEVEL_ASCENSION", false);
+    
+    /** Is set to the lowest dependent node if there is one. */
+    public static final IProperty<List<TNode>> COMPACT_CONSTRAINTS = 
+            new Property<List<TNode>>("COMPACT_CONSTRAINTS", new ArrayList<TNode>());
 
     /**
      * Id of of a real node. This Indicates the block by the most significant letters and level of

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/OrderWeighting.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/OrderWeighting.java
@@ -20,7 +20,7 @@ public enum OrderWeighting {
     
     /** Doesn't change node ordering. 
      * When using this nodes will be in the order of the definition of their incoming edges */
-    NONE,
+    MODEL_ORDER,
     /** Chooses the number of descendants for the weighting. */
     DESCENDANTS,
     /** Chooses maximal number of descendants at the same level. */

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/OrderWeighting.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/options/OrderWeighting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,12 +14,19 @@ package org.eclipse.elk.alg.mrtree.options;
  *
  * @author sor
  * @author sgu
+ * @author sdo
  */
 public enum OrderWeighting {
     
+    /** Doesn't change node ordering. 
+     * When using this nodes will be in the order of the definition of their incoming edges */
+    NONE,
     /** Chooses the number of descendants for the weighting. */
     DESCENDANTS,
     /** Chooses maximal number of descendants at the same level. */
-    FAN;
+    FAN,
+    /** Chooses the nodes with the highest position constraint. 
+     * Without set constraints this will behave just like NONE */
+    CONSTRAINT;
     
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p1treeify/DFSTreeifyer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p1treeify/DFSTreeifyer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,15 +35,18 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
  * @author sor
  * @author sgu
  * @author msp
+ * @author sdo
  */
 public class DFSTreeifyer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
 
     /** intermediate processing configuration. */
     private static final LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> INTERMEDIATE_PROCESSING_CONFIG =
             LayoutProcessorConfiguration.<TreeLayoutPhases, TGraph>create()
-                    .addAfter(TreeLayoutPhases.P4_EDGE_ROUTING, IntermediateProcessorStrategy.DETREEIFYING_PROC);
+                    .addAfter(TreeLayoutPhases.P3_NODE_PLACEMENT, IntermediateProcessorStrategy.DETREEIFYING_PROC);
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("DFS Treeifying phase", 1);
 
@@ -55,6 +58,9 @@ public class DFSTreeifyer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
         progressMonitor.done();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/NodeOrderer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/NodeOrderer.java
@@ -72,9 +72,12 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
         progressMonitor.begin("Processor arrange node", 1);
         
         debug = tGraph.getProperty(MrTreeOptions.DEBUG_MODE);
+
+        // elkjs-exclude-start
         if (debug) {
-            System.out.println("NodeOrderer!");
+            progressMonitor.log("NodeOrderer!");
         }
+        // elkjs-exclude-end
 
         // find the root node and add it to the root list, assuming that: 1. There is a root, 2. There is only one root
         TNode root = tGraph.getNodes().stream().
@@ -194,10 +197,12 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
      */
     private void orderLevelConstraint(final List<TNode> currentLevel, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor arrange level", 1);
-        
+
+        // elkjs-exclude-start
         if (debug) {
-            System.out.println("OrderLevelConstraint!");
+            progressMonitor.log("OrderLevelConstraint!");
         }
+        // elkjs-exclude-end
         
         List<TNode> undefinedNodes = currentLevel.stream().
                 filter(x -> x.getProperty(MrTreeOptions.POSITION_CONSTRAINT) < 0).

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/NodeOrderer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/NodeOrderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,21 +9,29 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree.p2order;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.elk.alg.mrtree.TreeLayoutPhases;
+import org.eclipse.elk.alg.mrtree.TreeUtil;
 import org.eclipse.elk.alg.mrtree.graph.TEdge;
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
 import org.eclipse.elk.alg.mrtree.graph.TNode;
 import org.eclipse.elk.alg.mrtree.intermediate.IntermediateProcessorStrategy;
 import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.alg.mrtree.options.OrderWeighting;
+import org.eclipse.elk.alg.mrtree.p2order.OrderBalance.SortTEdgeTargetProperty;
 import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.PropertyHolderComparator;
 
 /**
@@ -32,6 +40,8 @@ import org.eclipse.elk.graph.properties.PropertyHolderComparator;
  * 
  * @author sor
  * @author sgu
+ * @author jnc
+ * @author sdo
  */
 public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
 
@@ -40,32 +50,44 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
             LayoutProcessorConfiguration.<TreeLayoutPhases, TGraph>create()
                     .before(TreeLayoutPhases.P2_NODE_ORDERING)
                         .add(IntermediateProcessorStrategy.ROOT_PROC)
-                        .add(IntermediateProcessorStrategy.FAN_PROC);
+                        .add(IntermediateProcessorStrategy.FAN_PROC)
+                        .add(IntermediateProcessorStrategy.LEVEL_PROC);
+    
+    private OrderWeighting weighting;
+    private boolean debug = false;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
 
         progressMonitor.begin("Processor arrange node", 1);
-
-        // find the root of the component
-        // expected only one root exists
-        TNode root = null;
-        LinkedList<TNode> roots = new LinkedList<TNode>();
-        Iterator<TNode> it = tGraph.getNodes().iterator();
-        while (root == null && it.hasNext()) {
-            TNode tNode = it.next();
-            if (tNode.getProperty(InternalProperties.ROOT)) {
-                root = tNode;
-            }
+        
+        debug = tGraph.getProperty(MrTreeOptions.DEBUG_MODE);
+        if (debug) {
+            System.out.println("NodeOrderer!");
         }
-        // order each level
-        roots.add(root);
-        orderLevel(roots, progressMonitor.subTask(1.0f));
+
+        // find the root node and add it to the root list, assuming that: 1. There is a root, 2. There is only one root
+        TNode root = tGraph.getNodes().stream().
+                filter(x -> x.getProperty(InternalProperties.ROOT)).
+                findFirst().get();
+        
+        // call the right orderLevel on the first level, which is the root
+        weighting = tGraph.getProperty(MrTreeOptions.WEIGHTING);
+        if (weighting.equals(OrderWeighting.FAN) || weighting.equals(OrderWeighting.DESCENDANTS)) {
+            orderLevelFanDescendants(Arrays.asList(root), progressMonitor.subTask(1.0f));
+        } else if (weighting.equals(OrderWeighting.CONSTRAINT)) {
+            orderLevelConstraint(Arrays.asList(root), progressMonitor.subTask(1.0f));
+        } 
 
         progressMonitor.done();
 
@@ -74,35 +96,39 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
     /**
      * Order each level by separating the nodes into leaves and inner nodes. And then fill gaps with
      * corresponding leaves.
+     * This ordering will be applied when using orderWighting FAN / DESCENDANTS
      * 
      * @param currentLevel
      * @param progressMonitor
      */
-    private void orderLevel(final LinkedList<TNode> currentLevel,
-            final IElkProgressMonitor progressMonitor) {
-
+    private void orderLevelFanDescendants(final List<TNode> currentLevel, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor arrange level", 1);
-
+        
+        IProperty<Integer> sortProperty = InternalProperties.FAN;
+        if (weighting.equals(OrderWeighting.DESCENDANTS)) {
+            sortProperty = InternalProperties.DESCENDANTS;
+        }
+        
         int pos = 0;
 
         // sort all nodes in this level by their fan out
         // so the leaves are at the end of the list
-        Collections.sort(currentLevel, PropertyHolderComparator.with(InternalProperties.FAN));
+        Collections.sort(currentLevel, PropertyHolderComparator.with(sortProperty));
 
-        // find the first occurence of a leave in the list
+        // find the first occurrence of a leave in the list
         int firstOcc = currentLevel.size();
         ListIterator<TNode> it = currentLevel.listIterator(currentLevel.size());
         boolean notNull = true;
         while (notNull && it.hasPrevious()) {
             TNode tNode = (TNode) it.previous();
-            if ((tNode.getProperty(InternalProperties.FAN) == 0)) {
+            if ((tNode.getProperty(sortProperty) == 0)) {
                 firstOcc--;
             } else {
                 notNull = false;
             }
         }
 
-        // seperate the level into leaves and inner nodes
+        // Separate the level into leaves and inner nodes
         List<TNode> tmp = currentLevel.subList(0, firstOcc);
         LinkedList<TNode> inners = new LinkedList<TNode>(tmp);
         tmp = currentLevel.subList(firstOcc, currentLevel.size());
@@ -115,7 +141,6 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
                 tENode.setProperty(InternalProperties.POSITION, pos++);
             }
         } else {
-
             // order each level of descendants of the inner nodes
             int size = inners.size();
             for (TNode tPNode : inners) {
@@ -123,7 +148,7 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
 
                 // set the position of the children and set them in order
                 LinkedList<TNode> children = tPNode.getChildrenCopy();
-                orderLevel(children, progressMonitor.subTask(1 / size));
+                orderLevelFanDescendants(children, progressMonitor.subTask(1 / size));
 
                 // order the children by their reverse position
                 Collections.sort(children,
@@ -148,7 +173,7 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
                 notNull = true;
                 while ((0 < fillGap) && notNull && it.hasPrevious()) {
                     TNode tNode = (TNode) it.previous();
-                    if ((tNode.getProperty(InternalProperties.FAN) == 0)) {
+                    if ((tNode.getProperty(sortProperty) == 0)) {
                         tNode.setProperty(InternalProperties.POSITION, pos++);
                         fillGap--;
                         it.remove();
@@ -158,6 +183,113 @@ public class NodeOrderer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
                 }
             }
         }
+        progressMonitor.done();
+    }
+    
+    /**
+     * Order each level by moving the nodes with a position constraint option to that position.
+     * 
+     * @param currentLevel
+     * @param progressMonitor
+     */
+    private void orderLevelConstraint(final List<TNode> currentLevel, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Processor arrange level", 1);
+        
+        if (debug) {
+            System.out.println("OrderLevelConstraint!");
+        }
+        
+        List<TNode> undefinedNodes = currentLevel.stream().
+                filter(x -> x.getProperty(MrTreeOptions.POSITION_CONSTRAINT) < 0).
+                collect(Collectors.toList());
+        List<TNode> inBoundNodes = currentLevel.stream().
+                filter(x -> x.getProperty(MrTreeOptions.POSITION_CONSTRAINT) < currentLevel.size()
+                         && x.getProperty(MrTreeOptions.POSITION_CONSTRAINT) >= 0).
+                collect(Collectors.toList());
+        List<TNode> outOfBoundNodes = currentLevel.stream().
+                filter(x -> x.getProperty(MrTreeOptions.POSITION_CONSTRAINT) >= currentLevel.size()).
+                collect(Collectors.toList());
+        
+        TNode[] sortedNodes = new TNode[currentLevel.size()];
+        // Priority 1: Set non duplicate constraints
+        for (int i = 0; i < inBoundNodes.size(); i++) {
+            TNode curNode = inBoundNodes.get(i);
+            int targetPos = curNode.getProperty(MrTreeOptions.POSITION_CONSTRAINT);
+            if (targetPos >= 0 && targetPos < inBoundNodes.size() && sortedNodes[targetPos] == null) {
+                sortedNodes[targetPos] = curNode;
+                inBoundNodes.remove(i);
+                i--;
+            }
+        }
+        // Priority 2: Set duplicate constraints
+        for (int i = 0; i < inBoundNodes.size(); i++) {
+            TNode curNode = inBoundNodes.get(i);
+            int targetPos = curNode.getProperty(MrTreeOptions.POSITION_CONSTRAINT);
+            for (int j = 0;; j++) {
+                int newTargetPos = targetPos + j;
+                if (newTargetPos < sortedNodes.length && newTargetPos >= 0 && sortedNodes[newTargetPos] == null) {
+                    sortedNodes[newTargetPos] = curNode;
+                    inBoundNodes.remove(i);
+                    i--;
+                    break;
+                }
+                newTargetPos = targetPos - j;
+                if (newTargetPos < sortedNodes.length && newTargetPos >= 0 && sortedNodes[newTargetPos] == null) {
+                    sortedNodes[newTargetPos] = curNode;
+                    inBoundNodes.remove(i);
+                    i--;
+                    break;
+                }
+            }
+        }
+        // Priority 3: Set out of bounds constraints
+        outOfBoundNodes.sort((x, y) -> 
+            -Integer.compare(
+                    x.getProperty(MrTreeOptions.POSITION_CONSTRAINT), 
+                    y.getProperty(MrTreeOptions.POSITION_CONSTRAINT)));
+        for (int i = sortedNodes.length - 1; i >= 0; i--) {
+            if (sortedNodes[i] == null && !outOfBoundNodes.isEmpty()) {
+                sortedNodes[i] = outOfBoundNodes.get(0);
+                outOfBoundNodes.remove(0);
+            }
+        }
+        // Priority 4: Set no constraint nodes
+        for (int i = 0; i < sortedNodes.length; i++) {
+            if (sortedNodes[i] == null && !undefinedNodes.isEmpty()) {
+                sortedNodes[i] = undefinedNodes.get(0);
+                undefinedNodes.remove(0);
+            }
+        }
+        
+        // Set final node positions
+        for (int i = 0; i < sortedNodes.length; i++) {
+            sortedNodes[i].setProperty(InternalProperties.POSITION, i);
+        }
+        
+        // Recursive calls, apply node positions
+        TNode[] inners = currentLevel.stream().
+                filter(x -> x.getProperty(InternalProperties.FAN) != 0).toArray(TNode[]::new);
+        for (TNode tPNode : inners) {
+            // Recursive call
+            LinkedList<TNode> children = tPNode.getChildrenCopy();
+            orderLevelConstraint(children, progressMonitor.subTask(1 / inners.length));
+            
+            // Order the children by their position
+            Collections.sort(children, PropertyHolderComparator.with(InternalProperties.POSITION));
+
+            // Reset the list of children with the new order
+            List<TEdge> sortedOutEdges = new LinkedList<TEdge>();
+            for (TNode tNode : children) {
+                for (TEdge tEdge : tPNode.getOutgoingEdges()) {
+                    if (tEdge.getTarget() == tNode) {
+                        sortedOutEdges.add(tEdge);
+                    }
+                }
+            }
+            tPNode.getOutgoingEdges().clear();
+            tPNode.getOutgoingEdges().addAll(sortedOutEdges);
+        }
+        
         progressMonitor.done();
     }
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/OrderBalance.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/OrderBalance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,6 +39,7 @@ import org.eclipse.elk.graph.properties.IProperty;
  * 
  * @author sor
  * @author sgu
+ * @author sdo
  */
 public class OrderBalance implements ILayoutPhase<TreeLayoutPhases, TGraph> {
 
@@ -55,17 +56,26 @@ public class OrderBalance implements ILayoutPhase<TreeLayoutPhases, TGraph> {
      */
     private IProperty<Integer> weighting;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor arrange node", 1);
+        
+        if (tGraph.getProperty(MrTreeOptions.DEBUG_MODE)) {
+            System.out.println("OrderBalance!");
+        }
 
         /** get the weighting from the userinterface */
-        if (tGraph.getProperty(MrTreeOptions.WEIGHTING).equals(OrderWeighting.DESCENDANTS)) {
+        if (!tGraph.getProperty(MrTreeOptions.WEIGHTING).equals(OrderWeighting.FAN)) {
             weighting = InternalProperties.DESCENDANTS;
         } else {
             weighting = InternalProperties.FAN;
@@ -195,13 +205,19 @@ public class OrderBalance implements ILayoutPhase<TreeLayoutPhases, TGraph> {
     /**
      * A comparator for edge targets that uses the given property.
      */
-    private static class SortTEdgeTargetProperty implements Comparator<TEdge> {
+    public static class SortTEdgeTargetProperty implements Comparator<TEdge> {
         private IProperty<Integer> property;
 
         SortTEdgeTargetProperty(final IProperty<Integer> property) {
             this.property = property;
         }
-
+        
+        /**
+         * The compare method.
+         * @param t1 The first edge
+         * @param t2 The second edge
+         * @return The difference for the property
+         */
         public int compare(final TEdge t1, final TEdge t2) {
             return t2.getTarget().getProperty(property) - t1.getTarget().getProperty(property);
         }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/OrderBalance.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p2order/OrderBalance.java
@@ -69,10 +69,12 @@ public class OrderBalance implements ILayoutPhase<TreeLayoutPhases, TGraph> {
      */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor arrange node", 1);
-        
+
+        // elkjs-exclude-start
         if (tGraph.getProperty(MrTreeOptions.DEBUG_MODE)) {
-            System.out.println("OrderBalance!");
+            progressMonitor.log("OrderBalance!");
         }
+        // elkjs-exclude-end
 
         /** get the weighting from the userinterface */
         if (!tGraph.getProperty(MrTreeOptions.WEIGHTING).equals(OrderWeighting.FAN)) {

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p3place/NodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p3place/NodePlacer.java
@@ -77,10 +77,10 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
     private double spacing;
 
     /** Determine how to adjust all the nodes with respect to the location of the root. */
-    private double xTopAdjustment = 0d;
+    private double xTopAdjustment = 0d; 
     private double yTopAdjustment = 0d;
     
-    private Direction d;
+    private Direction direction;
 
     /**
      * {@inheritDoc}
@@ -95,15 +95,15 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
      */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor order nodes", 2);
-        
+
         /** set the settings according to the user inputs */
         spacing = tGraph.getProperty(MrTreeOptions.SPACING_NODE_NODE).doubleValue();
-        d = tGraph.getProperty(MrTreeOptions.DIRECTION);
+        direction = tGraph.getProperty(MrTreeOptions.DIRECTION);
         
         // Set Direction to DOWN if its UNDEFINED
-        if (d == Direction.UNDEFINED) {
-            d = Direction.DOWN;
-            tGraph.setProperty(MrTreeOptions.DIRECTION, d);
+        if (direction == Direction.UNDEFINED) {
+            direction = Direction.DOWN;
+            tGraph.setProperty(MrTreeOptions.DIRECTION, direction);
         }
 
         /** find the root node of this component */
@@ -114,7 +114,7 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
             }
         }
         TNode root = roots.getFirst();
-        
+
         /** Do the preliminary positioning with a postorder walk. */
         firstWalk(root, 0);
         progressMonitor.worked(1);
@@ -122,7 +122,7 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
         /** Do the final positioning with a preorder walk. */
         secondWalk(root, yTopAdjustment - (root.getProperty(InternalProperties.LEVELHEIGHT) / 2), xTopAdjustment);
         progressMonitor.worked(1);
-        
+
         progressMonitor.done();
     }
 
@@ -285,14 +285,14 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
     private double meanNodeWidth(final TNode leftNode, final TNode rightNode) {
         double nodeWidth = 0d;
         if (leftNode != null) {
-            if (d.isVertical()) {
+            if (direction.isVertical()) {
                 nodeWidth += leftNode.getSize().x / 2d;
             } else {
                 nodeWidth += leftNode.getSize().y / 2d;
             }
         }
         if (rightNode != null) {
-            if (d.isVertical()) {
+            if (direction.isVertical()) {
                 nodeWidth += rightNode.getSize().x / 2d;
             } else {
                 nodeWidth += rightNode.getSize().y / 2d;

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p3place/NodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p3place/NodePlacer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,10 +9,13 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree.p3place;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 import org.eclipse.elk.alg.mrtree.TreeLayoutPhases;
 import org.eclipse.elk.alg.mrtree.TreeUtil;
+import org.eclipse.elk.alg.mrtree.graph.TEdge;
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
 import org.eclipse.elk.alg.mrtree.graph.TNode;
 import org.eclipse.elk.alg.mrtree.intermediate.IntermediateProcessorStrategy;
@@ -20,7 +23,10 @@ import org.eclipse.elk.alg.mrtree.options.InternalProperties;
 import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
 import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.Direction;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.core.util.Pair;
 
 import com.google.common.collect.Iterables;
 
@@ -53,6 +59,7 @@ import com.google.common.collect.Iterables;
  * 
  * @author sor
  * @author sgu
+ * @author sdo
  */
 public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
 
@@ -63,25 +70,41 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
                     .before(TreeLayoutPhases.P3_NODE_PLACEMENT)
                         .add(IntermediateProcessorStrategy.LEVEL_HEIGHT)
                         .add(IntermediateProcessorStrategy.NEIGHBORS_PROC)
-                    .addBefore(TreeLayoutPhases.P4_EDGE_ROUTING, IntermediateProcessorStrategy.NODE_POSITION_PROC);
+                    .before(TreeLayoutPhases.P4_EDGE_ROUTING)
+                        .add(IntermediateProcessorStrategy.DIRECTION_PROC)
+                        .add(IntermediateProcessorStrategy.NODE_POSITION_PROC);
 
     private double spacing;
 
     /** Determine how to adjust all the nodes with respect to the location of the root. */
     private double xTopAdjustment = 0d;
     private double yTopAdjustment = 0d;
+    
+    private Direction d;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
         progressMonitor.begin("Processor order nodes", 2);
-
-        /** set the spacing according to the user inputs */
+        
+        /** set the settings according to the user inputs */
         spacing = tGraph.getProperty(MrTreeOptions.SPACING_NODE_NODE).doubleValue();
+        d = tGraph.getProperty(MrTreeOptions.DIRECTION);
+        
+        // Set Direction to DOWN if its UNDEFINED
+        if (d == Direction.UNDEFINED) {
+            d = Direction.DOWN;
+            tGraph.setProperty(MrTreeOptions.DIRECTION, d);
+        }
 
         /** find the root node of this component */
         LinkedList<TNode> roots = new LinkedList<TNode>();
@@ -91,7 +114,7 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
             }
         }
         TNode root = roots.getFirst();
-
+        
         /** Do the preliminary positioning with a postorder walk. */
         firstWalk(root, 0);
         progressMonitor.worked(1);
@@ -99,7 +122,7 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
         /** Do the final positioning with a preorder walk. */
         secondWalk(root, yTopAdjustment - (root.getProperty(InternalProperties.LEVELHEIGHT) / 2), xTopAdjustment);
         progressMonitor.worked(1);
-
+        
         progressMonitor.done();
     }
 
@@ -262,10 +285,18 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
     private double meanNodeWidth(final TNode leftNode, final TNode rightNode) {
         double nodeWidth = 0d;
         if (leftNode != null) {
-            nodeWidth += leftNode.getSize().x / 2d;
+            if (d.isVertical()) {
+                nodeWidth += leftNode.getSize().x / 2d;
+            } else {
+                nodeWidth += leftNode.getSize().y / 2d;
+            }
         }
         if (rightNode != null) {
-            nodeWidth += rightNode.getSize().x / 2d;
+            if (d.isVertical()) {
+                nodeWidth += rightNode.getSize().x / 2d;
+            } else {
+                nodeWidth += rightNode.getSize().y / 2d;
+            }
         }
         return nodeWidth;
     }
@@ -313,5 +344,4 @@ public class NodePlacer implements ILayoutPhase<TreeLayoutPhases, TGraph> {
             }
         }
     }
-    
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/EdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/EdgeRouter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Kiel University and others.
+ * Copyright (c) 2013 - 2022 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,43 +9,694 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.mrtree.p4route;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.eclipse.elk.alg.mrtree.TreeLayoutPhases;
+import org.eclipse.elk.alg.mrtree.TreeUtil;
 import org.eclipse.elk.alg.mrtree.graph.TEdge;
 import org.eclipse.elk.alg.mrtree.graph.TGraph;
 import org.eclipse.elk.alg.mrtree.graph.TNode;
+import org.eclipse.elk.alg.mrtree.intermediate.IntermediateProcessorStrategy;
+import org.eclipse.elk.alg.mrtree.options.EdgeRoutingMode;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
 import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.math.KVectorChain;
+import org.eclipse.elk.core.options.Direction;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.core.util.Pair;
+import org.eclipse.elk.core.util.Triple;
+import org.eclipse.elk.graph.ElkNode;
 
 /**
- * TODO: implement smart edge routing
- * 
- * This class implements a dull edge routing by setting just source and target of a edge.
+ * This class implements a dull edge routing by setting just source and target of a edge in mode MiddleToMiddle 
+ * as well as a edge routing algorithm that is designed to prevent edge node and edge edge overlaps in more complex 
+ * graphs.
  * 
  * @author sor
  * @author sgu
+ * @author jnc
+ * @author sdo
  * 
  */
 public class EdgeRouter implements ILayoutPhase<TreeLayoutPhases, TGraph> {
+    
+    private final double oneHalf = 0.5;
+    private final double steepEndEdgeTheresholdDistance = 50;
+    private final double steepEndEdgeRatio = 5.3;
+    private final double steepEndEdgeSampleHeight = 40;
 
     /** intermediate processing configuration. */
     private static final LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> INTERMEDIATE_PROCESSING_CONFIG =
-            LayoutProcessorConfiguration.<TreeLayoutPhases, TGraph>create();
+            LayoutProcessorConfiguration.<TreeLayoutPhases, TGraph>create()
+                    .before(TreeLayoutPhases.P4_EDGE_ROUTING)
+                        .add(IntermediateProcessorStrategy.LEVEL_COORDS)
+                        .add(IntermediateProcessorStrategy.COMPACTION_PROC)
+                        .add(IntermediateProcessorStrategy.GRAPH_BOUNDS_PROC);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public LayoutProcessorConfiguration<TreeLayoutPhases, TGraph> getLayoutProcessorConfiguration(final TGraph graph) {
         return INTERMEDIATE_PROCESSING_CONFIG;
     }
-
-    @Override
+    
+    /**
+     * {@inheritDoc}
+     */
     public void process(final TGraph tGraph, final IElkProgressMonitor progressMonitor) {
-        progressMonitor.begin("Dull edge routing", 1);
+        progressMonitor.begin("Edge routing", 1);
 
-        for (TNode tnode : tGraph.getNodes()) {
-            for (TEdge tedge : tnode.getOutgoingEdges()) {
-                tedge.getBendPoints().clear();
+        EdgeRoutingMode mode = tGraph.getProperty(MrTreeOptions.EDGE_ROUTING_MODE);
+        if (mode == EdgeRoutingMode.MiddleToMiddle) {
+            middleToMiddle(tGraph);
+        } else if (mode == EdgeRoutingMode.AvoidOverlap) {
+            avoidOverlap(tGraph);
+            
+            // fallback
+            for (TEdge e : tGraph.getEdges()) {
+                if (e.getBendPoints().size() < 2) {
+                    middleToMiddleEdgeRoute(e);
+                }
+            }
+        }
+        
+        progressMonitor.done();
+    }
+    
+    /**
+     * Handles MiddleToMiddle edge routing.
+     * 
+     * @param tGraph the graph to work on
+     */
+    private void middleToMiddle(final TGraph tGraph) {
+        for (TEdge tEdge : tGraph.getEdges()) {
+            middleToMiddleEdgeRoute(tEdge);
+        }
+    }
+    
+    /**
+     * Routes a single edge from the middle of one node to the other.
+     * 
+     * @param tEdge the edge to route
+     */
+    private void middleToMiddleEdgeRoute(final TEdge tEdge) {
+        KVectorChain bendPoints = tEdge.getBendPoints();
+
+        // add the source port and target points to the vector chain
+        TNode source = tEdge.getSource();
+        TNode target = tEdge.getTarget();
+        
+        KVector sourcePoint = new KVector(source.getPosition().x + source.getSize().x / 2, 
+                source.getPosition().y + source.getSize().y / 2);
+        KVector targetPoint = new KVector(target.getPosition().x + target.getSize().x / 2, 
+                target.getPosition().y + target.getSize().y / 2);
+        
+        bendPoints.addFirst(sourcePoint);
+        bendPoints.addLast(targetPoint);
+        
+        // correct the source and target points
+        TreeUtil.toNodeBorder(sourcePoint, bendPoints.get(1),
+                tEdge.getSource().getSize());
+        TreeUtil.toNodeBorder(targetPoint, bendPoints.get(bendPoints.size() - 2),
+                tEdge.getTarget().getSize());
+    }
+    
+    /**
+     * Handles AvoidOverlap Edge Routing.
+     * 
+     * @param tGraph
+     */
+    private void avoidOverlap(final TGraph tGraph) {
+        TNode root = TreeUtil.getRoot(tGraph);
+        double nodeBendpointPadding = tGraph.getProperty(MrTreeOptions.SPACING_EDGE_NODE);
+        double edgeEndTexturePadding = tGraph.getProperty(MrTreeOptions.EDGE_END_TEXTURE_LENGTH);
+        Direction d = tGraph.getProperty(MrTreeOptions.DIRECTION);
+        
+        avoidOverlapSetStartPoints(tGraph, d, nodeBendpointPadding);
+        
+        avoidOverlapSpecialEdges(tGraph, root, d, nodeBendpointPadding, edgeEndTexturePadding);
+        
+        avoidOverlapSetEndPoints(tGraph, d, nodeBendpointPadding, edgeEndTexturePadding);
+    }
+    
+    /**
+     * Handles special edges such as multi level edges and cycle inducing edges for the AvoidOverlap router.
+     * Multi level edges are edges that don't just go from one level to the next but through multiple levels.
+     * Cycle inducing edges start lower in the tree than where they end.
+     * 
+     * @param tGraph the Graph to work on
+     * @param root the Graph's root node
+     * @param d the current layout direction
+     * @param nodeBendpointPadding the Node BendPoint Padding
+     * @param edgeEndTexturePadding the length of the texture at the end of edges set in the MrTreeOptions
+     */
+    private void avoidOverlapSpecialEdges(final TGraph tGraph, final TNode root, final Direction d, 
+            final double nodeBendpointPadding, final double edgeEndTexturePadding) {
+        int sideOneEdges = 0, sideTwoEdges = 0; // Counts how many edges are routed along the sides of the tree
+        HashMap<Long, MultiLevelEdgeNodeNodeGap> nodeGaps = new HashMap<Long, MultiLevelEdgeNodeNodeGap>();
+        
+        int maxLevel = tGraph.getNodes().stream().
+                map(x -> x.getProperty(MrTreeOptions.TREE_LEVEL)).
+                max(Integer::compare).get() + 1;
+        int[] outsPerLevel = new int[maxLevel];
+        int[] insPerLevel = new int[maxLevel];
+        for (int i = 0; i < maxLevel; i++) {
+            outsPerLevel[i] = 0;
+            insPerLevel[i] = 0;
+        }
+        
+        List<TEdge> distictEdges = tGraph.getEdges().stream().distinct().collect(Collectors.toList());
+        for (TEdge e : distictEdges) {
+            int sourceLevel = e.getSource().getProperty(MrTreeOptions.TREE_LEVEL);
+            int targetLevel = e.getTarget().getProperty(MrTreeOptions.TREE_LEVEL);
+            int levelDiff = targetLevel - sourceLevel;
+            if (levelDiff > 1) {
+                // Multi level edges
+                for (int curLevel = sourceLevel + 1; curLevel < targetLevel; curLevel++) {
+                    final int finalCurlevel = curLevel;
+                    List<TNode> nextLevelNodes = tGraph.getNodes().stream().filter(x -> 
+                                    x.getProperty(MrTreeOptions.TREE_LEVEL) == finalCurlevel)
+                                    .collect(Collectors.toList());
+                    // Find the node gap in the next level through which we can route our multi level edge
+                    int i = 0;
+                    if (d.isHorizontal()) {
+                        nextLevelNodes.sort((x, y) -> Double.compare(x.getPosition().y, y.getPosition().y));
+                        for (i = 0; i < nextLevelNodes.size(); i++) {
+                            double interpolation = (curLevel - sourceLevel) / (double) (targetLevel - sourceLevel);
+                            if (nextLevelNodes.get(i).getPosition().y > (e.getSource().getPosition().y 
+                                    * (1 - interpolation) + e.getTarget().getPosition().y * interpolation)) {
+                                break;
+                            }
+                        }
+                        
+                        // Skip unnecessary level side bendPoints
+                        if (nextLevelNodes.size() > 0) {
+                            KVector start = e.getBendPoints().size() == 0 
+                                    ? e.getSource().getPosition().clone() : e.getBendPoints().getLast();
+                            KVector last = nextLevelNodes.get(nextLevelNodes.size() - 1).getPosition().clone().
+                                    add(nextLevelNodes.get(nextLevelNodes.size() - 1).getSize());
+                            KVector first = nextLevelNodes.get(0).getPosition().clone().
+                                    add(nextLevelNodes.get(0).getSize());
+                            if (i >= nextLevelNodes.size() - 1 && start.y > last.y 
+                                    && e.getTarget().getPosition().y > last.y) {
+                                continue;
+                            }
+                            if (i <= 0 && start.y < first.x 
+                                    && e.getTarget().getPosition().y < first.y) {
+                                continue;
+                            }
+                        }
+                    } else {
+                        nextLevelNodes.sort((x, y) -> Double.compare(x.getPosition().x, y.getPosition().x));
+                        for (i = 0; i < nextLevelNodes.size(); i++) {
+                            double interpolation = (curLevel - sourceLevel) / (double) (targetLevel - sourceLevel);
+                            if (nextLevelNodes.get(i).getPosition().x > (e.getSource().getPosition().x 
+                                    * (1 - interpolation) + e.getTarget().getPosition().x * interpolation)) {
+                                break;
+                            }
+                        }
+                        
+                        // Skip unnecessary level side bendPoints
+                        if (nextLevelNodes.size() > 0) {
+                            KVector start = e.getBendPoints().size() == 0 
+                                    ? e.getSource().getPosition().clone() : e.getBendPoints().getLast();
+                            KVector last = nextLevelNodes.get(nextLevelNodes.size() - 1).getPosition().clone().
+                                    add(nextLevelNodes.get(nextLevelNodes.size() - 1).getSize());
+                            KVector first = nextLevelNodes.get(0).getPosition().clone().
+                                    add(nextLevelNodes.get(0).getSize());
+                            if (i >= nextLevelNodes.size() - 1 && start.x > last.x 
+                                    && e.getTarget().getPosition().x > last.x) {
+                                continue;
+                            }
+                            if (i <= 0 && start.x < first.x 
+                                    && e.getTarget().getPosition().x < first.x) {
+                                continue;
+                            }
+                        }
+                    }
+                    
+                    // Add multi level edge gap to nodeGaps
+                    KVector bend1 = new KVector(), bend2 = new KVector();
+                    e.getBendPoints().add(bend1); e.getBendPoints().add(bend2);
+                    MultiLevelEdgeNodeNodeGap gap;
+                    Triple<KVector, KVector, TEdge> bendTriple = new Triple<KVector, KVector, TEdge>(bend1, bend2, e);
+                    long key = TreeUtil.getUniqueLong(curLevel, i);
+                    if (!nodeGaps.containsKey(key)) {
+                        gap = new MultiLevelEdgeNodeNodeGap(i == 0 ? null : nextLevelNodes.get(i - 1), 
+                                i == nextLevelNodes.size() ? null : nextLevelNodes.get(i), bendTriple, tGraph);
+                        nodeGaps.put(key, gap);
+                    } else {
+                        gap = nodeGaps.get(key);
+                        gap.addBendPoints(bendTriple);
+                    }
+                    
+                    // Increment end of level edge counters
+                    if (!d.isHorizontal()) {
+                        if (gap.isOnFirstNodeSide() && gap.getNeighborTwo().getPosition().x 
+                                <= tGraph.getProperty(InternalProperties.GRAPH_XMIN)) {
+                            sideOneEdges++;
+                        }
+                        if (gap.isOnLastNodeSide() 
+                                && gap.getNeighborOne().getPosition().x + gap.getNeighborOne().getSize().x
+                                >= tGraph.getProperty(InternalProperties.GRAPH_XMAX)) {
+                            sideTwoEdges++;
+                        }
+                    } else {
+                        if (gap.isOnFirstNodeSide() && gap.getNeighborTwo().getPosition().y 
+                                <= tGraph.getProperty(InternalProperties.GRAPH_YMIN)) {
+                            sideOneEdges++;
+                        }
+                        if (gap.isOnLastNodeSide() 
+                                && gap.getNeighborOne().getPosition().y + gap.getNeighborOne().getSize().y
+                                >= tGraph.getProperty(InternalProperties.GRAPH_YMAX)) {
+                            sideTwoEdges++;
+                        }
+                    }
+                }
+            } else if (levelDiff == 0) {
+                // Fallback for edges that come from and go to the same level
+                middleToMiddleEdgeRoute(e); 
+            } else if (levelDiff < 0) {
+                outsPerLevel[sourceLevel]++;
+                insPerLevel[targetLevel]++;
+                Pair<Integer, Integer> sides = avoidOverlapHandleCycleInducingEdges(e, d, tGraph, 
+                        new Pair<Integer, Integer>(sideOneEdges, sideTwoEdges), nodeBendpointPadding, 
+                        edgeEndTexturePadding, new Pair<Integer, Integer>(
+                                insPerLevel[targetLevel], outsPerLevel[sourceLevel]));
+                sideOneEdges = sides.getFirst();
+                sideTwoEdges = sides.getSecond();
+            }
+        }
+    }
+    
+    private Pair<Integer, Integer> avoidOverlapHandleCycleInducingEdges(final TEdge e, final Direction d, 
+            final TGraph tGraph, final Pair<Integer, Integer> sideEdges, final double nodeBendpointPadding, 
+            final double edgeEndTexturePadding, final Pair<Integer, Integer> inOuts) {
+        int sideOneEdges = sideEdges.getFirst();
+        int sideTwoEdges = sideEdges.getSecond();
+        
+        TNode s = e.getSource(), t = e.getTarget();
+        // Compute bendTmp which is the coordinate at the end of the graph the edge will be routed along
+        double bendTmp = 0, middleTree = 0;
+        if (d.isHorizontal()) {
+            middleTree = tGraph.getNodes().stream().
+                map(x -> x.getPosition().y + x.getSize().y / 2).
+                mapToDouble(Double::doubleValue).average().getAsDouble();
+            if (s.getPosition().y + s.getSize().y / 2 > middleTree) {
+                final int finalSideTwoEdges = ++sideTwoEdges;
+                bendTmp = tGraph.getNodes().stream().
+                        map(x -> x.getPosition().y + x.getSize().y + nodeBendpointPadding * finalSideTwoEdges).
+                        max(Double::compare).get();
+            } else {
+                final int finalSideOneEdges = ++sideOneEdges;
+                bendTmp = tGraph.getNodes().stream().
+                        map(x -> x.getPosition().y - nodeBendpointPadding * finalSideOneEdges).
+                        min(Double::compare).get();
+            }
+        } else {
+            middleTree = tGraph.getNodes().stream().
+                map(x -> x.getPosition().x + x.getSize().x / 2).
+                mapToDouble(Double::doubleValue).average().getAsDouble();
+            if (s.getPosition().x + s.getSize().x / 2 > middleTree) {
+                final int finalSideTwoEdges = ++sideTwoEdges;
+                bendTmp = tGraph.getNodes().stream().
+                        map(x -> x.getPosition().x + x.getSize().x + nodeBendpointPadding * finalSideTwoEdges).
+                        max(Double::compare).get();
+            } else {
+                final int finalSideOneEdges = ++sideOneEdges;
+                bendTmp = tGraph.getNodes().stream().
+                        map(x -> x.getPosition().x - nodeBendpointPadding * finalSideOneEdges).
+                        min(Double::compare).get();
+            }
+        }
+        // Set bendPoints
+        if (d == Direction.LEFT) {
+            e.getBendPoints().add(s.getProperty(InternalProperties.LEVELMIN) - nodeBendpointPadding, bendTmp);
+            e.getBendPoints().add(t.getPosition().x + t.getSize().x 
+                    + nodeBendpointPadding + edgeEndTexturePadding, bendTmp);
+            e.getBendPoints().add(t.getPosition().x + t.getSize().x 
+                    + nodeBendpointPadding + edgeEndTexturePadding, t.getPosition().y + t.getSize().y / 2);
+            e.getBendPoints().add(t.getPosition().x + t.getSize().x, t.getPosition().y + t.getSize().y / 2);
+        } else if (d == Direction.RIGHT) {
+            e.getBendPoints().add(s.getProperty(InternalProperties.LEVELMAX) + nodeBendpointPadding, 
+                    s.getPosition().y + s.getSize().y / 2);
+            e.getBendPoints().add(s.getPosition().x + s.getSize().x + nodeBendpointPadding, bendTmp);
+            e.getBendPoints().add(t.getPosition().x - nodeBendpointPadding - edgeEndTexturePadding, bendTmp);
+            e.getBendPoints().add(t.getPosition().x - nodeBendpointPadding - edgeEndTexturePadding, 
+                    t.getPosition().y + t.getSize().y / 2);
+            e.getBendPoints().add(t.getPosition().x, t.getPosition().y + t.getSize().y / 2);
+        } else if (d == Direction.UP) {
+            e.getBendPoints().add(bendTmp, s.getProperty(InternalProperties.LEVELMIN) - nodeBendpointPadding);
+            e.getBendPoints().add(bendTmp,
+                    t.getPosition().y + t.getSize().y + nodeBendpointPadding + edgeEndTexturePadding);
+            e.getBendPoints().add(t.getPosition().x + t.getSize().x / 2, 
+                    t.getPosition().y + t.getSize().y + nodeBendpointPadding + edgeEndTexturePadding);
+            e.getBendPoints().add(t.getPosition().x + t.getSize().x / 2, 
+                    t.getPosition().y + t.getSize().y + nodeBendpointPadding);
+        } else {
+            if (!e.getBendPoints().isEmpty()) {
+                e.getBendPoints().getLast().y = s.getProperty(InternalProperties.LEVELMAX) + nodeBendpointPadding 
+                        * inOuts.getSecond();
+            }
+            e.getBendPoints().add(bendTmp, 
+                    s.getProperty(InternalProperties.LEVELMAX) + nodeBendpointPadding * inOuts.getSecond());
+            e.getBendPoints().add(bendTmp,
+                    t.getPosition().y - nodeBendpointPadding * inOuts.getFirst() - edgeEndTexturePadding);
+        }
+        
+        return new Pair<Integer, Integer>(sideOneEdges, sideTwoEdges);
+    }
+
+    
+    /**
+     * Handles the start points for AvoidOverlap edge routing.
+     * 
+     * @param tGraph the graph to work on
+     * @param d the current layout direction
+     * @param nodeBendpointPadding the Node BendPoint Padding 
+     */
+    private void avoidOverlapSetStartPoints(final TGraph tGraph, final Direction d, final double nodeBendpointPadding) {
+        for (TNode n : tGraph.getNodes()) {
+            if (n.getLabel().equals("SUPER_ROOT")) {
+               continue;
+            }
+            
+            // Get a list of all outgoing edges from n
+            // I specifically do not use n.getOutgoingEdges() here because that list does not contain all outgoing 
+            // edges in certain scenarios. For example if a node has two parents who are also both root nodes
+            List<TEdge> outs = TreeUtil.getAllOutgoingEdges(n, tGraph); 
+            if (d.isHorizontal()) {
+                outs.sort((x, y) -> Double.compare(TreeUtil.getFirstPoint(x).y, 
+                        TreeUtil.getFirstPoint(y).y));
+            } else {
+                outs.sort((x, y) -> Double.compare(TreeUtil.getFirstPoint(x).x, 
+                        TreeUtil.getFirstPoint(y).x));
+            }
+
+            // Set the bendPoints for all outs
+            int num = outs.size();
+            for (int i = 0; i < num; i++) {
+                TNode tar = outs.get(i).getTarget();
+                if (tar.getLabel().equals("n11")) {
+                    getClass();
+                }
+                if (n.getProperty(InternalProperties.COMPACT_LEVEL_ASCENSION)
+                        && !TreeUtil.isCycleInducing(outs.get(i), tGraph)) {
+                    continue;
+                }
+                
+                double interpolation = num == 1 ? oneHalf : (i + 1) / (double) (num + 1);
+                if (d == Direction.LEFT) {
+                    double levelEndCoord = n.getProperty(InternalProperties.LEVELMIN);
+                    double y = n.getPosition().y + n.getSize().y * interpolation;
+                    outs.get(i).getBendPoints().addFirst(Math.min(levelEndCoord, 
+                            n.getPosition().x - nodeBendpointPadding), y);
+                    outs.get(i).getBendPoints().addFirst(n.getPosition().x, y);
+                } else if (d == Direction.RIGHT) {
+                    double levelEndCoord = n.getProperty(InternalProperties.LEVELMAX) + nodeBendpointPadding;
+                    double y = n.getPosition().y + n.getSize().y * interpolation;
+                    outs.get(i).getBendPoints().addFirst(levelEndCoord, y);
+                    outs.get(i).getBendPoints().addFirst(n.getPosition().x + n.getSize().x, y);
+                } else if (d == Direction.UP) {
+                    double levelEndCoord = n.getProperty(InternalProperties.LEVELMIN);
+                    double x = n.getPosition().x + n.getSize().x * interpolation;
+                    outs.get(i).getBendPoints().addFirst(x, 
+                            Math.min(n.getPosition().y - nodeBendpointPadding, levelEndCoord));
+                    outs.get(i).getBendPoints().addFirst(x, n.getPosition().y);
+                } else {
+                    double levelEndCoord = n.getProperty(InternalProperties.LEVELMAX) + nodeBendpointPadding;
+                    double x = n.getPosition().x + n.getSize().x * interpolation;
+                    outs.get(i).getBendPoints().addFirst(x, levelEndCoord);
+                    outs.get(i).getBendPoints().addFirst(x, n.getPosition().y + n.getSize().y);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Handles the end points for AvoidOverlap edge routing.
+     * 
+     * @param tGraph the graph to work on
+     * @param d the current layout direction
+     * @param nodeBendpointPadding the Node BendPoint Padding
+     * @param edgeEndTexturePadding the length of the texture at the end of edges set in the MrTreeOptions 
+     */
+    private void avoidOverlapSetEndPoints(final TGraph tGraph, final Direction d, final double nodeBendpointPadding, 
+            final double edgeEndTexturePadding) {
+        for (TNode n : tGraph.getNodes()) {
+            
+            if (n.getLabel().equals("SUPER_ROOT")) {
+                continue;
+            }
+            
+            // Get the incoming edges and sort them by their current bendPoints
+            // Similarly to setStartPoints I do not use the n.getIncomingEdges() here for the same reasons
+            List<TEdge> ins = TreeUtil.getAllIncomingEdges(n, tGraph).stream().collect(Collectors.toList());
+            if (d.isHorizontal()) {
+                ins.sort((x, y) -> Double.compare(TreeUtil.getLastPoint(x).y, 
+                        TreeUtil.getLastPoint(y).y));
+            } else {
+                ins.sort((x, y) -> Double.compare(TreeUtil.getLastPoint(x).x, 
+                        TreeUtil.getLastPoint(y).x));
+            }
+            
+            // Set the bendPoints
+            int num = ins.size();
+            for (int i = 0; i < num; i++) {
+                double interpolation = num == 1 ? oneHalf : (1 + i) / (double) (num + 1);
+                if (d == Direction.LEFT) {
+                    double levelStartCoord = n.getProperty(InternalProperties.LEVELMAX);
+                    // Only add level bendPoint if the distance is great enough
+                    if (n.getPosition().x + n.getSize().x + edgeEndTexturePadding < levelStartCoord) {
+                        ins.get(i).getBendPoints().add(levelStartCoord + nodeBendpointPadding, 
+                                n.getPosition().y + n.getSize().y * interpolation);
+                    // If the angle of the end piece is too steep, add another bendpoint
+                    } else if (ins.get(i).getBendPoints().size() > 0) {
+                        double lastX = ins.get(i).getBendPoints().getLast().x;
+                        double nextX = n.getPosition().x + n.getSize().x / 2;
+                        double lastY = ins.get(i).getBendPoints().getLast().y;
+                        double nextY = n.getPosition().y + n.getSize().y / 2;
+                        if (edgeEndTexturePadding > 0 && Math.abs(lastY - nextY) / (Math.abs(lastX - nextX) 
+                                / steepEndEdgeSampleHeight) > steepEndEdgeTheresholdDistance) {
+                            if (nextY > lastY) { 
+                                // Place it to the left
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x + n.getSize().x + edgeEndTexturePadding / steepEndEdgeRatio, 
+                                        n.getPosition().y + n.getSize().y * interpolation - edgeEndTexturePadding / 2);
+                            } else {
+                                // Place it to the right
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x + n.getSize().x + edgeEndTexturePadding / steepEndEdgeRatio, 
+                                        n.getPosition().y + n.getSize().y * interpolation + edgeEndTexturePadding / 2);
+                            }
+                        }
+                    }
+                    ins.get(i).getBendPoints().add(n.getPosition().x + n.getSize().x, 
+                            n.getPosition().y + n.getSize().y * interpolation);
+                } else if (d == Direction.RIGHT) {
+                    double levelStartCoord = n.getProperty(InternalProperties.LEVELMIN);
+                    // Only add level bendPoint if the distance is great enough
+                    if (n.getPosition().x - edgeEndTexturePadding > levelStartCoord) {
+                        ins.get(i).getBendPoints().add(levelStartCoord - nodeBendpointPadding, 
+                                n.getPosition().y + n.getSize().y * interpolation);
+                    // If the angle of the end piece is too steep, add another bendpoint
+                    } else if (ins.get(i).getBendPoints().size() > 0) {
+                        double lastX = ins.get(i).getBendPoints().getLast().x;
+                        double nextX = n.getPosition().x + n.getSize().x / 2;
+                        double lastY = ins.get(i).getBendPoints().getLast().y;
+                        double nextY = n.getPosition().y + n.getSize().y / 2;
+                        if (edgeEndTexturePadding > 0 && Math.abs(lastY - nextY) / (Math.abs(lastX - nextX) 
+                                / steepEndEdgeSampleHeight) > steepEndEdgeTheresholdDistance) {
+                            if (nextY > lastY) {
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x - edgeEndTexturePadding / steepEndEdgeRatio, 
+                                        n.getPosition().y + n.getSize().y * interpolation - edgeEndTexturePadding / 2);
+                            } else {
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x - edgeEndTexturePadding / steepEndEdgeRatio, 
+                                        n.getPosition().y + n.getSize().y * interpolation + edgeEndTexturePadding / 2);
+                            }
+                        }
+                    }
+                    ins.get(i).getBendPoints().add(n.getPosition().x, 
+                            n.getPosition().y + n.getSize().y * interpolation);
+                } else if (d == Direction.UP) {
+                    double levelStartCoord = n.getProperty(InternalProperties.LEVELMAX);
+                    // Only add level bendPoint if the distance is great enough
+                    if (n.getPosition().y + n.getSize().y + edgeEndTexturePadding < levelStartCoord) {
+                        ins.get(i).getBendPoints().add(n.getPosition().x + n.getSize().x * interpolation, 
+                                levelStartCoord + nodeBendpointPadding);
+                    // If the angle of the end piece is too steep, add another bendpoint
+                    } else if (ins.get(i).getBendPoints().size() > 0) {
+                        double lastX = ins.get(i).getBendPoints().getLast().x;
+                        double nextX = n.getPosition().x + n.getSize().x / 2;
+                        double lastY = ins.get(i).getBendPoints().getLast().y;
+                        double nextY = n.getPosition().y + n.getSize().y / 2;
+                        if (edgeEndTexturePadding > 0 && Math.abs(lastX - nextX) / (Math.abs(lastY - nextY) 
+                                / steepEndEdgeSampleHeight) > steepEndEdgeTheresholdDistance) {
+                            if (nextX > lastX) {
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x + n.getSize().x * interpolation - edgeEndTexturePadding / 2, 
+                                        n.getPosition().y + edgeEndTexturePadding / steepEndEdgeRatio + n.getSize().y);
+                            } else {
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x + n.getSize().x * interpolation + edgeEndTexturePadding / 2, 
+                                        n.getPosition().y + edgeEndTexturePadding / steepEndEdgeRatio + n.getSize().y);
+                            }
+                        }
+                    }
+                    ins.get(i).getBendPoints().add(n.getPosition().x + n.getSize().x * interpolation, 
+                            n.getPosition().y + n.getSize().y);
+                } else {
+                    double levelStartCoord = n.getProperty(InternalProperties.LEVELMIN);
+                    // For cycle inducing edges add the end piece
+                    if (TreeUtil.isCycleInducing(ins.get(i), tGraph)) {
+                        ins.get(i).getBendPoints().add(n.getPosition().x + n.getSize().x * interpolation, 
+                                ins.get(i).getBendPoints().getLast().y);
+                    // Only add level bendPoint if the distance is great enough
+                    } else if (n.getPosition().y - edgeEndTexturePadding > levelStartCoord) {
+                        ins.get(i).getBendPoints().add(n.getPosition().x + n.getSize().x * interpolation, 
+                                levelStartCoord - nodeBendpointPadding);
+                    // If the angle of the end piece is too steep, add another bend point
+                    } else if (ins.get(i).getBendPoints().size() > 0) {
+                        double lastX = ins.get(i).getBendPoints().getLast().x;
+                        double nextX = n.getPosition().x + n.getSize().x / 2;
+                        double lastY = ins.get(i).getBendPoints().getLast().y;
+                        double nextY = n.getPosition().y + n.getSize().y / 2;
+                        if (edgeEndTexturePadding > 0 && Math.abs(lastX - nextX) / (Math.abs(lastY - nextY) 
+                                / steepEndEdgeSampleHeight) > steepEndEdgeTheresholdDistance) {
+                            if (nextX > lastX) {
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x + n.getSize().x * interpolation - edgeEndTexturePadding / 2, 
+                                        n.getPosition().y - edgeEndTexturePadding / steepEndEdgeRatio);
+                            } else {
+                                ins.get(i).getBendPoints().add(
+                                        n.getPosition().x + n.getSize().x * interpolation + edgeEndTexturePadding / 2, 
+                                        n.getPosition().y - edgeEndTexturePadding / steepEndEdgeRatio);
+                            }
+                        }
+                    }
+                    
+                    ins.get(i).getBendPoints().add(n.getPosition().x + n.getSize().x * interpolation, 
+                            n.getPosition().y);
+                }
             }
         }
     }
 
+    /**
+     * Handles CyrusBeck Edge Routing.
+     * 
+     * @param tGraph
+     */
+    private void cyrusBeck(final TGraph tGraph) {
+        TNode root = TreeUtil.getRoot(tGraph);
+        double nodeBendpointPadding = tGraph.getProperty(MrTreeOptions.SPACING_EDGE_NODE);
+        
+        for (TEdge edge : tGraph.getEdges()) {
+            middleToMiddleEdgeRoute(edge);
+        }
+        
+        for (TEdge edge : tGraph.getEdges()) {
+            KVectorChain bends = edge.getBendPoints();
+            for (int i = 0; i < bends.size() - 1; i++) {
+                KVector start = bends.get(i);
+                KVector end = bends.get(i + 1);
+                KVector delta = start.clone().sub(end.clone());
+                
+                if (delta.x == 0 && delta.y == 0) {
+                    continue;
+                }
+                
+                for (TNode node : tGraph.getNodes()) {
+                    
+                    if (node.getLabel().equals(edge.getSource().getLabel()) 
+                            || node.getLabel().equals(edge.getTarget().getLabel())) {
+                        continue;
+                    }
+                    
+                    ArrayList<KVector> clip = new ArrayList<KVector>();
+                    double xmin = node.getPosition().x, xmax = node.getPosition().x + node.getSize().x, 
+                            ymin = node.getPosition().y, ymax = node.getPosition().y + node.getSize().y;
+                    
+                    // Cohen-Sutherland Test
+                    boolean so = start.y < ymin,
+                            su = start.y > ymax,
+                            sr = start.x > xmax,
+                            sl = start.x < xmin,
+                            eo = end.y < ymin,
+                            eu = end.y > ymax,
+                            er = end.x > xmax,
+                            el = end.x < xmin;
+                    
+                    if (edge.getSource().getLabel().equals("n8") && node.getLabel().equals("n6")) {
+                        getClass();
+                    }
+                    
+                    // None of the points are inside the node but they may still overlap according to the test
+                    if (!(so & eo) & !(su & eu) & !(sr & er) & !(sl & el)) {
+                        
+                        if (delta.x == 0) { // Special case: vert
+                            clip.add(new KVector(start.x, ymin));
+                            clip.add(new KVector(start.x, ymax));
+                        } else if (delta.y == 0) { // Special case: horz
+                            clip.add(new KVector(xmin, start.y));
+                            clip.add(new KVector(xmax, start.y));
+                        } else {
+                            ArrayList<Triple<Double, KVector, Double>> pclips = 
+                                    new ArrayList<Triple<Double, KVector, Double>>();
+                            
+                            if (so | eo) { // over
+                                double t = (ymin - start.y) / (end.y - start.y);
+                                KVector s = start.clone().add(delta.clone().scale(t));
+                                pclips.add(new Triple<Double, KVector, Double>(t, s, -delta.y));
+                            }
+                            if (su | eu) { // under
+                                double t = (ymax - start.y) / (end.y - start.y);
+                                KVector s = start.clone().add(delta.clone().scale(t));
+                                pclips.add(new Triple<Double, KVector, Double>(t, s, delta.y));
+                            }
+                            if (sl | el) { // left
+                                double t = (xmin - start.x) / (end.x - start.x);
+                                KVector s = start.clone().add(delta.clone().scale(t));
+                                pclips.add(new Triple<Double, KVector, Double>(t, s, -delta.x));
+                            }
+                            if (sr | er) { // right
+                                double t = (xmax - start.x) / (end.x - start.x);
+                                KVector s = start.clone().add(delta.clone().scale(t));
+                                pclips.add(new Triple<Double, KVector, Double>(t, s, delta.x));
+                            }
+                            
+                            pclips.sort((x, y) -> Double.compare(x.getThird(), y.getThird()));
+                            for (int j = 0; j < pclips.size(); j++) {
+                                if (pclips.get(j).getThird() > 0) {
+                                    clip.add(pclips.get(j).getSecond());
+                                    clip.add(pclips.get(j - 1).getSecond());
+                                    break;
+                                }
+                            }
+                        }
+                        
+                        clip.sort((x, y) -> Double.compare(
+                                delta.clone().dotProduct(x.clone()), 
+                                delta.clone().dotProduct(y.clone())));
+                        
+                        KVector middle = clip.get(0).clone().add(clip.get(1).clone()).scale(1 / 2);
+                        
+                        bends.addAll(0, clip);
+                        i += 2 * 2 * 2 * 2 * 2;
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/EdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/EdgeRouter.java
@@ -75,9 +75,9 @@ public class EdgeRouter implements ILayoutPhase<TreeLayoutPhases, TGraph> {
         progressMonitor.begin("Edge routing", 1);
 
         EdgeRoutingMode mode = tGraph.getProperty(MrTreeOptions.EDGE_ROUTING_MODE);
-        if (mode == EdgeRoutingMode.MiddleToMiddle) {
+        if (mode == EdgeRoutingMode.MIDDLE_TO_MIDDLE) {
             middleToMiddle(tGraph);
-        } else if (mode == EdgeRoutingMode.AvoidOverlap) {
+        } else if (mode == EdgeRoutingMode.AVOID_OVERLAP) {
             avoidOverlap(tGraph);
             
             // fallback

--- a/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/MultiLevelEdgeNodeNodeGap.java
+++ b/plugins/org.eclipse.elk.alg.mrtree/src/org/eclipse/elk/alg/mrtree/p4route/MultiLevelEdgeNodeNodeGap.java
@@ -1,0 +1,215 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0  *******************************************************************************/
+package org.eclipse.elk.alg.mrtree.p4route;
+
+import java.util.LinkedList;
+
+import org.eclipse.elk.alg.mrtree.TreeUtil;
+import org.eclipse.elk.alg.mrtree.graph.TEdge;
+import org.eclipse.elk.alg.mrtree.graph.TGraph;
+import org.eclipse.elk.alg.mrtree.graph.TNode;
+import org.eclipse.elk.alg.mrtree.options.InternalProperties;
+import org.eclipse.elk.alg.mrtree.options.MrTreeOptions;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.util.Pair;
+import org.eclipse.elk.core.util.Triple;
+
+/**
+ * This class keeps track of all the multi level edges bendPoints that come through this node node gap and updates the 
+ * registered bendPoints if new edges are added.
+ * 
+ * @author jnc
+ * @author sdo
+ */
+public class MultiLevelEdgeNodeNodeGap {
+    private TNode neighborOne, neighborTwo;
+    private LinkedList<Triple<KVector, KVector, TEdge>> bendPoints;
+    private TGraph graph;
+    private Direction d;
+    private double nodeBendpointPadding;
+    private boolean onFirstNodeSide, onLastNodeSide;
+    
+    /**
+     * @return the neighborOne
+     */
+    public TNode getNeighborOne() {
+        return neighborOne;
+    }
+
+    /**
+     * @return the neighborTwo
+     */
+    public TNode getNeighborTwo() {
+        return neighborTwo;
+    }
+
+    /**
+     * @return the onFirstNodeSide
+     */
+    public boolean isOnFirstNodeSide() {
+        return onFirstNodeSide;
+    }
+
+    /**
+     * @return the onLastNodeSide
+     */
+    public boolean isOnLastNodeSide() {
+        return onLastNodeSide;
+    }
+
+    /**
+     * Creates a new MultiLevelEdgeNodeNodeGap object.
+     * 
+     * @param neighborOne the neighbor with the lower index
+     * @param neighborTwo the neighbor with the higher index
+     * @param bendTriple the bendPoints between the two nodes
+     * @param graph the graph the nodes are in
+     */
+    public MultiLevelEdgeNodeNodeGap(final TNode neighborOne, final TNode neighborTwo,
+            final Triple<KVector, KVector, TEdge> bendTriple, final TGraph graph) {
+        this.neighborOne = neighborOne;
+        this.neighborTwo = neighborTwo;
+        this.graph = graph;
+        
+        LinkedList<Triple<KVector, KVector, TEdge>> bends = new LinkedList<Triple<KVector, KVector, TEdge>>();
+        bends.add(bendTriple);
+        this.bendPoints = bends;
+        
+        d = graph.getProperty(MrTreeOptions.DIRECTION);
+        nodeBendpointPadding = graph.getProperty(MrTreeOptions.SPACING_EDGE_NODE);
+        
+        updateBendPoints();
+    }
+    
+    /**
+     * Adds new bendPoints to the gap.
+     * 
+     * @param newBends the two new bendPoints
+     */
+    public void addBendPoints(final Triple<KVector, KVector, TEdge> newBends) {
+        bendPoints.add(newBends);
+        
+        if (d.isHorizontal()) {
+            bendPoints.sort((x, y) -> Double.compare(x.getThird().getTarget().getPosition().y, 
+                    y.getThird().getTarget().getPosition().y));
+        } else {
+            bendPoints.sort((x, y) -> Double.compare(x.getThird().getTarget().getPosition().x, 
+                    y.getThird().getTarget().getPosition().x));
+        }
+        
+        updateBendPoints();
+    }
+    
+    /**
+     * Updates the BendPoints according to the new amount of edges that come through this gap.
+     */
+    private void updateBendPoints() {
+        int i = 0, count = bendPoints.size();
+        for (Triple<KVector, KVector, TEdge> p : bendPoints) {
+            KVector bend1, bend2;
+            double bendTmp, interpolation = (i + 1) / (double) (count + 1);
+            if (neighborOne == null && neighborTwo == null) {
+                return;
+            } else if (neighborOne != null && neighborTwo == null) { // Bendpoint should be placed next to last node
+                onLastNodeSide = true;
+                if (d == Direction.LEFT) {
+                    bendTmp = neighborOne.getPosition().y + neighborOne.getSize().y + nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMAX) + nodeBendpointPadding, 
+                            bendTmp);
+                    bend2 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMIN) - nodeBendpointPadding, 
+                            bendTmp);
+                } else if (d == Direction.RIGHT) {
+                    bendTmp = neighborOne.getPosition().y + neighborOne.getSize().y + nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMIN) - nodeBendpointPadding, 
+                            bendTmp);
+                    bend2 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMAX) + nodeBendpointPadding, 
+                            bendTmp);
+                } else if (d == Direction.UP) {
+                    bendTmp = neighborOne.getPosition().x + neighborOne.getSize().x + nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding);
+                    bend2 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding);
+                } else {
+                    bendTmp = neighborOne.getPosition().x + neighborOne.getSize().x + nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding);
+                    bend2 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding);
+                }
+            } else if (neighborOne != null && neighborTwo != null) { // Bendpoint should be placed in between two nodes
+                if (d == Direction.LEFT) {
+                    bendTmp = neighborTwo.getPosition().y * interpolation + (neighborOne.getPosition().y 
+                            + neighborOne.getSize().y) * (1 - interpolation);
+                    bend1 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding, bendTmp);
+                    bend2 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding, bendTmp);
+                } else if (d == Direction.RIGHT) {
+                    bendTmp = neighborTwo.getPosition().y * interpolation + (neighborOne.getPosition().y 
+                            + neighborOne.getSize().y) * (1 - interpolation);
+                    bend1 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding, bendTmp);
+                    bend2 = new KVector(neighborOne.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding, bendTmp);
+                } else if (d == Direction.UP) {
+                    bendTmp = neighborTwo.getPosition().x * interpolation + (neighborOne.getPosition().x 
+                            + neighborOne.getSize().x) * (1 - interpolation);
+                    bend1 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding);
+                    bend2 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding);
+                } else {
+                    bendTmp = neighborTwo.getPosition().x * interpolation + (neighborOne.getPosition().x 
+                            + neighborOne.getSize().x) * (1 - interpolation);
+                    bend1 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding);
+                    bend2 = new KVector(bendTmp, neighborOne.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding);
+                }
+            } else { // Bendpoint should be placed next to the first node
+                onFirstNodeSide = true;
+                if (d == Direction.LEFT) {
+                    bendTmp = neighborTwo.getPosition().y - nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(neighborTwo.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding, bendTmp);
+                    bend2 = new KVector(neighborTwo.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding, bendTmp);
+                } else if (d == Direction.RIGHT) {
+                    bendTmp = neighborTwo.getPosition().y - nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(neighborTwo.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding, bendTmp);
+                    bend2 = new KVector(neighborTwo.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding, bendTmp);
+                } else if (d == Direction.UP) {
+                    bendTmp = neighborTwo.getPosition().x - nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(bendTmp, neighborTwo.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding);
+                    bend2 = new KVector(bendTmp, neighborTwo.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding);
+                } else {
+                    bendTmp = neighborTwo.getPosition().x - nodeBendpointPadding * (i + 1);
+                    bend1 = new KVector(bendTmp, neighborTwo.getProperty(InternalProperties.LEVELMIN) 
+                            - nodeBendpointPadding);
+                    bend2 = new KVector(bendTmp, neighborTwo.getProperty(InternalProperties.LEVELMAX) 
+                            + nodeBendpointPadding);
+                }
+            }
+            
+            // Commit new values
+            p.getFirst().x = bend1.x;
+            p.getFirst().y = bend1.y;
+            p.getSecond().x = bend2.x;
+            p.getSecond().y = bend2.y;
+            
+            i++;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #406.
Fixes #873.
It adds several edge routing strategies as well as horizontal ordering strategies.
Moreover trees can now be drawn in different directions than down.