### PR TITLE
libavoid: Added node micro layout.

### DIFF
--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/Libavoid.melk
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/Libavoid.melk
@@ -31,28 +31,29 @@ algorithm libavoid(LibavoidLayoutProvider) {
     metadataClass options.LibavoidOptions
     category edge
         
-       supports org.eclipse.elk.debugMode = false
-       supports org.eclipse.elk.port.side
-       supports org.eclipse.elk.direction
-       supports org.eclipse.elk.edgeRouting = EdgeRouting.ORTHOGONAL
-       supports org.eclipse.elk.portConstraints = PortConstraints.FREE
+    supports org.eclipse.elk.debugMode = false
+    supports org.eclipse.elk.port.side
+    supports org.eclipse.elk.direction
+    supports org.eclipse.elk.edgeRouting = EdgeRouting.ORTHOGONAL
+    supports org.eclipse.elk.portConstraints = PortConstraints.FREE
+    supports org.eclipse.elk.omitNodeMicroLayout
        
-       supports org.eclipse.elk.alg.libavoid.segmentPenalty
-       supports org.eclipse.elk.alg.libavoid.anglePenalty
-       supports org.eclipse.elk.alg.libavoid.crossingPenalty
-       supports org.eclipse.elk.alg.libavoid.clusterCrossingPenalty
-       supports org.eclipse.elk.alg.libavoid.fixedSharedPathPenalty
-       supports org.eclipse.elk.alg.libavoid.portDirectionPenalty
-       supports org.eclipse.elk.alg.libavoid.shapeBufferDistance
-       supports org.eclipse.elk.alg.libavoid.idealNudgingDistance
-       supports org.eclipse.elk.alg.libavoid.reverseDirectionPenalty
-       supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalSegmentsConnectedToShapes
-       supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingJunctions
-       supports org.eclipse.elk.alg.libavoid.penaliseOrthogonalSharedPathsAtConnEnds
-       supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalTouchingColinearSegments
-       supports org.eclipse.elk.alg.libavoid.performUnifyingNudgingPreprocessingStep
-       supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingAddingAndDeletingJunctions
-       supports org.eclipse.elk.alg.libavoid.nudgeSharedPathsWithCommonEndPoint
+    supports org.eclipse.elk.alg.libavoid.segmentPenalty
+    supports org.eclipse.elk.alg.libavoid.anglePenalty
+    supports org.eclipse.elk.alg.libavoid.crossingPenalty
+    supports org.eclipse.elk.alg.libavoid.clusterCrossingPenalty
+    supports org.eclipse.elk.alg.libavoid.fixedSharedPathPenalty
+    supports org.eclipse.elk.alg.libavoid.portDirectionPenalty
+    supports org.eclipse.elk.alg.libavoid.shapeBufferDistance
+    supports org.eclipse.elk.alg.libavoid.idealNudgingDistance
+    supports org.eclipse.elk.alg.libavoid.reverseDirectionPenalty
+    supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalSegmentsConnectedToShapes
+    supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingJunctions
+    supports org.eclipse.elk.alg.libavoid.penaliseOrthogonalSharedPathsAtConnEnds
+    supports org.eclipse.elk.alg.libavoid.nudgeOrthogonalTouchingColinearSegments
+    supports org.eclipse.elk.alg.libavoid.performUnifyingNudgingPreprocessingStep
+    supports org.eclipse.elk.alg.libavoid.improveHyperedgeRoutesMovingAddingAndDeletingJunctions
+    supports org.eclipse.elk.alg.libavoid.nudgeSharedPathsWithCommonEndPoint
 }      
 
 // --- Layout Options

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidLayoutProvider.java
@@ -9,7 +9,9 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.libavoid;
 
+import org.eclipse.elk.alg.common.NodeMicroLayout;
 import org.eclipse.elk.alg.common.nodespacing.NodeDimensionCalculation;
+import org.eclipse.elk.alg.libavoid.options.LibavoidOptions;
 import org.eclipse.elk.alg.libavoid.server.LibavoidServer;
 import org.eclipse.elk.alg.libavoid.server.LibavoidServerPool;
 import org.eclipse.elk.core.AbstractLayoutProvider;
@@ -39,6 +41,11 @@ public class LibavoidLayoutProvider extends AbstractLayoutProvider {
     @Override
     public void layout(final ElkNode parentNode, final IElkProgressMonitor progressMonitor) {
 
+        // if requested, compute nodes's dimensions, place node labels, ports, port labels, etc.
+        if (!parentNode.getProperty(LibavoidOptions.OMIT_NODE_MICRO_LAYOUT)) {
+            NodeMicroLayout.forGraph(parentNode)
+                           .execute();
+        }
         // Prepare the graph
     	prepareGraph(parentNode);
         ElkGraphAdapter adapter = ElkGraphAdapters.adapt(parentNode);


### PR DESCRIPTION
With micro layout
![libavoid](https://user-images.githubusercontent.com/6419799/233625419-ac3151c6-fa78-4921-b0a4-51a07b617cfd.svg)
Without micro layout
![libavoid02](https://user-images.githubusercontent.com/6419799/233625423-d18e45fe-ab2c-47bf-a309-b08f211e1266.svg)
With node micro layout the node labels are placed correctly.