### PR TITLE
update setup-java version

### DIFF
--- a/.github/workflows/elkjs.yml
+++ b/.github/workflows/elkjs.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: ${{ runner.os }}-node-
     # elkjs (or rather GWT) requires Java 1.8
     - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
This PR contains only the commit that still built elkjs correctly. https://github.com/eclipse/elk/actions/runs/9745969746/job/26895171275

The actions for this PR fail: https://github.com/eclipse/elk/actions/runs/9757883557/job/26931234022?pr=1049

I cannot reproduce this locally and the problem appears to have spontaneously appeared in Github Actions