### PR TITLE
Radial layout, rotation extensions.

### DIFF
--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/Radial.melk
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/Radial.melk
@@ -38,6 +38,10 @@ algorithm radial(RadialLayoutProvider) {
     supports org.eclipse.elk.portLabels.placement
     supports compactionStepSize
     supports compactor
+    supports rotator
+    supports targetAngle
+    supports computeAdditionalWedgeSpace
+    supports outgoingEdgeAngles
     supports optimizationCriteria
     supports orderId
     supports radius
@@ -70,6 +74,45 @@ option radius: double {
         "The radius option can be used to set the initial radius for the radial layouter."
     default = 0.0
     targets parents
+}
+
+// Rotation
+option rotator: RotationStrategy {
+    label "Rotation"
+    description
+        "The rotator option determines how a rotation of the layout should be performed."
+    targets parents
+    default = RotationStrategy.NONE
+}
+
+option targetAngle: double {
+    label "Target Angle"
+    description
+        "The angle in radians that the layout should be rotated to after layout. Used by 
+         {@link RotationStrategy.ROTATE_TO_ANGLE}."
+    targets parents
+    default = 0
+    requires rotator == RotationStrategy.ROTATE_TO_ANGLE
+}
+
+advanced option computeAdditionalWedgeSpace: boolean {
+    label "Additional Wedge Space"
+    description
+        "If set to true, modifies the target angle by rotating further such that space is left
+         for an edge to pass in between the nodes. This option should only be used in conjunction
+         with top-down layout."
+    targets parents
+    default = false
+    requires rotator == RotationStrategy.ROTATE_TO_ANGLE
+}
+
+advanced option outgoingEdgeAngles: boolean {
+    label "Outgoing Edge Angles"
+    description 
+        "Calculate the required angle of connected nodes to leave space for an incoming edge. This
+         option should only be used in conjunction with top-down layout."
+    targets parents
+    default = false
 }
 
 //Compaction

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/RadialLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/RadialLayoutProvider.java
@@ -12,17 +12,15 @@ package org.eclipse.elk.alg.radial;
 import java.util.List;
 
 import org.eclipse.elk.alg.common.NodeMicroLayout;
-import org.eclipse.elk.alg.common.nodespacing.NodeDimensionCalculation;
 import org.eclipse.elk.alg.radial.intermediate.IntermediateProcessorStrategy;
 import org.eclipse.elk.alg.radial.options.CompactionStrategy;
 import org.eclipse.elk.alg.radial.options.RadialOptions;
+import org.eclipse.elk.alg.radial.options.RotationStrategy;
 import org.eclipse.elk.core.AbstractLayoutProvider;
 import org.eclipse.elk.core.alg.AlgorithmAssembler;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
-import org.eclipse.elk.core.util.adapters.ElkGraphAdapters;
-import org.eclipse.elk.core.util.adapters.ElkGraphAdapters.ElkGraphAdapter;
 import org.eclipse.elk.graph.ElkNode;
 
 /**
@@ -89,8 +87,17 @@ public class RadialLayoutProvider extends AbstractLayoutProvider {
         if (layoutGraph.getProperty(RadialOptions.COMPACTOR) != CompactionStrategy.NONE) {
             configuration.addBefore(RadialLayoutPhases.P2_EDGE_ROUTING, IntermediateProcessorStrategy.COMPACTION);
         }
+
+        if (layoutGraph.getProperty(RadialOptions.ROTATOR) != RotationStrategy.NONE) {
+            configuration.addBefore(RadialLayoutPhases.P2_EDGE_ROUTING, IntermediateProcessorStrategy.ROTATION);
+        }
+
         configuration.addBefore(RadialLayoutPhases.P2_EDGE_ROUTING,
                 IntermediateProcessorStrategy.GRAPH_SIZE_CALCULATION);
+        
+        if (layoutGraph.getProperty(RadialOptions.OUTGOING_EDGE_ANGLES)) {
+            configuration.addAfter(RadialLayoutPhases.P2_EDGE_ROUTING, IntermediateProcessorStrategy.OUTGOING_EDGE_ANGLES);
+        }
 
         algorithmAssembler.addProcessorConfiguration(configuration);
 

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/EdgeAngleCalculator.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/EdgeAngleCalculator.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.radial.intermediate;
+
+import org.eclipse.elk.alg.radial.InternalProperties;
+import org.eclipse.elk.alg.radial.options.RadialOptions;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.graph.ElkEdge;
+import org.eclipse.elk.graph.ElkNode;
+
+/**
+ * Calculates the angles of outgoing edges so that they can be used as an input by subsequent child 
+ * layouts. Only makes sense when used in a top-down layout.
+ *
+ */
+public class EdgeAngleCalculator implements ILayoutProcessor<ElkNode> {
+
+    /* (non-Javadoc)
+     * @see org.eclipse.elk.core.alg.ILayoutProcessor#process(java.lang.Object, org.eclipse.elk.core.util.IElkProgressMonitor)
+     */
+    @Override
+    public void process(ElkNode graph, IElkProgressMonitor progressMonitor) {
+
+        ElkNode root = graph.getProperty(InternalProperties.ROOT_NODE);
+        for (ElkEdge edge : root.getOutgoingEdges()) {
+            
+            KVector start = new KVector(edge.getSections().get(0).getStartX(), edge.getSections().get(0).getStartY());
+            KVector end = new KVector(edge.getSections().get(0).getEndX(), edge.getSections().get(0).getEndY());
+            
+            KVector edgeVector = end.add(start.scale(-1, -1));
+            double angle = Math.atan2(edgeVector.y, edgeVector.x);
+            
+            edge.getTargets().get(0).setProperty(RadialOptions.TARGET_ANGLE, angle);
+        }
+
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/IntermediateProcessorStrategy.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/IntermediateProcessorStrategy.java
@@ -11,6 +11,7 @@ package org.eclipse.elk.alg.radial.intermediate;
 
 import org.eclipse.elk.alg.radial.intermediate.compaction.GeneralCompactor;
 import org.eclipse.elk.alg.radial.intermediate.overlaps.RadiusExtensionOverlapRemoval;
+import org.eclipse.elk.alg.radial.intermediate.rotation.GeneralRotator;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.alg.ILayoutProcessorFactory;
 import org.eclipse.elk.graph.ElkNode;
@@ -27,8 +28,15 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<Elk
     COMPACTION,
 
     // Before phase 2
+    /** Rotate the final layout. */
+    ROTATION,
     /** Calculate the graph size to the new values. */
-    GRAPH_SIZE_CALCULATION;
+    GRAPH_SIZE_CALCULATION,
+    
+    // After phase 2
+    /** Store a target angle on child nodes to leave space for an edge coming from the root to the center of the child node. */
+    OUTGOING_EDGE_ANGLES;
+    
 
     @Override
     public ILayoutProcessor<ElkNode> create() {
@@ -37,8 +45,12 @@ public enum IntermediateProcessorStrategy implements ILayoutProcessorFactory<Elk
             return new RadiusExtensionOverlapRemoval();
         case COMPACTION:
             return new GeneralCompactor();
+        case ROTATION:
+            return new GeneralRotator();
         case GRAPH_SIZE_CALCULATION:
             return new CalculateGraphSize();
+        case OUTGOING_EDGE_ANGLES:
+            return new EdgeAngleCalculator();
         default:
             throw new IllegalArgumentException(
                     "No implementation is available for the layout processor " + this.toString());

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/rotation/AngleRotation.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/rotation/AngleRotation.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.radial.intermediate.rotation;
+
+import org.eclipse.elk.alg.radial.InternalProperties;
+import org.eclipse.elk.alg.radial.options.RadialOptions;
+import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.graph.ElkNode;
+
+/**
+ * Rotates the entire layout around the origin to a set target angle.
+ *
+ */
+public class AngleRotation implements IRadialRotator {
+
+    /* (non-Javadoc)
+     * @see org.eclipse.elk.alg.radial.intermediate.rotation.IRadialRotator#rotate(org.eclipse.elk.graph.ElkNode)
+     */
+    @Override
+    public void rotate(ElkNode graph) {
+        double targetAngle = graph.getProperty(RadialOptions.TARGET_ANGLE);
+        
+        if (graph.getProperty(RadialOptions.COMPUTE_ADDITIONAL_WEDGE_SPACE)) {
+            // additionally we want to get half the angle of the first wedge to leave space
+            // take first two nodes and compute angle between their incident edges
+            ElkNode root = graph.getProperty(InternalProperties.ROOT_NODE);
+            if (root.getOutgoingEdges().size() <= 1) {
+                // leave angle untouched
+                if (targetAngle < 0) {
+                    targetAngle += 2*Math.PI;
+                }
+                ElkNode firstNode = (ElkNode) root.getOutgoingEdges().get(0).getTargets().get(0);
+                KVector firstVector = new KVector(firstNode.getX() + firstNode.getWidth() / 2, firstNode.getY() + firstNode.getHeight() / 2);
+                
+                double alignmentAngle = Math.atan2(firstVector.y, firstVector.x);
+                if (alignmentAngle < 0) {
+                    alignmentAngle += 2*Math.PI;
+                }
+                
+                targetAngle = Math.PI - (alignmentAngle - targetAngle + Math.PI);
+            } else {
+                ElkNode firstNode = (ElkNode) root.getOutgoingEdges().get(0).getTargets().get(0);
+                ElkNode secondNode = (ElkNode) root.getOutgoingEdges().get(1).getTargets().get(0);
+                KVector firstVector = new KVector(firstNode.getX() + firstNode.getWidth() / 2, firstNode.getY() + firstNode.getHeight() / 2);
+                KVector secondVector = new KVector(secondNode.getX() + secondNode.getWidth() / 2, secondNode.getY() + secondNode.getHeight() / 2);
+
+                double alpha = targetAngle;
+                if (alpha < 0) {
+                    alpha += 2*Math.PI;
+                }
+                
+                double wedgeAngle = firstVector.angle(secondVector);
+                if (wedgeAngle < 0) {
+                    wedgeAngle += 2*Math.PI;
+                }
+                
+                double alignmentAngle = Math.atan2(firstVector.y, firstVector.x);
+                if (alignmentAngle < 0) {
+                    alignmentAngle += 2*Math.PI;
+                }
+                
+                targetAngle = Math.PI - (alignmentAngle - alpha + wedgeAngle / 2);
+
+            }
+        }
+
+        // rotate all nodes around the origin, because the root node is positioned at the origin
+        // nodes are positioned with their center on the radius so use that for the rotation
+        for (ElkNode node : graph.getChildren()) {
+            KVector pos = new KVector(node.getX() + node.getWidth() / 2, node.getY() + node.getHeight() / 2);
+            pos.rotate(targetAngle);
+            node.setLocation(pos.x - node.getWidth() / 2, pos.y - node.getHeight() / 2);
+        }
+
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/rotation/GeneralRotator.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/rotation/GeneralRotator.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.radial.intermediate.rotation;
+
+import org.eclipse.elk.alg.radial.options.RadialOptions;
+import org.eclipse.elk.core.alg.ILayoutProcessor;
+import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.graph.ElkNode;
+
+/**
+ * The layout processor for rotation.
+ *
+ */
+public class GeneralRotator implements ILayoutProcessor<ElkNode> {
+    
+    @Override
+    public void process(final ElkNode graph, final IElkProgressMonitor progressMonitor) {
+        progressMonitor.begin("General 'Rotator", 1);
+        progressMonitor.logGraph(graph, "Before");
+        IRadialRotator rotator = graph.getProperty(RadialOptions.ROTATOR).create();
+        rotator.rotate(graph);
+        progressMonitor.logGraph(graph, "After");
+    }
+
+}

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/rotation/IRadialRotator.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/intermediate/rotation/IRadialRotator.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.radial.intermediate.rotation;
+
+import org.eclipse.elk.graph.ElkNode;
+
+/**
+ * An interface for rotating the radial layout.
+ *
+ */
+public interface IRadialRotator {
+    
+    /**
+     * Rotate the graph.
+     * 
+     * @param graph
+     *            The graph which is already radial.
+     */
+    void rotate(ElkNode graph);
+
+}

--- a/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/options/RotationStrategy.java
+++ b/plugins/org.eclipse.elk.alg.radial/src/org/eclipse/elk/alg/radial/options/RotationStrategy.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 
+ *******************************************************************************/
+package org.eclipse.elk.alg.radial.options;
+
+import org.eclipse.elk.alg.radial.intermediate.rotation.AngleRotation;
+import org.eclipse.elk.alg.radial.intermediate.rotation.IRadialRotator;
+
+/**
+ * The list of selectable rotation algorithms.
+ *
+ */
+public enum RotationStrategy {
+    
+    /** No rotation. **/
+    NONE,
+    /** Rotate to a given angle. */
+    ROTATE_TO_ANGLE;
+    
+    /**
+     * Instantiate the chosen rotation strategy.
+     * 
+     * @return A rotator.
+     */
+    public IRadialRotator create() {
+        switch (this) {
+        case ROTATE_TO_ANGLE:
+            return new AngleRotation();
+        default:
+            throw new IllegalArgumentException(
+                    "No implementation is available for the layout option " + this.toString());
+        }
+    }
+}

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/KVector.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/KVector.java
@@ -435,9 +435,19 @@ public final class KVector implements IDataObject, Cloneable {
      * @return the rotated vector
      */
     public KVector rotate(final double angle) {
-        this.x = this.x * Math.cos(angle) - this.y * Math.sin(angle);
-        this.y = this.y * Math.sin(angle) + this.y * Math.cos(angle);
+        double newX = this.x * Math.cos(angle) - this.y * Math.sin(angle);
+        this.y = this.x * Math.sin(angle) + this.y * Math.cos(angle);
+        this.x = newX;
         return this;
+    }
+    
+    /**
+     * Returns the angle between this vector and another given vector in radians.
+     * @param other
+     * @return angle between vectors
+     */
+    public double angle(KVector other) {
+        return Math.acos(this.dotProduct(other) / (this.length() * other.length()));
     }
 
     /**


### PR DESCRIPTION
Adds options to control the rotation of radial layouts. Particularly with top-down layout this can be used create fractal-like radial layouts such as balloon trees.

Example application:
![image](https://github.com/eclipse/elk/assets/10957098/21ba597e-bdb5-4818-85d8-41d2388ef0da)

also fixes a bug in the KVector rotation code and cleans up unused imports.