### PR TITLE
rename node placement to node arrangement and update references

### DIFF
--- a/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/INodeArranger.java
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/INodeArranger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Kiel University and others.
+ * Copyright (c) 2022 - 2023 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,9 +13,9 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.graph.ElkNode;
 
 /**
- * A node placer has to provide a size prediction without computing a layout.
+ * A node arranger has to provide a size prediction without computing a layout.
  */
-public interface INodePlacer {
+public interface INodeArranger {
     
     /**
      * Computes the predicted required size of the graph and returns it without computing a full layout.

--- a/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/LeftRightTopDownNodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/LeftRightTopDownNodePlacer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Kiel University and others.
+ * Copyright (c) 2022 - 2023 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,7 +25,7 @@ import org.eclipse.elk.graph.ElkNode;
  * Places nodes in a grid using the sizes provided by their parent node.
  *
  */
-public class LeftRightTopDownNodePlacer implements ILayoutPhase<TopdownPackingPhases, GridElkNode>, INodePlacer {
+public class LeftRightTopDownNodePlacer implements ILayoutPhase<TopdownPackingPhases, GridElkNode>, INodeArranger {
 
     /**
      * {@inheritDoc}

--- a/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/NodeArrangementStrategy.java
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/NodeArrangementStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Kiel University and others.
+ * Copyright (c) 2022 - 2023 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,10 +13,10 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.ILayoutPhaseFactory;
 
 /**
- * Node placement strategy to use during topdown packing algorithm.
+ * Node arrangement strategy to use during topdown packing algorithm.
  *
  */
-public enum NodePlacementStrategy implements ILayoutPhaseFactory<TopdownPackingPhases, GridElkNode> {
+public enum NodeArrangementStrategy implements ILayoutPhaseFactory<TopdownPackingPhases, GridElkNode> {
     /**
      * Places nodes from left to right, top to bottom in a grid.
      */

--- a/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/TopdownPackingPhases.java
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/TopdownPackingPhases.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Kiel University and others.
+ * Copyright (c) 2022 - 2023 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,9 +16,9 @@ package org.eclipse.elk.alg.topdownpacking;
 public enum TopdownPackingPhases {
 
     /**
-     * Place equally sized nodes where the size is defined by the parent.
+     * Arrange equally sized nodes where the size is defined by the parent.
      */
-    P1_NODE_PLACEMENT,
+    P1_NODE_ARRANGEMENT,
     
     /**
      * Eliminate white space by increasing the size of some nodes to fully fill the space provided by the parent. 

--- a/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/Topdownpacking.melk
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/Topdownpacking.melk
@@ -9,10 +9,10 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.topdownpacking
 
+import org.eclipse.elk.alg.topdownpacking.NodeArrangementStrategy
 import org.eclipse.elk.alg.topdownpacking.TopdownpackingLayoutProvider
-import org.eclipse.elk.core.options.TopdownNodeTypes
-import org.eclipse.elk.alg.topdownpacking.NodePlacementStrategy
 import org.eclipse.elk.alg.topdownpacking.WhitespaceEliminationStrategy
+import org.eclipse.elk.core.options.TopdownNodeTypes
 
 bundle {
     metadataClass options.TopdownpackingMetaDataProvider
@@ -34,16 +34,16 @@ algorithm topdownpacking(TopdownpackingLayoutProvider) {
     supports org.eclipse.elk.topdownLayout
     supports org.eclipse.elk.topdown.nodeType = TopdownNodeTypes.PARALLEL_NODE
     
-    supports nodePlacement.strategy
+    supports nodeArrangement.strategy
     supports whitespaceElimination.strategy
 }
 
-group nodePlacement {
+group nodeArrangement {
     
-    option strategy: NodePlacementStrategy {
-        label "Node placement strategy"
-        description "Strategy for node placement. The strategy determines the size of the resulting graph."
-        default = NodePlacementStrategy.LEFT_RIGHT_TOP_DOWN_NODE_PLACER
+    option strategy: NodeArrangementStrategy {
+        label "Node arrangement strategy"
+        description "Strategy for node arrangement. The strategy determines the size of the resulting graph."
+        default = NodeArrangementStrategy.LEFT_RIGHT_TOP_DOWN_NODE_PLACER
         targets parents
     }
 }

--- a/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/TopdownpackingLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/TopdownpackingLayoutProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Kiel University and others.
+ * Copyright (c) 2022 - 2023 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -54,8 +54,8 @@ public class TopdownpackingLayoutProvider extends AbstractLayoutProvider impleme
     public List<ILayoutProcessor<GridElkNode>> assembleAlgorithm(GridElkNode graph) {
         algorithmAssembler.reset();
         
-        algorithmAssembler.setPhase(TopdownPackingPhases.P1_NODE_PLACEMENT, 
-                graph.getProperty(TopdownpackingOptions.NODE_PLACEMENT_STRATEGY));
+        algorithmAssembler.setPhase(TopdownPackingPhases.P1_NODE_ARRANGEMENT, 
+                graph.getProperty(TopdownpackingOptions.NODE_ARRANGEMENT_STRATEGY));
         algorithmAssembler.setPhase(TopdownPackingPhases.P2_WHITESPACE_ELIMINATION, 
                 graph.getProperty(TopdownpackingOptions.WHITESPACE_ELIMINATION_STRATEGY));
         
@@ -68,7 +68,7 @@ public class TopdownpackingLayoutProvider extends AbstractLayoutProvider impleme
     @Override
     public KVector getPredictedGraphSize(ElkNode graph) {
         // FIXME: enforce that all node placement strategies implement INodePlacer
-        INodePlacer nodePlacer = (INodePlacer) graph.getProperty(TopdownpackingOptions.NODE_PLACEMENT_STRATEGY).create();
+        INodeArranger nodePlacer = (INodeArranger) graph.getProperty(TopdownpackingOptions.NODE_ARRANGEMENT_STRATEGY).create();
         return nodePlacer.getPredictedSize(graph);
     }
 }

--- a/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/WhitespaceEliminationStrategy.java
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/src/org/eclipse/elk/alg/topdownpacking/WhitespaceEliminationStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Kiel University and others.
+ * Copyright (c) 2022 - 2023 Kiel University and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at


### PR DESCRIPTION
Changes the word placement to arrangement.

fixes https://github.com/eclipse/elk/issues/947