### PR TITLE
Include padding when setting node sizes in top-down layout

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
@@ -252,8 +252,9 @@ public class RecursiveGraphLayoutEngine implements IGraphLayoutEngine {
                                 TopdownSizeApproximator approximator = 
                                         childNode.getProperty(CoreOptions.TOPDOWN_SIZE_APPROXIMATOR);
                                 KVector size = approximator.getSize(childNode);
-                                childNode.setDimensions(Math.max(childNode.getWidth(), size.x),
-                                        Math.max(childNode.getHeight(), size.y));
+                                ElkPadding padding = childNode.getProperty(CoreOptions.PADDING);
+                                childNode.setDimensions(Math.max(childNode.getWidth(), size.x + padding.left + padding.right),
+                                        Math.max(childNode.getHeight(), size.y + padding.top + padding.bottom));
                             }
                         }
                     }


### PR DESCRIPTION
This fixes a problem where the available child area would become negative if the estimated node size was very small because padding was neglected