### PR TITLE
rectpacking: Fix micro layout for rectpacking including content alignment and label placement.

### DIFF
--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPackingLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPackingLayoutProvider.java
@@ -58,6 +58,11 @@ public class RectPackingLayoutProvider extends AbstractLayoutProvider {
         boolean tryBox = layoutGraph.getProperty(RectPackingOptions.TRYBOX);
         List<ElkNode> rectangles = layoutGraph.getChildren();
         
+        // if requested, compute nodes's dimensions, place node labels, ports, port labels, etc.
+        if (!layoutGraph.getProperty(RectPackingOptions.OMIT_NODE_MICRO_LAYOUT)) {
+            NodeMicroLayout.forGraph(layoutGraph).execute();
+        }
+        
         // Check whether regions are stackable and do box layout instead.
         boolean stackable = false;
         if (tryBox && rectangles.size() >= 3) {
@@ -129,7 +134,7 @@ public class RectPackingLayoutProvider extends AbstractLayoutProvider {
                     layoutGraph.getProperty(InternalProperties.DRAWING_HEIGHT) + padding.getVertical(), false, true);
         }
 
-        // if requested, compute nodes's dimensions, place node labels, ports, port labels, etc.
+        // Do micro layout again since the whitspace elimination and other things might have changed node sizes.
         if (!layoutGraph.getProperty(RectPackingOptions.OMIT_NODE_MICRO_LAYOUT)) {
             NodeMicroLayout.forGraph(layoutGraph).execute();
         }

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPackingLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/RectPackingLayoutProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.elk.core.alg.AlgorithmAssembler;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.math.ElkPadding;
+import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.util.BasicProgressMonitor;
 import org.eclipse.elk.core.util.BoxLayoutProvider;
@@ -124,6 +125,20 @@ public class RectPackingLayoutProvider extends AbstractLayoutProvider {
             progressMonitor.logGraph(layoutGraph, slotIndex + "-Finished");
         }
         // elkjs-exclude-end
+        
+        // Content alignment
+        double realWidth = 0;
+        double realHeight = 0;
+        for (ElkNode rect : rectangles) {
+            realWidth = Math.max(realWidth, rect.getX() + rect.getWidth());
+            realHeight = Math.max(realHeight, rect.getY() + rect.getHeight());
+        }
+
+        ElkUtil.translate(layoutGraph,
+                new KVector(
+                        layoutGraph.getProperty(InternalProperties.DRAWING_WIDTH),
+                        layoutGraph.getProperty(InternalProperties.DRAWING_HEIGHT)),
+                new KVector(realWidth, realHeight));
 
         // Final touch.
         applyPadding(rectangles, padding);

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/intermediate/MinSizePostProcessor.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/intermediate/MinSizePostProcessor.java
@@ -15,7 +15,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.graph.ElkNode;
 
 /**
- * Sorts all child nodes by their desired position.
+ * Sets a target width at least as high as the minimum width of the parent
  * 
  * <dl>
  *   <dt>Precondition:</dt>

--- a/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/intermediate/MinSizePreProcessor.java
+++ b/plugins/org.eclipse.elk.alg.rectpacking/src/org/eclipse/elk/alg/rectpacking/intermediate/MinSizePreProcessor.java
@@ -17,7 +17,7 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.graph.ElkNode;
 
 /**
- * Sorts all child nodes by their desired position.
+ * Sets the minimum width and height of the parent since this influences decisions based on the aspect ratio.
  * 
  * <dl>
  *   <dt>Precondition:</dt>


### PR DESCRIPTION
Previously it was only done after because whitespace elimination might change node sizes. However, if the node size cannot fit the label, we need to do this before the layout too.

I suggest to maybe take a look at #989 and see whether this has the same reason. If both are fixed, I propose an elkjs only release for this fix.

Also fixes #996 