### PR TITLE
Added org.eclipse.elk.alg.libavoid

### DIFF
--- a/build/org.eclipse.elk.repository/category.xml
+++ b/build/org.eclipse.elk.repository/category.xml
@@ -29,6 +29,12 @@
    <feature url="features/org.eclipse.elk.algorithms.source_0.9.0.qualifier.jar" id="org.eclipse.elk.algorithms.feature.source" version="0.9.0.qualifier">
       <category name="elk"/>
    </feature>
+   <feature url="features/org.eclipse.elk.libavoid_0.9.0.qualifier.jar" id="org.eclipse.elk.libavoid.feature" version="0.9.0.qualifier">
+      <category name="elk"/>
+   </feature>
+   <feature url="features/org.eclipse.elk.libavoid.source_0.9.0.qualifier.jar" id="org.eclipse.elk.libavoid.feature.source" version="0.9.0.qualifier">
+      <category name="elk"/>
+   </feature>
    <feature url="features/org.eclipse.elk.gmf_0.9.0.qualifier.jar" id="org.eclipse.elk.gmf.feature" version="0.9.0.qualifier">
       <category name="elk"/>
    </feature>

--- a/features/org.eclipse.elk.libavoid.feature/.project
+++ b/features/org.eclipse.elk.libavoid.feature/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.elk.libavoid.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.eclipse.elk.libavoid.feature/build.properties
+++ b/features/org.eclipse.elk.libavoid.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/features/org.eclipse.elk.libavoid.feature/feature.xml
+++ b/features/org.eclipse.elk.libavoid.feature/feature.xml
@@ -1,0 +1,797 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.elk.libavoid.feature"
+      label="Libavoid Integration for ELK (includes LGPL code)"
+      version="0.9.0.qualifier"
+      provider-name="Eclipse Layout Kernel"
+      plugin="org.eclipse.elk.core"
+      os="linux,macosx,win32"
+      arch="aarch64,x86_64">
+
+   <description url="http://www.eclipse.org/elk">
+      This feature integrates the libavoid library (https://www.adaptagrams.org/documentation/libavoid.html)
+with Eclipse Layout Kernel (ELK) to provide high-quality edge
+routing to the Eclipse Platform. It is offered as a regular ELK
+layout algorithm, but computes only edge bend points while leaving
+node and port positions unchanged. This means that all nodes
+and ports need to have predetermined positions.
+   </description>
+
+   <copyright>
+      Copyright (c) 2008 Kiel University and others.
+This program and the accompanying materials are made available
+under the terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0.
+SPDX-License-Identifier: EPL-2.0
+   </copyright>
+
+   <license url="https://www.eclipse.org/legal/epl-2.0/">
+      Eclipse Public License 2.0 and LGPL 2.1
+
+This feature and its contained Java code as well as the libavoid-server
+executables are made available under the Eclipse Public License
+version 2.0 (EPL-2.0).
+
+The libavoid library is subject to the GNU Lesser General Public License
+version 2.1 (LGPL) and is linked into the libavoid-server executables
+which are distributed with this feature. The source code of libavoid is
+available at https://github.com/mjwybrow/adaptagrams
+
+The following text shows first EPL-2.0 and then LGPL.
+
+------------------------------------------------------------
+
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+&quot;Contribution&quot; means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  &quot;originates&quot; from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor&apos;s behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+&quot;Contributor&quot; means any person or entity that Distributes the Program.
+
+&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+&quot;Program&quot; means the Contributions Distributed in accordance with this
+Agreement.
+
+&quot;Recipient&quot; means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+&quot;Derivative Works&quot; shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+&quot;Modified Works&quot; shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+&quot;Distribute&quot; means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+&quot;Source Code&quot; means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+&quot;Secondary License&quot; means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient&apos;s responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient&apos;s
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients&apos; rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability (&quot;notices&quot;) contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+(&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every
+other Contributor (&quot;Indemnified Contributor&quot;) against any losses,
+damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor&apos;s responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot;
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient&apos;s rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient&apos;s
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient&apos;s obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+&quot;This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}.&quot;
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.
+
+------------------------------------------------------------
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author&apos;s reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the &quot;Lesser&quot; General Public License because it
+does Less to protect the user&apos;s freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users&apos; freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+&quot;work based on the library&quot; and a &quot;work that uses the library&quot;.  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called &quot;this License&quot;).
+Each licensee is addressed as &quot;you&quot;.
+
+  A &quot;library&quot; means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The &quot;Library&quot;, below, refers to any such software library or work
+which has been distributed under these terms.  A &quot;work based on the
+Library&quot; means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term &quot;modification&quot;.)
+
+  &quot;Source code&quot; for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library&apos;s
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a &quot;work that uses the Library&quot;.  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a &quot;work that uses the Library&quot; with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a &quot;work that uses the
+library&quot;.  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a &quot;work that uses the Library&quot; uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a &quot;work that uses the Library&quot; with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer&apos;s own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable &quot;work that
+    uses the Library&quot;, as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user&apos;s computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the &quot;work that uses the
+Library&quot; must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients&apos; exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+&quot;any later version&quot;, you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY &quot;AS IS&quot; WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+   </license>
+
+   <requires>
+      <import plugin="com.google.guava"/>
+      <import plugin="org.eclipse.core.runtime"/>
+      <import feature="org.eclipse.elk.feature"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.elk.alg.libavoid"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/features/org.eclipse.elk.libavoid.feature/pom.xml
+++ b/features/org.eclipse.elk.libavoid.feature/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2022 Kiel University and others.
+  
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+  
+  SPDX-License-Identifier: EPL-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.elk</groupId>
+    <artifactId>features</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.eclipse.elk</groupId>
+  <artifactId>org.eclipse.elk.libavoid.feature</artifactId>
+  <version>0.9.0-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+</project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -29,6 +29,7 @@
     <module>org.eclipse.elk.gmf.feature</module>
     <module>org.eclipse.elk.graph.json.feature</module>
     <module>org.eclipse.elk.graphviz.feature</module>
+    <module>org.eclipse.elk.libavoid.feature</module>
     <module>org.eclipse.elk.ui.feature</module>
   </modules>
 

--- a/plugins/org.eclipse.elk.alg.libavoid/.classpath
+++ b/plugins/org.eclipse.elk.alg.libavoid/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/plugins/org.eclipse.elk.alg.libavoid/.gitignore
+++ b/plugins/org.eclipse.elk.alg.libavoid/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/libavoid-server/*
+!/libavoid-server/*-LICENSE

--- a/plugins/org.eclipse.elk.alg.libavoid/.project
+++ b/plugins/org.eclipse.elk.alg.libavoid/.project
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.elk.alg.libavoid</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.eclipse.elk.alg.libavoid/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.elk.alg.libavoid/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/plugins/org.eclipse.elk.alg.libavoid/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.libavoid/META-INF/MANIFEST.MF
@@ -1,0 +1,18 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Libavoid Integration for ELK
+Bundle-SymbolicName: org.eclipse.elk.alg.libavoid;singleton:=true
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-Vendor: Eclipse Layout Kernel
+Bundle-Activator: org.eclipse.elk.alg.libavoid.LibavoidPlugin
+Bundle-ActivationPolicy: lazy
+Require-Bundle: com.google.guava,
+ org.eclipse.core.runtime,
+ org.eclipse.elk.graph,
+ org.eclipse.elk.core,
+ org.eclipse.elk.alg.common
+Export-Package: org.eclipse.elk.alg.libavoid,
+ org.eclipse.elk.alg.libavoid.options,
+ org.eclipse.elk.alg.libavoid.server
+Automatic-Module-Name: org.eclipse.elk.alg.libavoid

--- a/plugins/org.eclipse.elk.alg.libavoid/about.html
+++ b/plugins/org.eclipse.elk.alg.libavoid/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/plugins/org.eclipse.elk.alg.libavoid/build.properties
+++ b/plugins/org.eclipse.elk.alg.libavoid/build.properties
@@ -1,0 +1,8 @@
+source.. = src/,\
+           src-gen/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               libavoid-server/,\
+               about.html
+src.includes = about.html

--- a/plugins/org.eclipse.elk.alg.libavoid/libavoid-server/libavoid-LICENSE
+++ b/plugins/org.eclipse.elk.alg.libavoid/libavoid-server/libavoid-LICENSE
@@ -1,0 +1,458 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS

--- a/plugins/org.eclipse.elk.alg.libavoid/libavoid-server/libavoid-server-LICENSE
+++ b/plugins/org.eclipse.elk.alg.libavoid/libavoid-server/libavoid-server-LICENSE
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/plugins/org.eclipse.elk.alg.libavoid/pom.xml
+++ b/plugins/org.eclipse.elk.alg.libavoid/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2022 Kiel University and others.
+  
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+  
+  SPDX-License-Identifier: EPL-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.elk</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+    <relativePath>../../build/pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.eclipse.elk</groupId>
+  <artifactId>org.eclipse.elk.alg.libavoid</artifactId>
+  <name>Libavoid Integration for ELK</name>
+  <version>0.9.0-SNAPSHOT</version>
+  <description>Edge routing algorithm based on the libavoid C++ library.</description>
+  <packaging>eclipse-plugin</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.elk</groupId>
+      <artifactId>org.eclipse.elk.core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.elk</groupId>
+      <artifactId>org.eclipse.elk.alg.common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.core.runtime</artifactId>
+      <version>3.26.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Generate code from .melk files. -->
+      <plugin>
+        <groupId>org.eclipse.xtext</groupId>
+        <artifactId>xtext-maven-plugin</artifactId>
+      </plugin>
+      <!-- Download libavoid-server binaries. -->
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <executions>
+          <execution>
+            <id>download-linux</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.1.0/libavoid-server-linux</url>
+              <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>download-macos</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.1.0/libavoid-server-macos</url>
+              <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>download-win</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.1.0/libavoid-server-win.exe</url>
+              <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugins/org.eclipse.elk.alg.libavoid/src/META-INF/services/org.eclipse.elk.core.data.ILayoutMetaDataProvider
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/META-INF/services/org.eclipse.elk.core.data.ILayoutMetaDataProvider
@@ -1,0 +1,1 @@
+org.eclipse.elk.alg.libavoid.options.LibavoidMetaDataProvider

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/Libavoid.melk
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/Libavoid.melk
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.libavoid
+
+import org.eclipse.elk.core.options.EdgeRouting
+import org.eclipse.elk.alg.libavoid.LibavoidLayoutProvider
+import org.eclipse.elk.core.options.PortConstraints
+
+bundle {
+    label "Libavoid Connector Routing"
+    metadataClass options.LibavoidMetaDataProvider
+}
+
+category edge {
+    label "Edge Routing"
+    description "Only route the edges without touching the node&apos;s positions."
+}
+
+algorithm libavoid(LibavoidLayoutProvider) {
+    label "Libavoid"
+    description
+        "libavoid is a cross-platform C++ library providing fast, object-avoiding orthogonal 
+        and polyline connector routing for use in interactive diagram editors."
+    metadataClass options.LibavoidOptions
+    category edge
+        
+       supports org.eclipse.elk.debugMode = false
+       supports org.eclipse.elk.port.side
+       supports org.eclipse.elk.direction
+       supports org.eclipse.elk.edgeRouting = EdgeRouting.ORTHOGONAL
+       supports org.eclipse.elk.portConstraints = PortConstraints.FREE
+       
+       supports org.eclipse.elk.alg.libavoid.segmentPenalty
+       supports org.eclipse.elk.alg.libavoid.anglePenalty
+       supports org.eclipse.elk.alg.libavoid.crossingPenalty
+       supports org.eclipse.elk.alg.libavoid.clusterCrossingPenalty
+       supports org.eclipse.elk.alg.libavoid.fixedSharedPathPenalty
+       supports org.eclipse.elk.alg.libavoid.portDirectionPenalty
+       supports org.eclipse.elk.alg.libavoid.shapeBufferDistance
+       supports org.eclipse.elk.alg.libavoid.idealNudgingDistance
+       supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalSegmentsConnectedToShapes
+       supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingJunctions
+       supports org.eclipse.elk.alg.libavoid.penaliseOrthogonalSharedPathsAtConnEnds
+       supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalTouchingColinearSegments
+       supports org.eclipse.elk.alg.libavoid.performUnifyingNudgingPreprocessingStep
+       supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingAddingAndDeletingJunctions
+}      
+
+// --- Layout Options
+// NOTE: Do not group this layout options unless you change the libavoid server as well.
+
+option segmentPenalty: double {
+    label "Segment Penalty"
+    description 
+        "This penalty is applied for each segment in the connector path beyond the first. 
+        This should always normally be set when doing orthogonal routing to prevent 
+        step-like connector paths."
+    default = 10
+    targets parents
+}
+      
+option anglePenalty: double {
+    label "Angle Penalty"
+    description 
+        "This penalty is applied in its full amount to tight acute bends in the connector path. 
+        A smaller portion of the penalty is applied for slight bends, i.e., where the bend is close 
+        to 180 degrees. This is useful for polyline routing where there is some evidence that tighter 
+        corners are worse for readability, but that slight bends might not be so bad, 
+        especially when smoothed by curves."
+    default = 0
+    targets parents
+}
+
+advanced option crossingPenalty: double {
+    label "Crossing Penalty"
+    description 
+        "This penalty is applied whenever a connector path crosses another connector path. 
+        It takes shared paths into consideration and the penalty is only applied 
+        if there is an actual crossing."
+    default = 0
+    targets parents
+}
+
+advanced option clusterCrossingPenalty: double {
+    label "Cluster Crossing Penalty"
+    description "This penalty is applied whenever a connector path crosses a cluster boundary."
+    default = 4000
+    targets parents
+}
+
+advanced option fixedSharedPathPenalty: double {
+    label "Fixed Shared Path Penalty"
+    description
+        "This penalty is applied whenever a connector path shares some segments with an immovable
+        portion of an existing connector route (such as the first or last segment of a connector)."
+    default = 0
+    targets parents
+}
+
+advanced option portDirectionPenalty: double {
+    label "Port Direction Penalty"
+    description
+        "This penalty is applied to port selection choice when the other end of the connector 
+        being routed does not appear in any of the 90 degree visibility cones centered on the 
+        visibility directions for the port."
+    default = 100
+    targets parents
+}
+
+option shapeBufferDistance: double {
+    label "Shape Buffer Distance"
+    description
+        "This parameter defines the spacing distance that will be added to the sides of each 
+        shape when determining obstacle sizes for routing. This controls how closely connectors 
+        pass shapes, and can be used to prevent connectors overlapping with shape boundaries.
+        By default, this distance is set to a value of 4."
+    default = 4
+    targets parents
+}
+
+option idealNudgingDistance: double {
+    label "Ideal Nudging Distance"
+    description
+        "This parameter defines the spacing distance that will be used for nudging apart 
+        overlapping corners and line segments of connectors. By default, 
+        this distance is set to a value of 4."
+    default = 4
+    targets parents
+}
+
+option nudgeOrthogonalSegmentsConnectedToShapes: boolean {
+    label "Nudge Orthogonal Segments"
+    description
+        "This option causes the final segments of connectors, which are attached to shapes, 
+        to be nudged apart. Usually these segments are fixed, since they are considered to be 
+        attached to ports. This option is not set by default."
+    default = false
+    targets parents
+}
+
+
+option improveHyperedgeRoutesMovingJunctions: boolean {
+    label "Improve Hyperedge Routes"
+    description
+        "This option causes hyperedge routes to be locally improved fixing obviously bad paths. 
+        As part of this process libavoid will effectively move junctions, setting new ideal positions 
+        ( JunctionRef::recommendedPosition() ) for each junction."
+    default = true
+    targets parents
+}
+
+advanced option penaliseOrthogonalSharedPathsAtConnEnds: boolean {
+    label "Penalise Orthogonal Shared Paths"
+    description 
+        "This option penalises and attempts to reroute orthogonal shared connector paths terminating 
+        at a common junction or shape connection pin. When multiple connector paths enter or leave 
+        the same side of a junction (or shape pin), the router will attempt to reroute these to 
+        different sides of the junction or different shape pins. This option depends on the 
+        fixedSharedPathPenalty penalty having been set."
+    default = false
+    targets parents
+}
+
+option nudgeOrthogonalTouchingColinearSegments: boolean {
+    label "Nudge Orthogonal Touching Colinear Segments"
+    description
+        "This option can be used to control whether colinear line segments that touch just at 
+        their ends will be nudged apart. The overlap will usually be resolved in the other dimension, 
+        so this is not usually required and is not set by default."
+    default = false
+    targets parents
+}
+
+advanced option performUnifyingNudgingPreprocessingStep: boolean {
+    label "Perform Unifying Nudging Preprocessing"
+    description
+        "This option can be used to control whether the router performs a preprocessing step before 
+        orthogonal nudging where is tries to unify segments and centre them in free space. 
+        This generally results in better quality ordering and nudging."
+    default = true
+    targets parents
+}
+
+advanced option improveHyperedgeRoutesMovingAddingAndDeletingJunctions: boolean {
+    label "Improve Hyperedge Routes Add Delete"
+    description 
+        "This option causes hyperedge routes to be locally improved fixing obviously bad paths."
+    default = true
+    targets parents
+}

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidLayoutProvider.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.libavoid;
+
+import org.eclipse.elk.alg.common.nodespacing.NodeDimensionCalculation;
+import org.eclipse.elk.alg.libavoid.options.LibavoidOptions;
+import org.eclipse.elk.alg.libavoid.server.LibavoidServer;
+import org.eclipse.elk.alg.libavoid.server.LibavoidServerPool;
+import org.eclipse.elk.core.AbstractLayoutProvider;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.core.util.adapters.ElkGraphAdapters;
+import org.eclipse.elk.core.util.adapters.ElkGraphAdapters.ElkGraphAdapter;
+import org.eclipse.elk.graph.ElkNode;
+
+/**
+ * A layout provider for KIML that performs layout using the Libavoid connector routing library. See
+ * http://www.adaptagrams.org/documentation/ for further information on the library.
+ * 
+ * @author uru
+ */
+public class LibavoidLayoutProvider extends AbstractLayoutProvider {
+
+    private LibavoidServerCommunicator comm = new LibavoidServerCommunicator();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void layout(final ElkNode parentNode, final IElkProgressMonitor progressMonitor) {
+
+        // TODO
+        // at this point the 'DIRECTION' should be set to a reasonable value ... 
+        // parentNode.setProperty(LibavoidOptions.DIRECTION, Direction.DOWN);
+        
+        // TODO check if we should set this to 0 by default
+        parentNode.setProperty(LibavoidOptions.IDEAL_NUDGING_DISTANCE, 0d);
+        
+        // calculate node margins
+        ElkGraphAdapter adapter = ElkGraphAdapters.adapt(parentNode);
+
+        NodeDimensionCalculation.sortPortLists(adapter);
+        
+        // TODO this behaves strangely (creates different node sizes for the layered alg)
+        // NodeDimensionCalculation.calculateLabelAndNodeSizes(adapter);
+        
+        NodeDimensionCalculation.calculateNodeMargins(adapter);
+        
+        // create an Libavoid server process instance or use an existing one
+        LibavoidServer lvServer = LibavoidServerPool.INSTANCE.fetch();
+        // send a layout request to the server process and apply the layout
+        comm.requestLayout(parentNode, progressMonitor, lvServer);
+        // if everything worked well, release the used process instance
+        LibavoidServerPool.INSTANCE.release(lvServer);
+
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidPlugin.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidPlugin.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.libavoid;
+
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.elk.alg.libavoid.server.LibavoidServerPool;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle.
+ * 
+ * @author uru
+ */
+public class LibavoidPlugin extends Plugin {
+
+    /** the plug-in ID. */
+    public static final String PLUGIN_ID = "org.adaptagrams.cola.libavoid"; //$NON-NLS-1$
+
+    /** the shared instance. */
+    private static LibavoidPlugin plugin;
+    
+    /**
+     * The constructor.
+     */
+    public LibavoidPlugin() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start(final BundleContext context) throws Exception {
+        super.start(context);
+        plugin = this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stop(final BundleContext context) throws Exception {
+        plugin = null;
+        LibavoidServerPool.INSTANCE.dispose();
+        super.stop(context);
+    }
+
+    /**
+     * Returns the shared instance.
+     *
+     * @return the shared instance
+     */
+    public static LibavoidPlugin getDefault() {
+        return plugin;
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidServerCommunicator.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidServerCommunicator.java
@@ -1,0 +1,623 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.libavoid;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.StringTokenizer;
+
+import org.eclipse.elk.alg.libavoid.options.LibavoidOptions;
+import org.eclipse.elk.alg.libavoid.server.LibavoidServer;
+import org.eclipse.elk.alg.libavoid.server.LibavoidServer.Cleanup;
+import org.eclipse.elk.alg.libavoid.server.LibavoidServerException;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.math.KVectorChain;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.options.EdgeRouting;
+import org.eclipse.elk.core.options.PortConstraints;
+import org.eclipse.elk.core.options.PortSide;
+import org.eclipse.elk.core.util.ElkUtil;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.core.util.WrappedException;
+import org.eclipse.elk.graph.ElkEdge;
+import org.eclipse.elk.graph.ElkEdgeSection;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.ElkPort;
+import org.eclipse.elk.graph.properties.IProperty;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Maps;
+
+/**
+ * Performs the actual communication with the libabvoid-server. The graph to layout is send to the
+ * server using a textual format. The server then sends back the layouted information.
+ * 
+ * Protocol: 
+ *    - All nodes are passed together with a continuously increasing id starting by 1. 
+ *      (1 2 3 4 ...) 
+ *    - The same goes for the edges.
+ *    - Port's ids start at 5, leaving the ids [1,..,4] as special cases for internal 
+ *      handling of libavoid  
+ *    - The edge routing option has to be passed first!
+ *      The information is required to initialize the libavoid router properly 
+ *      before the router can be configured with additional options.
+ * 
+ * @author uru
+ */
+public class LibavoidServerCommunicator {
+
+    private static final boolean DEBUG = false;
+
+    /** the separator used to separate chunks of data sent to the libavoid-server process. */
+    private static final String CHUNK_KEYWORD = "[CHUNK]\n";
+
+    // Maps holding the nodes and edges of the current graph.
+    private BiMap<Integer, ElkNode> nodeIdMap = HashBiMap.create();
+    private BiMap<Integer, ElkPort> portIdMap = HashBiMap.create();
+    private BiMap<Integer, ElkEdge> edgeIdMap = HashBiMap.create();
+
+    // Internal data.
+    private static final int PORT_ID_START = 5;
+    private static final int NODE_ID_START = 5;
+    // reserved for compound node's boundaries
+    private static final int NODE_COMPOUND_NORTH = 1;
+    private static final int NODE_COMPOUND_EAST = 2;
+    private static final int NODE_COMPOUND_SOUTH = 3;
+    private static final int NODE_COMPOUND_WEST = 4;
+    /** size, either width or height, of the surrounding rectangles of compound nodes. */
+    private static final int SURROUNDING_RECT_SIZE = 10;
+
+    private int nodeIdCounter = NODE_ID_START;
+    private int portIdCounter = PORT_ID_START;
+    private int edgeIdCounter = 1;
+    private static final int SUBTASK_WORK = 1;
+    private static final int LAYOUT_WORK = SUBTASK_WORK + SUBTASK_WORK + SUBTASK_WORK
+            + SUBTASK_WORK;
+
+    /** String builder holding the textual graph. */
+    private StringBuilder sb = new StringBuilder();
+
+    /** The direction of the current drawing. */
+    private Direction currentDirection = Direction.UNDEFINED;
+
+    /**
+     * Resets the communicator, i.e., clearing the maps to remember current nodes and the textual
+     * representation of the graph.
+     */
+    private void reset() {
+        nodeIdCounter = NODE_ID_START;
+        nodeIdMap.clear();
+        portIdCounter = PORT_ID_START;
+        portIdMap.clear();
+        edgeIdCounter = 1;
+        edgeIdMap.clear();
+        sb = new StringBuilder();
+    }
+
+    /**
+     * Requests a layout from the libavoid server.
+     * 
+     * @param layoutNode
+     *            the root node of the graph to layout.
+     * @param progressMonitor
+     *            the monitor
+     * @param lvServer
+     *            an instance of the libavoid server.
+     */
+    public void requestLayout(final ElkNode layoutNode, final IElkProgressMonitor progressMonitor,
+            final LibavoidServer lvServer) {
+        progressMonitor.begin("Libavoid Layout", LAYOUT_WORK);
+        // if the graph is empty there is no need to layout
+        if (layoutNode.getChildren().isEmpty()) {
+            progressMonitor.done();
+            return;
+        }
+
+        // start the libavoid server process, or retrieve the previously used process
+        lvServer.initialize();
+
+        try {
+            // retrieve the libavoid server input
+            OutputStream outputStream = lvServer.input();
+            // write the graph to the process
+            writeTextGraph(layoutNode, outputStream);
+            // flush the stream
+            outputStream.flush();
+
+            // read the layout information
+            Map<String, KVectorChain> layoutInformation =
+                    readLayoutInformation(lvServer, progressMonitor.subTask(1));
+
+            // apply the layout back to the KGraph
+            applyLayout(layoutNode, layoutInformation, progressMonitor.subTask(1));
+            // calculate junction points
+            calculateJunctionPoints(layoutNode);
+            // clean up the Libavoid server process
+            lvServer.cleanup(Cleanup.NORMAL);
+
+        } catch (IOException exception) {
+            lvServer.cleanup(Cleanup.ERROR);
+            throw new WrappedException("Failed to communicate with the Libavoid process.", exception);
+        } finally {
+            progressMonitor.done();
+            reset();
+        }
+    }
+
+    /**
+     * Applies the layout information back to the original graph.
+     * 
+     * @param parentNode
+     *            the parent node of the layout graph
+     * @param layoutInformation
+     *            the layout information
+     * @param progressMonitor
+     *            the progress monitor
+     */
+    private void applyLayout(final ElkNode parentNode,
+            final Map<String, KVectorChain> layoutInformation,
+            final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Apply layout", SUBTASK_WORK);
+
+        // Libavoid only routes edges, hence we only have to apply the new edge information
+        for (Entry<String, KVectorChain> entry : layoutInformation.entrySet()) {
+
+            // assure we have enough points
+            KVectorChain points = entry.getValue();
+            if (points.size() < 2) {
+                throw new IllegalStateException(
+                        "An edge retrieved from Libavoid has less than 2 points.");
+            }
+
+            // get the corresponding edge
+            int edgeId = Integer.valueOf(entry.getKey().split(" ")[1]);
+            ElkEdge e = edgeIdMap.get(edgeId);
+            if (e == null) {
+                throw new IllegalStateException("A problem within the edge mapping occured."
+                        + "Could not determine edge for id " + edgeId + ".");
+            }
+            
+            // clean bend points
+            ElkEdgeSection edgeSection = ElkGraphUtil.firstEdgeSection(e, true, true);
+            ElkUtil.applyVectorChain(points, edgeSection);
+        }
+
+        progressMonitor.done();
+    }
+    
+    /**
+     * Calculates and sets the junction points for each edge of the graph.
+     * 
+     * @param graph
+     *            the graph.
+     */
+    private void calculateJunctionPoints(final ElkNode graph) {
+        for (ElkNode n : graph.getChildren()) {
+            for (ElkEdge edge : ElkGraphUtil.allOutgoingEdges(n)) {
+                KVectorChain junctionPoints = ElkUtil.determineJunctionPoints(edge);
+                edge.setProperty(CoreOptions.JUNCTION_POINTS, junctionPoints);
+            }
+        }
+    }
+
+    /**
+     * Read layout information from the Libavoid server process.
+     * 
+     * @param libavoidServer
+     *            the Libavoid server process interface
+     * @param progressMonitor
+     *            the progress monitor
+     * @return a map of layout information
+     */
+    private Map<String, KVectorChain> readLayoutInformation(final LibavoidServer libavoidServer,
+            final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("Read output from Libavoid", 1);
+        Map<String, String> outputData = libavoidServer.readOutputData();
+        if (outputData == null) {
+            libavoidServer.cleanup(Cleanup.ERROR);
+            throw new LibavoidServerException("No output from the Libavoid process."
+                    + " Try increasing the timeout value in the preferences"
+                    + " (KIELER / Layout / Libavoid).");
+        }
+        Map<String, KVectorChain> layoutInformation =
+                Maps.newHashMapWithExpectedSize(outputData.size());
+        for (Map.Entry<String, String> entry : outputData.entrySet()) {
+            KVectorChain pointList = new KVectorChain();
+            StringTokenizer tokenizer = new StringTokenizer(entry.getValue(), " ");
+            // now the coordinates
+            while (tokenizer.countTokens() >= 2) {
+                double x = parseDouble(tokenizer.nextToken());
+                double y = parseDouble(tokenizer.nextToken());
+                pointList.add(new KVector(x, y));
+            }
+            layoutInformation.put(entry.getKey(), pointList);
+        }
+        progressMonitor.done();
+        return layoutInformation;
+    }
+
+    /**
+     * Transforms the passed graph to a textual format and writes it to the specified output stream.
+     */
+    private void writeTextGraph(final ElkNode root, final OutputStream stream) {
+
+        // first send the options
+        transformOptions(root);
+
+        if (root.getProperty(CoreOptions.DEBUG_MODE)) {
+            sb.append("DEBUG\n");
+        }
+        
+        // transform the graph to a text format
+        transformGraph(root);
+
+        // finish with the chunk keyword
+        sb.append(CHUNK_KEYWORD);
+
+        if (DEBUG) {
+            System.out.println(sb);
+        }
+
+        try {
+            // write it to the stream
+            stream.write(sb.toString().getBytes());
+        } catch (IOException e) {
+            throw new WrappedException("Could not write to the outputstream of the libavoid server.", e);
+        }
+    }
+
+    private void transformOptions(final ElkNode node) {
+
+        /*
+         * General Properties
+         */
+        // IMPORTANT: the edge routing option has to be passed first!
+        // The information is required to initialize the libavoid router properly
+        // before the router can be configured with additional options
+        EdgeRouting edgeRouting = node.getProperty(LibavoidOptions.EDGE_ROUTING);
+        addOption(LibavoidOptions.EDGE_ROUTING, edgeRouting);
+
+        Direction direction = node.getProperty(LibavoidOptions.DIRECTION);
+        currentDirection = direction;
+        addOption(LibavoidOptions.DIRECTION, direction);
+
+        /*
+         * Penalties
+         */
+        double segmentPenalty = node.getProperty(LibavoidOptions.SEGMENT_PENALTY);
+        addPenalty(LibavoidOptions.SEGMENT_PENALTY, segmentPenalty);
+
+        double anglePenalty = node.getProperty(LibavoidOptions.ANGLE_PENALTY);
+        addPenalty(LibavoidOptions.ANGLE_PENALTY, anglePenalty);
+
+        double crossingPenalty = node.getProperty(LibavoidOptions.CROSSING_PENALTY);
+        addPenalty(LibavoidOptions.CROSSING_PENALTY, crossingPenalty);
+
+        double clusterCrossingPenalty =
+                node.getProperty(LibavoidOptions.CLUSTER_CROSSING_PENALTY);
+        addPenalty(LibavoidOptions.CLUSTER_CROSSING_PENALTY, clusterCrossingPenalty);
+
+        double fixedSharedPathPenalty =
+                node.getProperty(LibavoidOptions.FIXED_SHARED_PATH_PENALTY);
+        addPenalty(LibavoidOptions.FIXED_SHARED_PATH_PENALTY, fixedSharedPathPenalty);
+
+        double portDirectionPenalty =
+                node.getProperty(LibavoidOptions.PORT_DIRECTION_PENALTY);
+        addPenalty(LibavoidOptions.PORT_DIRECTION_PENALTY, portDirectionPenalty);
+
+        double shapeBufferDistance =
+                node.getProperty(LibavoidOptions.SHAPE_BUFFER_DISTANCE);
+        addPenalty(LibavoidOptions.SHAPE_BUFFER_DISTANCE, shapeBufferDistance);
+
+        double idealNudgingDistance =
+                node.getProperty(LibavoidOptions.IDEAL_NUDGING_DISTANCE);
+        addPenalty(LibavoidOptions.IDEAL_NUDGING_DISTANCE, idealNudgingDistance);
+
+        /*
+         * Routing options
+         */
+        boolean nudgeOrthogonalSegmentsConnectedToShapes =
+                node.getProperty(LibavoidOptions.NUDGE_ORTHOGONAL_SEGMENTS_CONNECTED_TO_SHAPES);
+        addRoutingOption(LibavoidOptions.NUDGE_ORTHOGONAL_SEGMENTS_CONNECTED_TO_SHAPES,
+                nudgeOrthogonalSegmentsConnectedToShapes);
+
+        boolean improveHyperedgeRoutesMovingJunctions =
+                node.getProperty(LibavoidOptions.IMPROVE_HYPEREDGE_ROUTES_MOVING_JUNCTIONS);
+        addRoutingOption(LibavoidOptions.IMPROVE_HYPEREDGE_ROUTES_MOVING_JUNCTIONS,
+                improveHyperedgeRoutesMovingJunctions);
+
+        boolean penaliseOrthogonalSharedPathsAtConnEnds =
+                node.getProperty(LibavoidOptions.PENALISE_ORTHOGONAL_SHARED_PATHS_AT_CONN_ENDS);
+        addRoutingOption(LibavoidOptions.PENALISE_ORTHOGONAL_SHARED_PATHS_AT_CONN_ENDS,
+                penaliseOrthogonalSharedPathsAtConnEnds);
+
+        boolean nudgeOrthogonalTouchingColinearSegments =
+                node.getProperty(LibavoidOptions.NUDGE_ORTHOGONAL_TOUCHING_COLINEAR_SEGMENTS);
+        addRoutingOption(LibavoidOptions.NUDGE_ORTHOGONAL_TOUCHING_COLINEAR_SEGMENTS,
+                nudgeOrthogonalTouchingColinearSegments);
+
+        boolean performUnifyingNudgingPreprocessingStep =
+                node.getProperty(LibavoidOptions.PERFORM_UNIFYING_NUDGING_PREPROCESSING_STEP);
+        addRoutingOption(LibavoidOptions.PERFORM_UNIFYING_NUDGING_PREPROCESSING_STEP,
+                performUnifyingNudgingPreprocessingStep);
+
+        boolean improveHyperedgeRoutesMovingAddingAndDeletingJunctions = node.getProperty(
+                LibavoidOptions.IMPROVE_HYPEREDGE_ROUTES_MOVING_ADDING_AND_DELETING_JUNCTIONS);
+        addRoutingOption(
+                LibavoidOptions.IMPROVE_HYPEREDGE_ROUTES_MOVING_ADDING_AND_DELETING_JUNCTIONS,
+                improveHyperedgeRoutesMovingAddingAndDeletingJunctions);
+
+    }
+
+    private void addOption(final IProperty<?> key, final Object value) {
+        sb.append("OPTION " + getOptionId(key) + " " + value.toString());
+        sb.append("\n");
+    }
+
+    private void addRoutingOption(final IProperty<?> key, final Object value) {
+        sb.append("ROUTINGOPTION " + getOptionId(key) + " " + value.toString());
+        sb.append("\n");
+    }
+
+    private void addPenalty(final IProperty<?> key, final Object value) {
+        sb.append("PENALTY " + getOptionId(key) + " " + value.toString());
+        sb.append("\n");
+    }
+    
+    private String getOptionId(final IProperty<?> key) {
+    	String optionId = key.getId();
+    	if (optionId.startsWith("org.eclipse.elk.alg.libavoid")) {
+    		optionId = "de.cau.cs.kieler.kiml.libavoid" + optionId.substring("org.eclipse.elk.alg.libavoid".length());
+    	}
+    	return optionId;
+    }
+
+    /**
+     * Transform the actual graph.
+     * 
+     * @param root
+     *            of the current graph.
+     */
+    private void transformGraph(final ElkNode root) {
+
+        sb.append("GRAPH");
+        sb.append("\n");
+
+        // add boundaries if this node is a compound node
+        if (root.getParent() != null) {
+            transformHierarchicalParent(root);
+        } else {
+            // create 4 dummy nodes, as the libavoid process expects gap-less node
+            // ids starting from 1.
+            transformHierarchicalParentDummy(root);
+        }
+
+        // nodes
+        for (ElkNode node : root.getChildren()) {
+            transformNode(node);
+        }
+
+        // edges
+        for (ElkNode node : root.getChildren()) {
+            // all edges between nodes within the root node
+            for (ElkEdge edge : ElkGraphUtil.allOutgoingEdges(node)) {
+                if (!edge.isHierarchical()) {
+                    transformEdge(edge);
+                }
+            }
+        }
+        
+        // AND, in case of an compound node,
+        // all edges between hierarchical ports and nodes within the root node
+        for (ElkPort p : root.getPorts()) {
+            for (ElkEdge e : ElkGraphUtil.allIncidentEdges(p)) {
+                ElkNode src = ElkGraphUtil.connectableShapeToNode(e.getSources().get(0));
+                ElkNode tgt = ElkGraphUtil.connectableShapeToNode(e.getTargets().get(0));
+                if ((src.getParent().equals(root) || tgt.getParent().equals(root))) {
+                    transformEdge(e);
+                }
+            }
+        }
+
+        sb.append("GRAPHEND");
+        sb.append("\n");
+    }
+
+    /**
+     * Create 4 nodes that "surround", hence restrict, the child area. This way it is guaranteed
+     * that no edge is routed outsite its compound node.
+     */
+    private void transformHierarchicalParent(final ElkNode parent) {
+
+        // offset each side by the parent buffer distance to let edges route properly
+        double bufferDistance = parent.getProperty(LibavoidOptions.SHAPE_BUFFER_DISTANCE);
+        // top
+        libavoidNode(parent, NODE_COMPOUND_NORTH, 0, 0 - SURROUNDING_RECT_SIZE - bufferDistance,
+                parent.getWidth(), SURROUNDING_RECT_SIZE, 0, 0);
+        // right
+        libavoidNode(parent, NODE_COMPOUND_EAST, 0 + parent.getWidth() + bufferDistance, 0,
+                SURROUNDING_RECT_SIZE, parent.getHeight(), 0, 0);
+        // bottom
+        libavoidNode(parent, NODE_COMPOUND_SOUTH, 0, 0 + parent.getHeight() + bufferDistance,
+                parent.getWidth(), SURROUNDING_RECT_SIZE, 0, 0);
+        // left
+        libavoidNode(parent, NODE_COMPOUND_WEST, 0 - bufferDistance - SURROUNDING_RECT_SIZE, 0,
+                SURROUNDING_RECT_SIZE, parent.getHeight(), 0, 0);
+
+        // convert the ports of the compound node itself
+        for (ElkPort port : parent.getPorts()) {
+            int nodeId = determineHierarchicalNodeId(port);
+            libavoidPort(port, portIdCounter, nodeId, parent);
+            portIdCounter++;
+        }
+    }
+
+    private void transformHierarchicalParentDummy(final ElkNode root) {
+        // 4 dummies
+        libavoidNode(root, NODE_COMPOUND_NORTH, 0, 0, 0, 0, 0, 0);
+        libavoidNode(root, NODE_COMPOUND_EAST, 0, 0, 0, 0, 0, 0);
+        libavoidNode(root, NODE_COMPOUND_SOUTH, 0, 0, 0, 0, 0, 0);
+        libavoidNode(root, NODE_COMPOUND_WEST, 0, 0, 0, 0, 0, 0);
+    }
+
+    // SUPPRESS CHECKSTYLE NEXT 1 ParameterNumber 
+    private void libavoidNode(final ElkNode node, final int id, 
+            final double xPos, final double yPos,
+            final double width, final double height, 
+            final int portLessIncomingEdges, final int portLessOutgoingEdges) {
+
+        // put to map
+        if (id >= NODE_ID_START) {
+            nodeIdMap.put(id, node);
+        }
+
+        // format:
+        // id topleft bottomright portLessIncomingEdges portLessOutgoingEdges
+        sb.append("NODE " + id + " " + xPos + " " + yPos + " " + (xPos + width) + " "
+                + (yPos + height) + " " + portLessIncomingEdges + " " + portLessOutgoingEdges);
+        sb.append("\n");
+    }
+
+    private void libavoidPort(final ElkPort port, final int portId, final int nodeId,
+            final ElkNode compoundNode) {
+
+        // put to map
+        portIdMap.put(portId, port);
+
+        // gather information
+        PortSide side = ElkUtil.calcPortSide(port, currentDirection);
+
+        // get center point of port
+        double centerX = port.getX() + port.getWidth() / 2;
+        double centerY = port.getY() + port.getHeight() / 2;
+        
+        // for compound nodes we have to mirror the port sides
+        if (compoundNode != null) {
+            side = side.opposed();
+        }
+
+        // format: portId nodeId portSide centerX centerYs
+        sb.append("PORT " + portId + " " + nodeId + " " + side.toString() + " " + centerX + " "
+                + centerY);
+        sb.append("\n");
+
+    }
+
+    private void transformNode(final ElkNode node) {
+        // get information about port-less incoming and outgoing edges
+        int portLessIncomingEdges = node.getIncomingEdges().size();
+        int portLessOutgoingEdges = node.getOutgoingEdges().size();
+
+        // convert the bounds
+        libavoidNode(node, nodeIdCounter, 
+                node.getX(), node.getY(), node.getWidth(), node.getHeight(), 
+                portLessIncomingEdges, portLessOutgoingEdges);
+
+        // transfer port constraints
+        PortConstraints pc = node.getProperty(LibavoidOptions.PORT_CONSTRAINTS);
+        sb.append("NODEOPTION " + nodeIdCounter + " " + pc);
+        sb.append("\n");
+
+        // transfer all ports
+        for (ElkPort port : node.getPorts()) {
+            libavoidPort(port, portIdCounter, nodeIdCounter, null);
+            portIdCounter++;
+        }
+
+        nodeIdCounter++;
+    }
+
+    private void transformEdge(final ElkEdge edge) {
+        // assign an id
+        edgeIdMap.put(edgeIdCounter, edge);
+
+        ElkNode srcNode = ElkGraphUtil.connectableShapeToNode(edge.getSources().get(0));
+        ElkNode tgtNode = ElkGraphUtil.connectableShapeToNode(edge.getTargets().get(0));
+        ElkPort srcPort = ElkGraphUtil.connectableShapeToPort(edge.getSources().get(0));
+        ElkPort tgtPort = ElkGraphUtil.connectableShapeToPort(edge.getTargets().get(0));
+        
+        // convert the edge
+        Integer srcId = nodeIdMap.inverse().get(srcNode);
+        Integer tgtId = nodeIdMap.inverse().get(tgtNode);
+
+        Integer srcPortId = portIdMap.inverse().get(srcPort);
+        Integer tgtPortId = portIdMap.inverse().get(tgtPort);
+
+        // hierarchical port's libavoid nodes are not stored in the mapping
+        if (srcPortId != null && srcId == null) {
+            srcId = determineHierarchicalNodeId(srcPort);
+        }
+        if (tgtPortId != null && tgtId == null) {
+            tgtId = determineHierarchicalNodeId(tgtPort);
+        }
+
+        // determine the type of the edge, ie, if it involves ports
+        String edgeType = "EDGE";
+        if (srcPortId != null && tgtPortId != null) {
+            edgeType = "PEDGEP";
+        } else if (srcPortId != null) {
+            edgeType = "PEDGE";
+        } else if (tgtPortId != null) {
+            edgeType = "EDGEP";
+        }
+
+        // format: edgeId srcId tgtId srcPort tgtPort
+        sb.append(edgeType + " " + edgeIdCounter + " " + srcId + " " + tgtId + " " + srcPortId + " "
+                + tgtPortId);
+        sb.append("\n");
+
+        edgeIdCounter++;
+    }
+
+    /*
+     * Convenient methods.
+     */
+
+    /**
+     * Parse a double value ignoring illegal string values.
+     * 
+     * @param string
+     *            a string value
+     * @return the corresponding double, or NaN if the string is illegal
+     */
+    private static double parseDouble(final String string) {
+        try {
+            return Double.parseDouble(string);
+        } catch (NumberFormatException exception) {
+            // the vector chain could not be parsed - return NaN
+            return Double.NaN;
+        }
+    }
+
+    private int determineHierarchicalNodeId(final ElkPort port) {
+        PortSide ps = ElkUtil.calcPortSide(port, currentDirection);
+        int nodeId = 0;
+        switch (ps) {
+        case NORTH:
+            nodeId = NODE_COMPOUND_NORTH;
+            break;
+        case EAST:
+            nodeId = NODE_COMPOUND_EAST;
+            break;
+        case SOUTH:
+            nodeId = NODE_COMPOUND_SOUTH;
+            break;
+        default: // WEST
+            nodeId = NODE_COMPOUND_WEST;
+            break;
+        }
+        return nodeId;
+    }
+}

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
@@ -1,0 +1,506 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.libavoid.server;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.elk.alg.libavoid.LibavoidPlugin;
+import org.osgi.framework.Bundle;
+
+/**
+ * Wraps the execution of the libavoid-server binary. Also employs an watchdog in case of errors.
+ * 
+ * @author uru
+ * @author msp
+ */
+public class LibavoidServer {
+
+    /**
+     * Available cleanup modes.
+     */
+    public static enum Cleanup {
+        /** normal cleanup. */
+        NORMAL,
+        /** read error output and stop the Libavoid process and the watcher thread. */
+        ERROR,
+        /** stop the Libavoid process and the watcher thread. */
+        STOP;
+    }
+
+    /**
+     * A helper enumeration for identifying the operating system.
+     */
+    private enum OS {
+        LINUX32, LINUX64, WIN32, WIN64, OSX32, OSX64, SOLARIS, UNKNOWN
+    }
+
+    /**
+     * Detect the operating system from system properties.
+     * 
+     * @return the operating system
+     */
+    private static OS detectOS() {
+        String os = System.getProperty("os.name").toLowerCase();
+        String arch = System.getProperty("os.arch").toLowerCase();
+        if (os.contains("linux")) {
+            if (arch.contains("64")) {
+                return OS.LINUX64;
+            } else if (arch.contains("86")) {
+                return OS.LINUX32;
+            }
+        } else if (os.contains("win")) {
+            if (arch.contains("64")) {
+                return OS.WIN64;
+            } else if (arch.contains("86")) {
+                return OS.WIN32;
+            }
+        } else if (os.contains("mac")) {
+            if (arch.contains("64")) {
+                return OS.OSX64;
+            } else if (arch.contains("86")) {
+                return OS.OSX32;
+            }
+        } else if (os.contains("solaris")) {
+            return OS.SOLARIS;
+        }
+        return OS.UNKNOWN;
+    }
+
+    /**
+     * Constructor only has package visibility. Use {@link LibavoidServerPool} to create instances.
+     */
+    LibavoidServer() {
+    }
+
+    /** The ogdf server executable. */
+    private String executable;
+    /** The ogdf server process. */
+    private Process process;
+    /** The watcher thread used to cancel a blocked read operation. */
+    private Watchdog watchdog;
+    /** The input stream given by the Libavoid process. */
+    private InputStream libavoidStream;
+    /** A temporary file that should be removed after closing the process. */
+    private File tempFile;
+    /** Timeout waiting for the Libavoid process */
+    private int processTimeout = PROCESS_DEF_TIMEOUT;
+
+    /** the relative path for the linux64 executable. */
+    public static final String EXECUTABLE_PATH_LINUX64 = "/libavoid-server/libavoid-server-linux";
+    /** the relative path for the win64 executable. */
+    public static final String EXECUTABLE_PATH_WIN64 = "/libavoid-server/libavoid-server-win.exe";
+    /** the relative path for the osx64 executable. */
+    public static final String EXECUTABLE_PATH_OSX64 = "/libavoid-server/libavoid-server-macos";
+
+    /** the size for file transfer buffers. */
+    public static final int BUFFER_SIZE = 512;
+
+    /**
+     * Resolve the Libavoid server executable.
+     * 
+     * @param an
+     *            executable file
+     * @throws IOException
+     *             when the executable could not be located
+     */
+    @SuppressWarnings("incomplete-switch")
+    private File resolveExecutable() throws IOException {
+        String path = null;
+        OS os = detectOS();
+        switch (os) {
+        case LINUX64:
+            path = EXECUTABLE_PATH_LINUX64;
+            break;
+        case WIN64:
+            path = EXECUTABLE_PATH_WIN64;
+            break;
+        case OSX64:
+            path = EXECUTABLE_PATH_OSX64;
+            break;
+        default:
+            throw new LibavoidServerException("Unsupported operating system.");
+        }
+        URL url = null;
+        if (LibavoidPlugin.getDefault() != null) {
+	        Bundle bundle = LibavoidPlugin.getDefault().getBundle();
+	        url = FileLocator.find(bundle, new Path(path), null);
+        }
+        if (url == null) {
+        	url = getClass().getResource(path);
+        }
+        if (url == null) {
+            throw new LibavoidServerException("Libavoid binary could not be located.");
+        }
+        File execFile = new File(FileLocator.resolve(url).getFile());
+
+        // if the plug-in is in a jar archive, create a temporary file to execute
+        if (!execFile.exists()) {
+            execFile = File.createTempFile("libavoid-server", ".exe");
+            OutputStream dest = new FileOutputStream(execFile);
+            InputStream source = url.openStream();
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int count;
+            do {
+                count = source.read(buffer);
+                if (count > 0) {
+                    dest.write(buffer, 0, count);
+                }
+            } while (count > 0);
+            dest.close();
+            tempFile = execFile;
+        }
+
+        // set the file permissions if necessary
+
+        switch (os) {
+        case LINUX32:
+        case LINUX64:
+        case OSX32:
+        case OSX64:
+        case SOLARIS:
+            if (!execFile.canExecute()) {
+                boolean success = execFile.setExecutable(true);
+                if (!success) {
+                    throw new LibavoidServerException("Failed to set executable permission for "
+                            + execFile.getPath());
+                }
+            }
+            break;
+        }
+        return execFile;
+    }
+
+    /**
+     * Initialize the Libavoid server instance by starting the Libavoid process and the watcher
+     * thread as necessary.
+     */
+    public synchronized void initialize() {
+        if (watchdog == null) {
+            // start the watcher thread for timeout checking
+            watchdog = new Watchdog();
+            watchdog.setName("Libavoid Watchdog");
+            watchdog.start();
+        }
+
+        if (process == null) {
+            try {
+                if (executable == null) {
+                    executable = resolveExecutable().getPath();
+                }
+                process = Runtime.getRuntime().exec(new String[] { executable });
+            } catch (IOException exception) {
+                throw new LibavoidServerException("Failed to start libavoid server process.", exception);
+            } finally {
+                if (process == null) {
+                    cleanup(Cleanup.STOP);
+                }
+            }
+        }
+    }
+
+    /**
+     * Return the stream that is used to give input to Libavoid.
+     * 
+     * @return an output stream for writing to the tool
+     */
+    public OutputStream input() {
+        if (process != null) {
+            return new BufferedOutputStream(process.getOutputStream());
+        }
+        throw new IllegalStateException("Libavoid server has not been initialized.");
+    }
+
+    /**
+     * Return the stream for reading the output of the Libavoid process.
+     * 
+     * @return an input stream for reading from the tool
+     */
+    private InputStream output() {
+        if (process != null) {
+            synchronized (nextJob) {
+                // create an input stream and make it visible to the watcher thread
+                libavoidStream = process.getInputStream();
+                // wake the watcher, which will then sleep until a timeout occurs
+                nextJob.notify();
+            }
+            return libavoidStream;
+        }
+        throw new IllegalStateException("Libavoid server has not been initialized.");
+    }
+
+    /**
+     * An enumeration for keeping track of the current parser state.
+     */
+    private enum ParseState {
+        TYPE, DATA, ERROR
+    }
+
+    /**
+     * Read output data from the Libavoid server process.
+     * 
+     * @return key-value map of output data, or {@code null} if the process output was not complete
+     */
+    public Map<String, String> readOutputData() {
+        Map<String, String> data = new HashMap<String, String>();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(output()));
+        ParseState state = ParseState.TYPE;
+        boolean parseMore = true;
+        StringBuilder error = null;
+
+        while (parseMore) {
+            String line = null;
+            try {
+                line = reader.readLine();
+                // System.out.println(line);
+            } catch (IOException exception) {
+                // most probably the stream was closed due to a timeout of the watchdog thread
+            }
+            if (line == null) {
+                // the stream is empty although more input is expected
+                return null;
+            }
+            
+            // capture debug output
+            if (line.startsWith("DEBUG")){
+                System.out.println(line);
+                continue;
+            } 
+
+            switch (state) {
+            case TYPE:
+                if (line.equals("LAYOUT")) {
+                    state = ParseState.DATA;
+                } else if (line.equals("ERROR")) {
+                    state = ParseState.ERROR;
+                    error = new StringBuilder();
+                }
+                break;
+
+            case DATA:
+                if (line.equals("DONE")) {
+                    parseMore = false;
+                } else {
+                    String[] tokens = line.split("=");
+                    if (tokens.length == 2 && tokens[0].length() > 0) {
+                        data.put(tokens[0], tokens[1]);
+                    }
+                }
+                break;
+
+            case ERROR:
+                if (line.equals("DONE")) {
+                    cleanup(Cleanup.STOP);
+                    throw new LibavoidServerException(error.toString());
+                } else {
+                    if (error.length() > 0) {
+                        error.append('\n');
+                    }
+                    error.append(line);
+                }
+                break;
+            }
+
+        }
+        return data;
+    }
+
+    /** maximal number of characters to read from error stream. */
+    private static final int MAX_ERROR_OUTPUT = 512;
+    /** time to wait before checking process errors. */
+    private static final int PROC_ERROR_TIME = 500;
+
+    /**
+     * Clean up, optionally preparing the tool for the next use.
+     * 
+     * @param c
+     *            the cleanup option
+     */
+    public synchronized void cleanup(final Cleanup c) {
+        StringBuilder error = null;
+        if (process != null) {
+            InputStream errorStream = process.getErrorStream();
+            try {
+                if (c == Cleanup.ERROR) {
+                    // wait a bit so the process can either terminate or generate error
+                    Thread.sleep(PROC_ERROR_TIME);
+                    // read the error stream to display a meaningful error message
+                    error = new StringBuilder();
+                    int ch;
+                    do {
+                        ch = errorStream.read();
+                        if (ch >= 0) {
+                            error.append((char) ch);
+                        }
+                    } while (error.length() < MAX_ERROR_OUTPUT && ch >= 0);
+                    if (error.length() == 0) {
+                        // no error message -- check for exit value
+                        int exitValue = process.exitValue();
+                        if (exitValue != 0) {
+                            exitValueError(exitValue, error);
+                        }
+                    }
+                }
+                // if error stream is not empty, the process may not terminate
+                while (errorStream.available() > 0) {
+                    errorStream.read();
+                }
+            } catch (Exception ex) {
+                // ignore exception
+            }
+
+            // terminate the Libavoid process if requested
+            if (c == Cleanup.ERROR || c == Cleanup.STOP) {
+                try {
+                    process.getOutputStream().close();
+                    process.getInputStream().close();
+                } catch (IOException exception) {
+                    // ignore exception
+                }
+                process.destroy();
+                process = null;
+
+                if (tempFile != null) {
+                    tempFile.delete();
+                    tempFile = null;
+                }
+            }
+        }
+
+        synchronized (nextJob) {
+            // reset the stream to indicate that the job is done
+            libavoidStream = null;
+            if (watchdog != null) {
+                Watchdog myWatchdog = watchdog;
+                // if requested, reset the watcher to indicate that it should terminate
+                if (c == Cleanup.ERROR || c == Cleanup.STOP) {
+                    watchdog = null;
+                }
+                // wake the watcher if it is still waiting for timeout
+                myWatchdog.interrupt();
+            }
+        }
+
+        if (error != null && error.length() > 0) {
+            // an error output could be read from Libavoid, so display that to the user
+            error.insert(0, "Libavoid error: ");
+            throw new LibavoidServerException("Libavoid error: " + error.toString());
+        }
+    }
+    
+    /**
+     * Generate an error message for the given exit value.
+     * 
+     * @param exitValue an exit value
+     * @param error a string builder for error messages
+     */
+    private void exitValueError(final int exitValue, final StringBuilder error) {
+        error.append("Process terminated with exit value ").append(exitValue);
+        if (exitValue > 128) {
+            switch (exitValue - 128) {
+            case 2: // SIGINT
+                error.append(" (interrupted)");
+                break;
+            case 3: // SIGQUIT
+                error.append(" (quit)");
+                break;
+            case 4: // SIGILL
+                error.append(" (illegal instruction)");
+                break;
+            case 6: // SIGABRT
+                error.append(" (aborted)");
+                break;
+            case 8: // SIGFPE
+                error.append(" (floating point error)");
+                break;
+            case 9: // SIGKILL
+                error.append(" (killed)");
+                break;
+            case 11: // SIGSEGV
+                error.append(" (segmentation fault)");
+                break;
+            case 13: // SIGPIPE
+                error.append(" (broken pipe)");
+                break;
+            case 15: // SIGTERM
+                error.append(" (terminated)");
+                break;
+            }
+        }
+        error.append('.');
+    }
+
+    /** default timeout for waiting for the server to give some output. */
+    public static final int PROCESS_DEF_TIMEOUT = 10000;
+
+    /** synchronization object between the main thread and the watcher thread. */
+    private Object nextJob = new Object();
+
+    /**
+     * A watcher thread that takes action when a timeout occurs.
+     */
+    private class Watchdog extends Thread {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void run() {
+            do {
+                synchronized (nextJob) {
+                    // the watcher starts working as soon as a stream is made visible
+                    while (libavoidStream == null) {
+                        try {
+                            // wait for notification by the main thread
+                            nextJob.wait();
+                        } catch (InterruptedException ex) {
+                            // the watchdog thread is interrupted: shutdown is requested
+                            if (watchdog != this) {
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                boolean interrupted = false;
+                try {
+                    Thread.sleep(processTimeout);
+                } catch (InterruptedException ex) {
+                    // this means the main thread has done a cleanup before the timeout occurred
+                    interrupted = true;
+                }
+
+                if (!interrupted) {
+                    synchronized (nextJob) {
+                        // timeout has occurred! kill the process so the main thread will wake
+                        Process myProcess = process;
+                        if (myProcess != null) {
+                            libavoidStream = null;
+                            myProcess.destroy();
+                        }
+                    }
+                }
+
+            } while (watchdog == this);
+        }
+
+    }
+}

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServerException.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServerException.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.libavoid.server;
+
+/**
+ * An exception that is thrown when execution of the Libavoid server process fails.
+ *
+ * @author uru
+ */
+public class LibavoidServerException extends RuntimeException {
+
+    /** the serial version UID. */
+    private static final long serialVersionUID = 8631325948240011630L;
+    
+    /**
+     * Constructs a new server exception.
+     */
+    public LibavoidServerException() {
+        super();
+    }
+    
+    /**
+     * Constructs a new server exception with a detail message.
+     * 
+     * @param message a detail message
+     */
+    public LibavoidServerException(final String message) {
+        super(message);
+    }
+    
+    /**
+     * Constructs a new server exception with a detail message and a cause.
+     * 
+     * @param message a detail message
+     * @param cause the cause for this exception
+     */
+    public LibavoidServerException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServerPool.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServerPool.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.libavoid.server;
+
+import java.util.LinkedList;
+
+import org.eclipse.elk.alg.libavoid.server.LibavoidServer.Cleanup;
+
+
+/**
+ * A pool for Libavoid server process instances.
+ *
+ * @author msp
+ */
+public final class LibavoidServerPool {
+    
+    /** the singleton instance of the server pool. */
+    public static final LibavoidServerPool INSTANCE = new LibavoidServerPool();
+    
+    /**
+     * Hide constructor to avoid instantiation from outside.
+     */
+    private LibavoidServerPool() {
+    }
+    
+    /** the list of currently available servers. */
+    private LinkedList<LibavoidServer> servers = new LinkedList<LibavoidServer>();
+    
+    /**
+     * Fetch an Libavoid server process from the pool, creating one if necessary.
+     * 
+     * @return an Libavoid server process
+     */
+    public LibavoidServer fetch() {
+        synchronized (servers) {
+            if (servers.isEmpty()) {
+                return new LibavoidServer();
+            }
+            return servers.removeFirst();
+        }
+    }
+    
+    /**
+     * Release a previously created server process into the pool. Only instances that
+     * are still usable may be released. Process instances that lead to errors must be closed
+     * without releasing them.
+     * 
+     * @param server an Libavoid server process
+     */
+    public void release(final LibavoidServer server) {
+        synchronized (servers) {
+            servers.add(server);
+        }
+    }
+    
+    /**
+     * Dispose all created server instances.
+     */
+    public void dispose() {
+        synchronized (servers) {
+            for (LibavoidServer server : servers) {
+                server.cleanup(Cleanup.STOP);
+            }
+            servers.clear();
+        }
+    }
+
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -32,6 +32,7 @@
     <module>org.eclipse.elk.alg.graphviz.dot</module>
     <module>org.eclipse.elk.alg.graphviz.layouter</module>
     <module>org.eclipse.elk.alg.layered</module>
+    <module>org.eclipse.elk.alg.libavoid</module>
     <module>org.eclipse.elk.alg.mrtree</module>
     <module>org.eclipse.elk.alg.rectpacking</module>
     <module>org.eclipse.elk.alg.spore</module>


### PR DESCRIPTION
This PR adds a new plug-in `org.eclipse.elk.alg.libavoid` that integrates the [libavoid](https://www.adaptagrams.org/documentation/libavoid.html) library with ELK. The plug-in is provided to the update site in a separate feature because libavoid is LGPL licensed, so not all users might want to include it.

The license check for this new dependency is approved:
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=24155

The Java code is taken from https://github.com/TypeFox/elk-libavoid, which in turn has been copied from the [KIELER](https://rtsys.informatik.uni-kiel.de/confluence/display/KIELER/Home) project by the rtsys group at Kiel University.

The Maven build downloads three binaries from https://github.com/TypeFox/libavoid-server/releases/tag/v0.1.0 which contain the actual routing algorithm. This needs to be done for testing the algorithm in the development workspace as well. I'm not sure what would be the best solution for that... could it be added to the Oomph setup?