### PR TITLE
layered: MO save transitive dependencies when comparing ports by model order.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -86,6 +86,7 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
 
     @Override
     public int compare(final LPort p1, final LPort p2) {
+        // TODO handle different port sides separately
         if (!biggerThan.containsKey(p1)) {
             biggerThan.put(p1, new HashSet<>());
         } else if (biggerThan.get(p1).contains(p2)) {
@@ -232,13 +233,15 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
         } else if (p1.hasProperty(InternalProperties.MODEL_ORDER) && p2.hasProperty(InternalProperties.MODEL_ORDER)) {
             // The ports have no edges.
             // Use the port model order to compare them.
-            if (p1.getProperty(InternalProperties.MODEL_ORDER) > p2.getProperty(InternalProperties.MODEL_ORDER)) {
-                updateBiggerAndSmallerAssociations(p1, p2);
-            } else {
+            int p1MO = p1.getProperty(InternalProperties.MODEL_ORDER);
+            int p2MO = p2.getProperty(InternalProperties.MODEL_ORDER);
+            if (p1MO > p2MO) {
                 updateBiggerAndSmallerAssociations(p2, p1);
+            } else {
+                updateBiggerAndSmallerAssociations(p1, p2);
             }
-            return Integer.compare(p1.getProperty(InternalProperties.MODEL_ORDER),
-                    p2.getProperty(InternalProperties.MODEL_ORDER));
+            return Integer.compare(p2MO,
+                    p1MO);
         } else {
             updateBiggerAndSmallerAssociations(p2, p1);
             return -1;
@@ -255,7 +258,8 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
      *         second.
      */
     public int checkPortModelOrder(final LPort p1, final LPort p2) {
-        if (p1.hasProperty(InternalProperties.MODEL_ORDER) && p2.hasProperty(InternalProperties.MODEL_ORDER)) {
+        if (p1.hasProperty(InternalProperties.MODEL_ORDER)
+                && p2.hasProperty(InternalProperties.MODEL_ORDER)) {
             return Integer.compare(p1.getProperty(InternalProperties.MODEL_ORDER),
                     p2.getProperty(InternalProperties.MODEL_ORDER));
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -90,7 +90,7 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
         LPort p1 = originalP1;
         LPort p2 = originalP2;
 
-        if (p1.getSide() == PortSide.WEST && p2.getSide() == PortSide.WEST) {
+        if (portModelOrder && p1.getSide() == PortSide.WEST && p2.getSide() == PortSide.WEST) {
             // Both nodes have the same port side.
             // Hence I need to determine their ordering based on the side.
             // WEST sort descending

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -48,11 +48,11 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
     private OrderingStrategy strategy;
     
     /**
-     * Each node has an entry of nodes for which it is bigger.
+     * Each port has an entry of ports for which it is bigger.
      */
     private HashMap<LPort, HashSet<LPort>> biggerThan = new HashMap<>();
     /**
-     * Each node has an entry of nodes for which it is smaller.
+     * Each port has an entry of ports for which it is smaller.
      */
     private HashMap<LPort, HashSet<LPort>> smallerThan = new HashMap<>();
 
@@ -292,23 +292,23 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
     }
     
     private void updateBiggerAndSmallerAssociations(final LPort bigger, final LPort smaller) {
-        HashSet<LPort> biggerNodeBiggerThan = biggerThan.get(bigger);
-        HashSet<LPort> smallerNodeBiggerThan = biggerThan.get(smaller);
-        HashSet<LPort> biggerNodeSmallerThan = smallerThan.get(bigger);
-        HashSet<LPort> smallerNodeSmallerThan = smallerThan.get(smaller);
-        biggerNodeBiggerThan.add(smaller);
-        smallerNodeSmallerThan.add(bigger);
-        for (LPort verySmall : smallerNodeBiggerThan) {
-            biggerNodeBiggerThan.add(verySmall);
+        HashSet<LPort> biggerPortBiggerThan = biggerThan.get(bigger);
+        HashSet<LPort> smallerPortBiggerThan = biggerThan.get(smaller);
+        HashSet<LPort> biggerPortSmallerThan = smallerThan.get(bigger);
+        HashSet<LPort> smallerPortSmallerThan = smallerThan.get(smaller);
+        biggerPortBiggerThan.add(smaller);
+        smallerPortSmallerThan.add(bigger);
+        for (LPort verySmall : smallerPortBiggerThan) {
+            biggerPortBiggerThan.add(verySmall);
             smallerThan.get(verySmall).add(bigger);
-            smallerThan.get(verySmall).addAll(biggerNodeSmallerThan);
+            smallerThan.get(verySmall).addAll(biggerPortSmallerThan);
         }
         
 
-        for (LPort veryBig : biggerNodeSmallerThan) {
-            smallerNodeSmallerThan.add(veryBig);
+        for (LPort veryBig : biggerPortSmallerThan) {
+            smallerPortSmallerThan.add(veryBig);
             biggerThan.get(veryBig).add(smaller);
-            biggerThan.get(veryBig).addAll(smallerNodeBiggerThan);
+            biggerThan.get(veryBig).addAll(smallerPortBiggerThan);
         }
     }
     

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -226,6 +226,16 @@ public class LayerSweepCrossingMinimizer
 
     private int minimizeCrossingsWithCounter(final GraphInfoHolder gData) {
         boolean isForwardSweep = random.nextBoolean();
+
+        // If the first, initial ordering is already optimal, do not change anything.
+        // If the initial order should be tried, model order should be active.
+        // So if the initial ordering has no crossings, just do not change anything in the graph.
+        // Normally a first sweep should change the order of not connected ports, which is bad.
+        double initialCrossings = countCurrentNumberOfCrossings(gData);
+        if (initialCrossings == 0 && gData.lGraph().getProperty(InternalProperties.FIRST_TRY_WITH_INITIAL_ORDER)) {
+            // E.g. model order is already correct.
+            return 0;
+        }
         
         if ((!gData.lGraph().getProperty(InternalProperties.FIRST_TRY_WITH_INITIAL_ORDER)
                 && !gData.lGraph().getProperty(InternalProperties.SECOND_TRY_WITH_INITIAL_ORDER))
@@ -262,6 +272,16 @@ public class LayerSweepCrossingMinimizer
     
     private double minimizeCrossingsNodePortOrderWithCounter(final GraphInfoHolder gData) {
         boolean isForwardSweep = random.nextBoolean();
+        
+        // If the first, initial ordering is already optimal, do not change anything.
+        // If the initial order should be tried, model order should be active.
+        // So if the initial ordering has no crossings, just do not change anything in the graph.
+        // Normally a first sweep should change the order of not connected ports, which is bad.
+        double initialCrossings = countCurrentNumberOfCrossingsNodePortOrder(gData);
+        if (initialCrossings == 0 && gData.lGraph().getProperty(InternalProperties.FIRST_TRY_WITH_INITIAL_ORDER)) {
+            // E.g. model order is already correct.
+            return 0;
+        }
         
         if ((!gData.lGraph().getProperty(InternalProperties.FIRST_TRY_WITH_INITIAL_ORDER)
                 && !gData.lGraph().getProperty(InternalProperties.SECOND_TRY_WITH_INITIAL_ORDER))

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/TestGraphCreator.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/TestGraphCreator.java
@@ -721,7 +721,7 @@ public class TestGraphCreator {
         LNode[] leftNodes = addNodesToLayer(2, layers[0]);
         LNode[] rightNodes = addNodesToLayer(3, layers[1]);
 
-        eastWestEdgeFromTo(leftNodes[0], rightNodes[1]);
+        eastWestEdgeFromTo(leftNodes[1], rightNodes[0]);
 
         addNorthSouthEdge(PortSide.EAST, rightNodes[2], rightNodes[1], leftNodes[0], true);
 


### PR DESCRIPTION
Fixed #918 
Fixes #930 