### PR TITLE
Added bendpoints to force layout.

### DIFF
--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FEdge.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FEdge.java
@@ -149,8 +149,8 @@ public final class FEdge extends MapPropertyHolder {
             KVector incr = targetPos.clone().sub(sourcePos).scale(1 / (double) (count + 1));
             KVector pos = sourcePos.clone();
             for (FBendpoint bendPoint : bendpoints) {
-                bendPoint.getPosition().x = pos.x;
-                bendPoint.getPosition().y = pos.y;
+                bendPoint.getPosition().x = pos.x + incr.x;
+                bendPoint.getPosition().y = pos.y + incr.y;
                 pos.add(incr);
             }
         }

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FNode.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FNode.java
@@ -29,9 +29,6 @@ public final class FNode extends FParticle {
     /** the identifier number. */
     public int id;
     // CHECKSTYLEON VisibilityModifier
-    
-    /** particle position displacement for each iteration. */
-    private KVector displacement = new KVector();
     /** the node label. */
     private String label;
     /** The parent node. */
@@ -72,15 +69,6 @@ public final class FNode extends FParticle {
         } else {
             return "n_" + label;
         }
-    }
-
-    /**
-     * Returns the displacement vector.
-     * 
-     * @return the displacement vector
-     */
-    public KVector getDisplacement() {
-        return displacement;
     }
 
     /**

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FParticle.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/graph/FParticle.java
@@ -23,6 +23,9 @@ public abstract class FParticle extends MapPropertyHolder {
     /** the serial version UID. */
     private static final long serialVersionUID = -6264474302326798066L;
     
+    /** particle position displacement for each iteration. */
+    private KVector displacement = new KVector();
+
     /** Position of this particle. */
     private KVector position = new KVector();
     /** Width and height of graphical representation. */
@@ -53,6 +56,15 @@ public abstract class FParticle extends MapPropertyHolder {
      */
     public double getRadius() {
         return size.length() / 2;
+    }
+
+    /**
+     * Returns the displacement vector.
+     * 
+     * @return the displacement vector
+     */
+    public KVector getDisplacement() {
+        return displacement;
     }
 
 }

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/AbstractForceModel.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/AbstractForceModel.java
@@ -184,15 +184,17 @@ public abstract class AbstractForceModel {
             if (u instanceof FBendpoint && v instanceof FBendpoint && !triedForBendPoints) {
                 // Wiggle orthogonal to edge direction
                 FEdge uE = ((FBendpoint) u).getEdge();
-                KVector uV = new KVector(uE.getTargetPoint()).sub(uE.getSourcePoint());
+                KVector uVector = new KVector(uE.getTargetPoint()).sub(uE.getSourcePoint());
                 double length = 2;
-                KVector orthogonaluV = new KVector(uV.x / uV.length() * length, -uV.y / uV.length() * length);
+                KVector orthogonaluV = new KVector(uVector.x / uVector.length() * length,
+                        -uVector.y / uVector.length() * length);
                 pu.add(orthogonaluV);
 
                 FEdge vE = ((FBendpoint) v).getEdge();
-                KVector vV = new KVector(vE.getTargetPoint()).sub(vE.getSourcePoint());
-                length = uV == vV ? -2 : 2;
-                KVector orthogonalvV = new KVector(vV.x / vV.length() * length, -vV.y / vV.length() * length);
+                KVector vVector = new KVector(vE.getTargetPoint()).sub(vE.getSourcePoint());
+                length = uVector == vVector ? -2 : 2;
+                KVector orthogonalvV = new KVector((vVector.x / vVector.length()) * length,
+                        -(vVector.y / vVector.length()) * length);
                 pu.add(orthogonalvV);
                 triedForBendPoints = true;
                 

--- a/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/AbstractForceModel.java
+++ b/plugins/org.eclipse.elk.alg.force/src/org/eclipse/elk/alg/force/model/AbstractForceModel.java
@@ -110,9 +110,10 @@ public abstract class AbstractForceModel {
         int iterations = 0;
         
         while (moreIterations(iterations) && !monitor.isCanceled()) {
-            
+
+            iterationDone();
             // calculate attractive and repulsive forces
-            for (FNode v : fgraph.getNodes()) {
+            for (FParticle v : fgraph.getParticles()) {
                 for (FParticle u : fgraph.getParticles()) {
                     if (u != v) {
                         KVector displacement = calcDisplacement(u, v);
@@ -124,14 +125,12 @@ public abstract class AbstractForceModel {
             }
             
             // apply calculated displacement
-            for (FNode v : fgraph.getNodes()) {
+            for (FParticle v : fgraph.getParticles()) {
                 KVector d = v.getDisplacement();
                 d.bound(-dispBound, -dispBound, dispBound, dispBound);
                 v.getPosition().add(d);
                 d.reset();
             }
-            
-            iterationDone();
             iterations++;
         }
         monitor.done();
@@ -181,8 +180,26 @@ public abstract class AbstractForceModel {
         KVector pu = u.getPosition();
         KVector pv = v.getPosition();
         while (pu.x - pv.x == 0 && pu.y - pv.y == 0) {
-            pu.wiggle(random, 1);
-            pv.wiggle(random, 1);
+            boolean triedForBendPoints = false;
+            if (u instanceof FBendpoint && v instanceof FBendpoint && !triedForBendPoints) {
+                // Wiggle orthogonal to edge direction
+                FEdge uE = ((FBendpoint) u).getEdge();
+                KVector uV = new KVector(uE.getTargetPoint()).sub(uE.getSourcePoint());
+                double length = 2;
+                KVector orthogonaluV = new KVector(uV.x / uV.length() * length, -uV.y / uV.length() * length);
+                pu.add(orthogonaluV);
+
+                FEdge vE = ((FBendpoint) v).getEdge();
+                KVector vV = new KVector(vE.getTargetPoint()).sub(vE.getSourcePoint());
+                length = uV == vV ? -2 : 2;
+                KVector orthogonalvV = new KVector(vV.x / vV.length() * length, -vV.y / vV.length() * length);
+                pu.add(orthogonalvV);
+                triedForBendPoints = true;
+                
+            } else {
+                pu.wiggle(random, 1);
+                pv.wiggle(random, 1);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #806.
The solution works well with a limited amount of bendpoints. If they get too many, edges become intertwined.
Fixes #849.
The offset is applied to all elements (also all labels).
![Screenshot from 2022-11-14 17-41-58](https://user-images.githubusercontent.com/6419799/201716235-8d2cca60-4bdd-406b-98f3-c0856a8115e9.png)
![test](https://user-images.githubusercontent.com/6419799/201716561-8a6f4b6c-6592-4721-8e40-22f52f6c4bce.svg)
@Eddykasp 