### PR TITLE
Jep/node label adjustment

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/GraphConfigurator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/GraphConfigurator.java
@@ -22,6 +22,8 @@ import org.eclipse.elk.alg.layered.options.GraphProperties;
 import org.eclipse.elk.alg.layered.options.GreedySwitchType;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.NodeFlexibility;
+import org.eclipse.elk.alg.layered.options.NodePlacementStrategy;
 import org.eclipse.elk.alg.layered.options.NodePromotionStrategy;
 import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.alg.layered.options.Spacings;
@@ -279,6 +281,16 @@ final class GraphConfigurator {
         if (lgraph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_SEMI_INTERACTIVE)) {
             configuration.addBefore(LayeredPhases.P3_NODE_ORDERING,
                     IntermediateProcessorStrategy.SEMI_INTERACTIVE_CROSSMIN_PROCESSOR);
+        }
+        
+        // Multiple labels in one node are combined to fewer labels if the node width allows it
+        if (lgraph.getProperty(LayeredOptions.NODE_PLACEMENT_STRATEGY) == NodePlacementStrategy.NETWORK_SIMPLEX
+                && (lgraph.getProperty(
+                        LayeredOptions.NODE_PLACEMENT_NETWORK_SIMPLEX_NODE_FLEXIBILITY) == NodeFlexibility.NODE_SIZE
+                        || lgraph.getProperty(
+                                LayeredOptions.NODE_PLACEMENT_NETWORK_SIMPLEX_NODE_FLEXIBILITY_DEFAULT) == NodeFlexibility.NODE_SIZE)) {
+            configuration.addBefore(LayeredPhases.P5_EDGE_ROUTING,
+                    IntermediateProcessorStrategy.ADJUST_LABELS_TO_NODE_WIDTH);
         }
 
         // Configure greedy switch

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/Layered.melk
@@ -16,6 +16,7 @@ import org.eclipse.elk.core.math.ElkPadding
 import org.eclipse.elk.core.options.Direction
 import org.eclipse.elk.core.options.EdgeRouting
 import org.eclipse.elk.core.options.HierarchyHandling
+import org.eclipse.elk.core.options.MergeRange
 import org.eclipse.elk.core.options.PortAlignment
 import org.eclipse.elk.core.util.ExclusiveBounds
 
@@ -92,6 +93,7 @@ algorithm layered(LayeredLayoutProvider) {
     // flexible nodes during node placement
     supports nodePlacement.networkSimplex.nodeFlexibility
     supports nodePlacement.networkSimplex.nodeFlexibility.^default
+    supports nodePlacement.networkSimplex.nodeFlexibility.labelMerging
     
     // splines
     supports edgeRouting.splines.mode
@@ -530,6 +532,17 @@ group nodePlacement {
                 description
                     "Default value of the 'nodeFlexibility' option for the children of a hierarchical node."
                 default = NodeFlexibility.NONE
+                targets parents   
+                requires nodePlacement.strategy == NodePlacementStrategy.NETWORK_SIMPLEX
+            }
+            
+            advanced option labelMerging: MergeRange {
+                label "Merging of Node Labels"
+                description
+                    "Merges labels of nodes if the node width allows it. The values of the pair determine the labels 
+                     that should be tried to merge. E.g. for the Pair (2,4) the second, third, and fourth label are
+                     merged as far as possible."
+                default = new MergeRange(0,0)
                 targets parents   
                 requires nodePlacement.strategy == NodePlacementStrategy.NETWORK_SIMPLEX
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/AdjustNodeLabels.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/AdjustNodeLabels.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.intermediate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LLabel;
+import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.graph.Layer;
+import org.eclipse.elk.alg.layered.options.InternalProperties;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.p4nodes.NetworkSimplexPlacer;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.math.ElkPadding;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.options.MergeRange;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.graph.ElkLabel;
+import org.eclipse.elk.graph.ElkNode;
+
+/**
+ * @author jep
+ *
+ */
+public final class AdjustNodeLabels implements ILayoutProcessor<LGraph> {
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.elk.core.alg.ILayoutProcessor#process(java.lang.Object,
+     * org.eclipse.elk.core.util.IElkProgressMonitor)
+     */
+    @Override
+    public void process(final LGraph graph, final IElkProgressMonitor monitor) {
+        monitor.begin("Label adjustment", 0);
+
+        // combine node labels if possible
+        Direction direction = graph.getProperty(LayeredOptions.DIRECTION);
+        if (direction == Direction.DOWN || direction == Direction.UP) {
+            // node sizes and label sizes and positions are transposed here
+            down(graph);
+        } else if (direction == Direction.RIGHT || direction == Direction.LEFT) {
+            right(graph);
+        }
+
+        // recalculate size of labels and nodes
+        LabelManagementProcessor labelManager = new LabelManagementProcessor(false);
+        labelManager.process(graph, monitor);
+        LabelAndNodeSizeProcessor nodeSizeProcessor = new LabelAndNodeSizeProcessor();
+        nodeSizeProcessor.process(graph, monitor);
+        NetworkSimplexPlacer placer = new NetworkSimplexPlacer();
+        placer.process(graph, monitor);
+
+        monitor.done();
+    }
+
+    /**
+     * Combines labels if the node size allows it.
+     * 
+     * @param graph
+     *            The graph.
+     */
+    private void down(final LGraph graph) {
+        for (Layer layer : graph) {
+            for (LNode node : layer) {
+                KVector nodeSize = node.getSize();
+                ElkPadding padding = graph.getProperty(LayeredOptions.NODE_LABELS_PADDING);
+                // the space that can be used by a label
+                double usableSpace = nodeSize.y - padding.top - padding.bottom;
+
+                // determines which labels are tried to merge
+                MergeRange range =
+                        node.getProperty(LayeredOptions.NODE_PLACEMENT_NETWORK_SIMPLEX_NODE_FLEXIBILITY_LABEL_MERGING);
+
+                List<LLabel> labels = node.getLabels();
+                if (range.start != 0 && range.end != 0 && labels.size() >= range.start) {
+                    int current = range.start - 1;
+                    // needed to delete elkLabels corresponding to the llabels that will be deleted
+                    ElkNode elkNode = (ElkNode) node.getProperty(InternalProperties.ORIGIN);
+                    List<ElkLabel> originLabels = elkNode.getLabels();
+
+                    // get the values of the first label
+                    LLabel lastLabel = labels.get(current);
+                    String currentText = lastLabel.getText();
+                    double currentWidth = lastLabel.getSize().y;
+                    labels.remove(current);
+
+                    // try to merge labels that are in the given range
+                    for (int i = range.start; i < range.end && current < labels.size(); i++) {
+                        LLabel label = labels.get(current);
+                        if (currentWidth + label.getSize().y <= usableSpace) {
+                            // labels can be combined
+                            currentText += " " + label.getText();
+                            currentWidth += label.getSize().y;
+                            // original elklabel must be removed
+                            originLabels.remove(current + 1);
+                        } else {
+                            // add a new label with the text of the previous labels
+                            LLabel newLabel = addLabel(currentText, lastLabel);
+                            labels.add(current, newLabel);
+                            // values of the current label
+                            currentText = label.getText();
+                            currentWidth = label.getSize().y;
+                            lastLabel = label;
+                            current++;
+                        }
+
+                        labels.remove(current);
+                    }
+                    // add a label for the remaining (combined) labels
+                    LLabel newLabel = addLabel(currentText, lastLabel);
+                    labels.add(current, newLabel);
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a new label with the given attributes and updates the original elkLabel.
+     * 
+     * @param text
+     *            The text of the new label.
+     * @param label
+     *            The original label from which the properties are copied.
+     * @return a new label with the given attributes.
+     */
+    private LLabel addLabel(final String text, final LLabel label) {
+        // create a label with the given values
+        LLabel newLabel = new LLabel(text);
+        // copy the properties of the original label
+        newLabel.copyProperties(label);
+        // set the text of the original elk label
+        Object origin = newLabel.getProperty(InternalProperties.ORIGIN);
+        if (origin instanceof ElkLabel) {
+            ElkLabel elkLabel = (ElkLabel) origin;
+            elkLabel.setText(newLabel.getText());
+        }
+        return newLabel;
+    }
+
+    private void right(final LGraph graph) {
+        // TODO: implement / rework code
+        // for (Layer layer : graph) {
+        // for (LNode node : layer) {
+        // KVector nodeSize = node.getSize();
+        // ElkPadding padding = graph.getProperty(LayeredOptions.NODE_LABELS_PADDING);
+        // double usableSpace = nodeSize.x - padding.left - padding.right;
+        //
+        // List<LLabel> labels = node.getLabels();
+        // List<LLabel> newLabels = new ArrayList<>();
+        // if (labels.size() > 1) {
+        // ElkNode elkNode = (ElkNode) node.getProperty(InternalProperties.ORIGIN);
+        // List<ElkLabel> originLabels = elkNode.getLabels();
+        //
+        // LLabel firstLabel = labels.get(0);
+        // double labelHeight = labels.get(0).getSize().y;
+        // String currentText = labels.get(0).getText();
+        // double currentWidth = labels.get(0).getSize().x;
+        // labels.remove(0);
+        // int counter = 1;
+        //
+        // while (!labels.isEmpty()) {
+        // LLabel label = labels.get(0);
+        // if (currentWidth + label.getSize().x < usableSpace) {
+        // currentText += " " + label.getText();
+        // currentWidth += label.getSize().x;
+        // originLabels.remove(counter);
+        // } else {
+        // LLabel test = new LLabel(currentText);
+        // test.getSize().x = currentWidth;
+        // test.getSize().y = labelHeight;
+        // test.getPosition().x = (node.getSize().x - test.getSize().x) / 2.0;
+        // test.getPosition().y = (node.getSize().y - test.getSize().y) / 2.0 + test.getSize().y;
+        // newLabels.add(test);
+        // currentText = label.getText();
+        // currentWidth = label.getSize().x;
+        // test.copyProperties(label);
+        // counter++;
+        // Object origin = test.getProperty(InternalProperties.ORIGIN);
+        // if (origin instanceof ElkLabel) {
+        // ElkLabel elkLabel = (ElkLabel) origin;
+        // elkLabel.setText(test.getText());
+        // }
+        // }
+        //
+        // labels.remove(0);
+        // }
+        //
+        // LLabel test = new LLabel(currentText);
+        // test.getSize().x = currentWidth;
+        // test.getSize().y = labelHeight;
+        // test.getPosition().x = (node.getSize().x - test.getSize().x) / 2.0;
+        // test.getPosition().y = (node.getSize().y - test.getSize().y) / 2.0 + test.getSize().y;
+        // newLabels.add(test);
+        // test.copyProperties(firstLabel);
+        // Object origin = test.getProperty(InternalProperties.ORIGIN);
+        // if (origin instanceof ElkLabel) {
+        // ElkLabel elkLabel = (ElkLabel) origin;
+        // elkLabel.setText(test.getText());
+        // }
+        //
+        // labels.addAll(newLabels);
+        // }
+        // }
+        // }
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/IntermediateProcessorStrategy.java
@@ -84,7 +84,7 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<LGr
     SORT_BY_INPUT_ORDER_OF_MODEL,
     /** Inserts dummy nodes to take care of northern and southern ports. */
     NORTH_SOUTH_PORT_PREPROCESSOR,
-
+    
     // Before Phase 4
     
     /** Performs 'wrapping' of the graph, potentially executing improvement heuristics. */
@@ -123,7 +123,8 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<LGr
     HIERARCHICAL_PORT_DUMMY_SIZE_PROCESSOR,
 
     // Before Phase 5
-
+    /** Adjust the node labels when network simplex with node flexibility is used. */
+    ADJUST_LABELS_TO_NODE_WIDTH,
     /** Calculate the size of layers and the graph's height and offset. */
     LAYER_SIZE_AND_GRAPH_HEIGHT_CALCULATOR,
     /** Fix coordinates of hierarchical port dummy nodes. */
@@ -282,6 +283,9 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<LGr
 
         case LAYER_CONSTRAINT_PREPROCESSOR:
             return new LayerConstraintPreprocessor();
+            
+        case ADJUST_LABELS_TO_NODE_WIDTH:
+            return new AdjustNodeLabels();
             
         case LAYER_SIZE_AND_GRAPH_HEIGHT_CALCULATOR:
             return new LayerSizeAndGraphHeightCalculator();

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
@@ -24,6 +24,7 @@ import org.eclipse.elk.core.math.ElkPadding;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.MergeRange;
 import org.eclipse.elk.core.util.IndividualSpacings;
 import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.graph.util.ElkReflect;
@@ -128,6 +129,9 @@ public final class LayoutMetaDataService {
         ElkReflect.register(IndividualSpacings.class, 
                 () -> new IndividualSpacings(), 
                 (is) -> new IndividualSpacings((IndividualSpacings) is));
+        ElkReflect.register(MergeRange.class, 
+                () -> new MergeRange(),
+                (mr) -> new MergeRange((MergeRange) mr));
         
         // Commonly used classes for internal properties
         ElkReflect.register(ArrayList.class, 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/MergeRange.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/MergeRange.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.core.options;
+
+import org.eclipse.elk.core.math.ElkPadding;
+import org.eclipse.elk.core.util.IDataObject;
+
+/**
+ * Stores the range for label merging. The range determines which labels will be tried to merge.
+ * @author jep
+ *
+ */
+public class MergeRange implements IDataObject, Cloneable {
+    
+    /** The serial version UID. */
+    private static final long serialVersionUID = 2491028146866390909L;
+    
+    public int start = 0;
+    public int end = 0;
+    
+    /**
+     * Creates a new instance with all fields set to 0.
+     */
+    public MergeRange() {}
+    
+    /**
+     * Creates a new instance with the given values.
+     * @param start The start of the range.
+     * @param end The end of the range.
+     */
+    public MergeRange(final int start, final int end) {
+        this.start = start;
+        this.end = end;
+    }
+    
+    /**
+     * @return the start
+     */
+    public int getStart() {
+        return this.start;
+    }
+    
+    /**
+     * @return the end
+     */
+    public int getEnd() {
+        return this.end;
+    }
+
+    @Override
+    public void parse(String string) {
+        int start = 0;
+        while (start < string.length() && isdelim(string.charAt(start), "([{\"' \t\r\n")) {
+            start++;
+        }
+        int end = string.length();
+        while (end > 0 && isdelim(string.charAt(end - 1), ")]}\"' \t\r\n")) {
+            end--;
+        }
+        if (start < end) {
+            String[] tokens = string.substring(start, end).split(",|;");
+            try {
+                for (String token : tokens) {
+                    String[] keyandvalue = token.split("=");
+                    if (keyandvalue.length != 2) {
+                        throw new IllegalArgumentException("Expecting a list of key-value pairs.");
+                    }
+                    String key = keyandvalue[0].trim();
+                    int value = Integer.parseInt(keyandvalue[1].trim());
+                    if (key.equals("start")) {
+                        this.start = value;
+                    } else if (key.equals("end")) {
+                        this.end = value;
+                    }
+                }
+            } catch (NumberFormatException exception) {
+                throw new IllegalArgumentException(
+                        "The given string contains parts that cannot be parsed as numbers." + exception);
+            }
+        }
+    }
+    
+    /**
+     * Determine whether the given character is a delimiter.
+     * 
+     * @param c
+     *            a character
+     * @param delims
+     *            a string of possible delimiters
+     * @return true if {@code c} is one of the characters in {@code delims}
+     */
+    private static boolean isdelim(final char c, final String delims) {
+        for (int i = 0; i < delims.length(); i++) {
+            if (c == delims.charAt(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Creates a new instance with all fields set to the value of {@code other}.
+     * 
+     * @param other
+     *            merge range object from which to copy the values.
+     */
+    public MergeRange(final MergeRange other) {
+        this(other.start, other.end);
+    }
+
+
+    @Override
+    public MergeRange clone() {
+        return new MergeRange(this);
+    }
+    
+}


### PR DESCRIPTION
When using NETWORK_SIMPLEX and NODE_SIZE nodeFlexibility the node flexibility possibly increases the width of nodes. As a result multiple labels may be placed beside each other. With the new property "labelMerging" the user can define which labels should be tried to place beside each other.

Added a property and a postprocessor to merge labels when using NETWORK_SIMPLEX and NODE_SIZE nodeFlexibility. Currently only implemented for the layout directions UP and DOWN.
In the following example the second, third, and fourth label of the node n1 are merged.
![multipleLabelsOriginal](https://user-images.githubusercontent.com/71103057/208103976-71c577af-5c0d-44ae-adcd-1ff7aa62146f.svg)

```
org.eclipse.elk.direction: DOWN
org.eclipse.elk.algorithm: layered
org.eclipse.elk.layered.nodePlacement.strategy: NETWORK_SIMPLEX
org.eclipse.elk.layered.nodePlacement.networkSimplex.nodeFlexibility.default: NODE_SIZE
org.eclipse.elk.spacing.portsSurrounding: "[top=10.0,left=10.0,bottom=10.0,right=10.0]"


node n1 {
    nodePlacement.networkSimplex.nodeFlexibility.labelMerging: "[start=2, end=4]"
    label "naecafc1"
    label "hggsdsdg"
    label "hjkfh"
    label "hjha"
}

node n2
node n3 
node n4 

edge n2 -> n1 
edge n3 -> n1 
edge n4 -> n1
```

![multipleLabels](https://user-images.githubusercontent.com/71103057/208103570-38775b21-a4f7-4e69-bc36-9d38acb798ae.svg)
