### PR TITLE
Remove all checkstyle natures from all projects.

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/.project
+++ b/plugins/org.eclipse.elk.alg.common/.project
@@ -41,6 +41,5 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.disco.debug/.project
+++ b/plugins/org.eclipse.elk.alg.disco.debug/.project
@@ -35,6 +35,5 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.disco/.project
+++ b/plugins/org.eclipse.elk.alg.disco/.project
@@ -41,6 +41,5 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.force/.project
+++ b/plugins/org.eclipse.elk.alg.force/.project
@@ -40,7 +40,6 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/.project
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/.project
@@ -41,6 +41,5 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/.project
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/.project
@@ -40,7 +40,6 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.layered/.project
+++ b/plugins/org.eclipse.elk.alg.layered/.project
@@ -40,7 +40,6 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.libavoid/.project
+++ b/plugins/org.eclipse.elk.alg.libavoid/.project
@@ -29,7 +29,6 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.mrtree/.project
+++ b/plugins/org.eclipse.elk.alg.mrtree/.project
@@ -40,7 +40,6 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.alg.spore/.project
+++ b/plugins/org.eclipse.elk.alg.spore/.project
@@ -41,6 +41,5 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.conn.gmf/.project
+++ b/plugins/org.eclipse.elk.conn.gmf/.project
@@ -40,7 +40,6 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.core.service/.project
+++ b/plugins/org.eclipse.elk.core.service/.project
@@ -35,6 +35,5 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.core.ui/.project
+++ b/plugins/org.eclipse.elk.core.ui/.project
@@ -35,6 +35,5 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.core/.project
+++ b/plugins/org.eclipse.elk.core/.project
@@ -40,7 +40,6 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.graph.json/.project
+++ b/plugins/org.eclipse.elk.graph.json/.project
@@ -41,6 +41,5 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.elk.graph/.project
+++ b/plugins/org.eclipse.elk.graph/.project
@@ -40,7 +40,6 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/test/org.eclipse.elk.alg.disco.test/.project
+++ b/test/org.eclipse.elk.alg.disco.test/.project
@@ -35,6 +35,5 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/test/org.eclipse.elk.alg.force.test/.project
+++ b/test/org.eclipse.elk.alg.force.test/.project
@@ -35,6 +35,5 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/test/org.eclipse.elk.alg.radial.test/.project
+++ b/test/org.eclipse.elk.alg.radial.test/.project
@@ -35,6 +35,5 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/test/org.eclipse.elk.alg.test/.project
+++ b/test/org.eclipse.elk.alg.test/.project
@@ -35,6 +35,5 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
The checkstyle annotations and the configuration still remain since they might be useful once we decide to reconfigure checkstyle.