### PR TITLE
libavoid bug fixes

### DIFF
--- a/plugins/org.eclipse.elk.alg.libavoid/pom.xml
+++ b/plugins/org.eclipse.elk.alg.libavoid/pom.xml
@@ -62,7 +62,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.3.0/libavoid-server-linux</url>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.3.1/libavoid-server-linux</url>
               <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
             </configuration>
           </execution>
@@ -73,7 +73,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.3.0/libavoid-server-macos</url>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.3.1/libavoid-server-macos</url>
               <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
             </configuration>
           </execution>
@@ -84,7 +84,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.3.0/libavoid-server-win.exe</url>
+              <url>https://github.com/TypeFox/libavoid-server/releases/download/v0.3.1/libavoid-server-win.exe</url>
               <outputDirectory>${project.basedir}/libavoid-server</outputDirectory>
             </configuration>
           </execution>

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidServerCommunicator.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidServerCommunicator.java
@@ -310,6 +310,11 @@ public class LibavoidServerCommunicator {
         	addOption(LibavoidOptions.DIRECTION, direction);
         }
 
+        boolean enableHyperedgesFromCommonSource =
+        		node.getProperty(LibavoidOptions.ENABLE_HYPEREDGES_FROM_COMMON_SOURCE);
+        addOption(LibavoidOptions.ENABLE_HYPEREDGES_FROM_COMMON_SOURCE,
+        		enableHyperedgesFromCommonSource);
+
         /*
          * Penalties
          */
@@ -384,11 +389,6 @@ public class LibavoidServerCommunicator {
         		node.getProperty(LibavoidOptions.NUDGE_SHARED_PATHS_WITH_COMMON_END_POINT);
         addRoutingOption(LibavoidOptions.NUDGE_SHARED_PATHS_WITH_COMMON_END_POINT,
         		nudgeSharedPathsWithCommonEndPoint);
-        
-        boolean enableHyperedgesFromCommonSource =
-        		node.getProperty(LibavoidOptions.ENABLE_HYPEREDGES_FROM_COMMON_SOURCE);
-        addRoutingOption(LibavoidOptions.ENABLE_HYPEREDGES_FROM_COMMON_SOURCE,
-        		enableHyperedgesFromCommonSource);
     }
 
     private void addOption(final IProperty<?> key, final Object value) {
@@ -609,13 +609,14 @@ public class LibavoidServerCommunicator {
 		libavoidNode(node, nodeIdCounter, 
 				x, y, node.getWidth(), node.getHeight(), 
 				portLessIncomingEdges, portLessOutgoingEdges);
-		nodeIdCounter++;
 		
 		// transfer all ports
 		for (ElkPort port : node.getPorts()) {
 			libavoidPort(port, portIdCounter, nodeIdCounter, null);
 			portIdCounter++;
 		}
+
+        nodeIdCounter++;
 	}
     
 	/**


### PR DESCRIPTION
Bug fixes:
- ports were given the wrong node id's (off-by-one error)
- the hyperedge option was added as a routing option despite being handled as a normal one by the server

Changes:
- updated the libavoid server to the newest version