### PR TITLE
Improved libavoid integration

### DIFF
--- a/docs/content/blog/posts/2022/22-11-17-libavoid.md
+++ b/docs/content/blog/posts/2022/22-11-17-libavoid.md
@@ -54,7 +54,6 @@ The new layout algorithm has the identifier `org.eclipse.elk.alg.libavoid`. Its 
  * If your graph uses ports:
     * Every port must have a position on the border of its parent node.
     * `org.eclipse.elk.port.side` must be set to either `NORTH`, `EAST`, `SOUTH` or `WEST` for each port.
-    * `org.eclipse.elk.portConstraints` should be set to `FIXED_POS` for each node.
 
 The libavoid algorithm also brings its own configuration options.
 They are included in ELK's [reference documentation](/reference.html), but you can find documentation on the Doxygen pages of libavoid as well:

--- a/plugins/org.eclipse.elk.alg.libavoid/pom.xml
+++ b/plugins/org.eclipse.elk.alg.libavoid/pom.xml
@@ -62,7 +62,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.1.0/libavoid-server-linux</url>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.2.0/libavoid-server-linux</url>
               <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
             </configuration>
           </execution>
@@ -73,7 +73,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.1.0/libavoid-server-macos</url>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.2.0/libavoid-server-macos</url>
               <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
             </configuration>
           </execution>
@@ -84,7 +84,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.1.0/libavoid-server-win.exe</url>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.2.0/libavoid-server-win.exe</url>
               <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
             </configuration>
           </execution>

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/Libavoid.melk
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/Libavoid.melk
@@ -45,16 +45,18 @@ algorithm libavoid(LibavoidLayoutProvider) {
        supports org.eclipse.elk.alg.libavoid.portDirectionPenalty
        supports org.eclipse.elk.alg.libavoid.shapeBufferDistance
        supports org.eclipse.elk.alg.libavoid.idealNudgingDistance
+       supports org.eclipse.elk.alg.libavoid.reverseDirectionPenalty
        supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalSegmentsConnectedToShapes
        supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingJunctions
        supports org.eclipse.elk.alg.libavoid.penaliseOrthogonalSharedPathsAtConnEnds
        supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalTouchingColinearSegments
        supports org.eclipse.elk.alg.libavoid.performUnifyingNudgingPreprocessingStep
        supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingAddingAndDeletingJunctions
+       supports org.eclipse.elk.alg.libavoid.nudgeSharedPathsWithCommonEndPoint
 }      
 
 // --- Layout Options
-// NOTE: Do not group this layout options unless you change the libavoid server as well.
+// NOTE: Do not group these layout options unless you change the libavoid server as well.
 
 option segmentPenalty: double {
     label "Segment Penalty"
@@ -91,7 +93,7 @@ advanced option crossingPenalty: double {
 advanced option clusterCrossingPenalty: double {
     label "Cluster Crossing Penalty"
     description "This penalty is applied whenever a connector path crosses a cluster boundary."
-    default = 4000
+    default = 0
     targets parents
 }
 
@@ -110,7 +112,7 @@ advanced option portDirectionPenalty: double {
         "This penalty is applied to port selection choice when the other end of the connector 
         being routed does not appear in any of the 90 degree visibility cones centered on the 
         visibility directions for the port."
-    default = 100
+    default = 0
     targets parents
 }
 
@@ -119,8 +121,7 @@ option shapeBufferDistance: double {
     description
         "This parameter defines the spacing distance that will be added to the sides of each 
         shape when determining obstacle sizes for routing. This controls how closely connectors 
-        pass shapes, and can be used to prevent connectors overlapping with shape boundaries.
-        By default, this distance is set to a value of 4."
+        pass shapes, and can be used to prevent connectors overlapping with shape boundaries."
     default = 4
     targets parents
 }
@@ -129,9 +130,19 @@ option idealNudgingDistance: double {
     label "Ideal Nudging Distance"
     description
         "This parameter defines the spacing distance that will be used for nudging apart 
-        overlapping corners and line segments of connectors. By default, 
-        this distance is set to a value of 4."
+        overlapping corners and line segments of connectors."
     default = 4
+    targets parents
+}
+
+option reverseDirectionPenalty: double {
+    label "Reverse Direction Penalty"
+    description
+        "This penalty is applied whenever a connector path travels in the direction opposite
+		of the destination from the source endpoint. By default this penalty is set to zero.
+		This shouldn't be needed in most cases but can be useful if you use penalties such as
+		crossingPenalty which cause connectors to loop around obstacles."
+    default = 0
     targets parents
 }
 
@@ -140,7 +151,7 @@ option nudgeOrthogonalSegmentsConnectedToShapes: boolean {
     description
         "This option causes the final segments of connectors, which are attached to shapes, 
         to be nudged apart. Usually these segments are fixed, since they are considered to be 
-        attached to ports. This option is not set by default."
+        attached to ports."
     default = false
     targets parents
 }
@@ -151,7 +162,7 @@ option improveHyperedgeRoutesMovingJunctions: boolean {
     description
         "This option causes hyperedge routes to be locally improved fixing obviously bad paths. 
         As part of this process libavoid will effectively move junctions, setting new ideal positions 
-        ( JunctionRef::recommendedPosition() ) for each junction."
+        for each junction."
     default = true
     targets parents
 }
@@ -173,7 +184,7 @@ option nudgeOrthogonalTouchingColinearSegments: boolean {
     description
         "This option can be used to control whether colinear line segments that touch just at 
         their ends will be nudged apart. The overlap will usually be resolved in the other dimension, 
-        so this is not usually required and is not set by default."
+        so this is not usually required."
     default = false
     targets parents
 }
@@ -189,9 +200,24 @@ advanced option performUnifyingNudgingPreprocessingStep: boolean {
 }
 
 advanced option improveHyperedgeRoutesMovingAddingAndDeletingJunctions: boolean {
-    label "Improve Hyperedge Routes Add Delete"
+    label "Improve Hyperedge Routes Add/Delete"
     description 
-        "This option causes hyperedge routes to be locally improved fixing obviously bad paths."
+        "This option causes hyperedge routes to be locally improved fixing obviously bad paths.
+		It can cause junctions and connectors to be added or removed from hyperedges. As part of
+		this process libavoid will effectively move junctions by setting new ideal positions for
+		each remaining or added junction. If set, this option overrides the
+		improveHyperedgeRoutesMovingJunctions option."
+    default = false
+    targets parents
+}
+
+advanced option nudgeSharedPathsWithCommonEndPoint: boolean {
+    label "Nudge Shared Paths With Common Endpoint"
+    description 
+        "This option determines whether intermediate segments of connectors that are attached to
+		common endpoints will be nudged apart. Usually these segments get nudged apart, but you
+		may want to turn this off if you would prefer that entire shared paths terminating at a
+		common end point should overlap."
     default = true
     targets parents
 }

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
@@ -401,7 +401,6 @@ public class LibavoidServer {
 
         if (error != null && error.length() > 0) {
             // an error output could be read from Libavoid, so display that to the user
-            error.insert(0, "Libavoid error: ");
             throw new LibavoidServerException("Libavoid error: " + error.toString());
         }
     }


### PR DESCRIPTION
 - Upgraded to `libavoid-server` [v0.2.0](https://github.com/TypeFox/libavoid-server/releases/tag/v0.2.0)
 - Added new options `reverseDirectionPenalty` and `nudgeSharedPathsWithCommonEndPoint`
 - Don't override `idealNudgingDistance` (https://github.com/eclipse/elk/pull/886#discussion_r1022634617)
 - Compute port sides if they're not specified in the graph
 - Compute size of parent node