### PR TITLE
Fix always existing bug in model order port sorting.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -10,7 +10,9 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -78,10 +80,11 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                 }
             }
             // Sort nodes.
-            Collections.sort(layer.getNodes(),
-                    new ModelOrderNodeComparator(previousLayer,
-                            graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
-                            graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY)));
+            ModelOrderNodeComparator comparator = new ModelOrderNodeComparator(previousLayer,
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
+            SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
+                    
             progressMonitor.log("Layer " + layerIndex + ": " + layer);
             layerIndex++;
         }
@@ -140,6 +143,21 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             }
         } while (node != null && node.getType() != NodeType.NORMAL);
         return node;
+    }
+    
+    public static void insertionSort(final List<LNode> layer,
+            final ModelOrderNodeComparator comparator) {
+        LNode temp;
+        for (int i = 1; i < layer.size(); i++) {
+            temp = layer.get(i);
+            int j = i;
+            while (j > 0 && comparator.compare(layer.get(j - 1), temp) > 0) {
+                layer.set(j, layer.get(j - 1));
+                j--;
+            }
+            layer.set(j, temp);
+        }
+        comparator.clearTransitiveOrdering();
     }
 }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -10,7 +10,6 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             ModelOrderNodeComparator comparator = new ModelOrderNodeComparator(previousLayer,
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
-            SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
+            Collections.sort(layer.getNodes(), comparator);
             for (LNode node : layer.getNodes()) {
                 if (node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_ORDER
                         && node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_POS) {
@@ -83,11 +82,6 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                     progressMonitor.log("Node " + node + " ports: " + node.getPorts());
                 }
             }
-            // Sort nodes.
-            comparator = new ModelOrderNodeComparator(previousLayer,
-                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
-                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
-            SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
                     
             progressMonitor.log("Layer " + layerIndex + ": " + layer);
             layerIndex++;
@@ -152,6 +146,21 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
     public static void insertionSort(final List<LNode> layer,
             final ModelOrderNodeComparator comparator) {
         LNode temp;
+        for (int i = 1; i < layer.size(); i++) {
+            temp = layer.get(i);
+            int j = i;
+            while (j > 0 && comparator.compare(layer.get(j - 1), temp) > 0) {
+                layer.set(j, layer.get(j - 1));
+                j--;
+            }
+            layer.set(j, temp);
+        }
+        comparator.clearTransitiveOrdering();
+    }
+    
+    public static void insertionSortPort(final List<LPort> layer,
+            final ModelOrderPortComparator comparator) {
+        LPort temp;
         for (int i = 1; i < layer.size(); i++) {
             temp = layer.get(i);
             int j = i;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -82,6 +82,11 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                     progressMonitor.log("Node " + node + " ports: " + node.getPorts());
                 }
             }
+            // Sort nodes after port sorting to also sort dummy feedback nodes from the current layer correctly.
+            comparator = new ModelOrderNodeComparator(previousLayer,
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
+            Collections.sort(layer.getNodes(), comparator);
                     
             progressMonitor.log("Layer " + layerIndex + ": " + layer);
             layerIndex++;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -75,7 +75,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                     // Therefore all ports that connect to the same node should have the same
                     // (their minimal) model order.
                     // Get minimal model order for target node
-                    insertionSortPorts(node.getPorts(),
+                    Collections.sort(node.getPorts(),
                             new ModelOrderPortComparator(previousLayer,
                                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
                                     longEdgeTargetNodePreprocessing(node),
@@ -160,21 +160,6 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                 j--;
             }
             layer.set(j, temp);
-        }
-        comparator.clearTransitiveOrdering();
-    }
-    
-    public static void insertionSortPorts(final List<LPort> ports,
-            final ModelOrderPortComparator comparator) {
-        LPort temp;
-        for (int i = 1; i < ports.size(); i++) {
-            temp = ports.get(i);
-            int j = i;
-            while (j > 0 && comparator.compare(ports.get(j - 1), temp) > 0) {
-                ports.set(j, ports.get(j - 1));
-                j--;
-            }
-            ports.set(j, temp);
         }
         comparator.clearTransitiveOrdering();
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -64,7 +64,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             // Sort nodes before port sorting to have sorted nodes for in-layer feedback edge dummies.
             ModelOrderNodeComparator comparator = new ModelOrderNodeComparator(previousLayer,
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
-                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY), true);
             SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
             for (LNode node : layer.getNodes()) {
                 if (node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_ORDER
@@ -85,7 +85,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             // Sort nodes after port sorting to also sort dummy feedback nodes from the current layer correctly.
             comparator = new ModelOrderNodeComparator(previousLayer,
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
-                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY), false);
             SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
                     
             progressMonitor.log("Layer " + layerIndex + ": " + layer);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -70,8 +70,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                     // Therefore all ports that connect to the same node should have the same
                     // (their minimal) model order.
                     // Get minimal model order for target node
-                    
-                    Collections.sort(node.getPorts(),
+                    insertionSortPorts(node.getPorts(),
                             new ModelOrderPortComparator(previousLayer,
                                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
                                     longEdgeTargetNodePreprocessing(node),
@@ -156,6 +155,21 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                 j--;
             }
             layer.set(j, temp);
+        }
+        comparator.clearTransitiveOrdering();
+    }
+    
+    public static void insertionSortPorts(final List<LPort> ports,
+            final ModelOrderPortComparator comparator) {
+        LPort temp;
+        for (int i = 1; i < ports.size(); i++) {
+            temp = ports.get(i);
+            int j = i;
+            while (j > 0 && comparator.compare(ports.get(j - 1), temp) > 0) {
+                ports.set(j, ports.get(j - 1));
+                j--;
+            }
+            ports.set(j, temp);
         }
         comparator.clearTransitiveOrdering();
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -62,6 +62,11 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             layer.id = layerIndex;
             final int previousLayerIndex = layerIndex == 0 ? 0 : layerIndex - 1;
             Layer previousLayer = graph.getLayers().get(previousLayerIndex);
+            // Sort nodes before port sorting to have sorted nodes for in-layer feedback edge dummies.
+            ModelOrderNodeComparator comparator = new ModelOrderNodeComparator(previousLayer,
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
+                    graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
+            SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
             for (LNode node : layer.getNodes()) {
                 if (node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_ORDER
                         && node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_POS) {
@@ -79,7 +84,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                 }
             }
             // Sort nodes.
-            ModelOrderNodeComparator comparator = new ModelOrderNodeComparator(previousLayer,
+            comparator = new ModelOrderNodeComparator(previousLayer,
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
             SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -65,7 +65,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             ModelOrderNodeComparator comparator = new ModelOrderNodeComparator(previousLayer,
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
-            Collections.sort(layer.getNodes(), comparator);
+            SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
             for (LNode node : layer.getNodes()) {
                 if (node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_ORDER
                         && node.getProperty(LayeredOptions.PORT_CONSTRAINTS) != PortConstraints.FIXED_POS) {
@@ -86,7 +86,7 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
             comparator = new ModelOrderNodeComparator(previousLayer,
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY),
                     graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_LONG_EDGE_STRATEGY));
-            Collections.sort(layer.getNodes(), comparator);
+            SortByInputModelProcessor.insertionSort(layer.getNodes(), comparator);
                     
             progressMonitor.log("Layer " + layerIndex + ": " + layer);
             layerIndex++;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/SortByInputModelProcessor.java
@@ -55,6 +55,9 @@ public class SortByInputModelProcessor implements ILayoutProcessor<LGraph> {
                 + graph.getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY), 1);
         int layerIndex = 0;
         for (Layer layer : graph) {
+            // The layer.id is necessary to check whether nodes really connect to the previous layer.
+            // Feedback long edge dummies do might have a long-edge dummy in the same layer.
+            layer.id = layerIndex;
             final int previousLayerIndex = layerIndex == 0 ? 0 : layerIndex - 1;
             Layer previousLayer = graph.getLayers().get(previousLayerIndex);
             for (LNode node : layer.getNodes()) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
@@ -53,6 +53,11 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
     private LongEdgeOrderingStrategy longEdgeNodeOrder = LongEdgeOrderingStrategy.EQUAL;
     
     /**
+     * Whether the node comparator was called before ports.
+     */
+    private boolean beforePorts;
+    
+    /**
      * Creates a comparator to compare {@link LNode}s in the same layer.
      * 
      * @param thePreviousLayer The previous layer
@@ -60,8 +65,8 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
      * @param longEdgeOrderingStrategy The strategy to order dummy nodes and nodes with no connection the previous layer
      */
     public ModelOrderNodeComparator(final Layer thePreviousLayer, final OrderingStrategy orderingStrategy,
-            final LongEdgeOrderingStrategy longEdgeOrderingStrategy) {
-        this(orderingStrategy, longEdgeOrderingStrategy);
+            final LongEdgeOrderingStrategy longEdgeOrderingStrategy, boolean beforePorts) {
+        this(orderingStrategy, longEdgeOrderingStrategy, beforePorts);
         this.previousLayer = new LNode[thePreviousLayer.getNodes().size()];
         thePreviousLayer.getNodes().toArray(this.previousLayer);
     }
@@ -74,15 +79,16 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
      * @param longEdgeOrderingStrategy The strategy to order dummy nodes and nodes with no connection the previous layer
      */
     public ModelOrderNodeComparator(final LNode[] previousLayer, final OrderingStrategy orderingStrategy,
-            final LongEdgeOrderingStrategy longEdgeOrderingStrategy) {
-        this(orderingStrategy, longEdgeOrderingStrategy);
+            final LongEdgeOrderingStrategy longEdgeOrderingStrategy, boolean beforePorts) {
+        this(orderingStrategy, longEdgeOrderingStrategy, beforePorts);
         this.previousLayer = previousLayer;
     }
     
     private ModelOrderNodeComparator(final OrderingStrategy orderingStrategy,
-            final LongEdgeOrderingStrategy longEdgeOrderingStrategy) {
+            final LongEdgeOrderingStrategy longEdgeOrderingStrategy, boolean beforePorts) {
         this.orderingStrategy = orderingStrategy;
         this.longEdgeNodeOrder = longEdgeOrderingStrategy;
+        this.beforePorts = beforePorts;
     }
 
     @Override
@@ -204,10 +210,10 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
                     int n2ModelOrder = getModelOrderFromConnectedEdges(n2);
                     if (n1ModelOrder > n2ModelOrder) {
                         updateBiggerAndSmallerAssociations(n1, n2);
-                        return -1;
+                        return 1;
                     } else {
                         updateBiggerAndSmallerAssociations(n2, n1);
-                        return 1;
+                        return -1;
                     }
                 }
             }
@@ -265,8 +271,8 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
                 return edge.getProperty(InternalProperties.MODEL_ORDER);
             }
         }
-        // Set to -1 to sort dummy nodes under nodes without a connection to the previous layer.
         // Set to MAX_INT to sort dummy nodes over nodes without a connection to the previous layer.
+        // Set to -MAX_INT to sort dummy nodes under nodes without a connection to the previous layer.
         // Set to 0 if you do not care about their order.
         // One of this has to be chosen, since dummy nodes are not comparable with nodes
         // that do not have a connection to the previous layer.
@@ -296,18 +302,24 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
     
     private int handleHelperDummyNodes(LNode n1, LNode n2) {
         if (n1.getType() == NodeType.LONG_EDGE && n2.getType() == NodeType.NORMAL) {
-            // n1 is a long edge node feedback node.
+            // n1 could be a long edge node feedback node.
             
             LPort dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n1);
             LNode dummyNodeSourceNode = dummyNodeSourcePort.getNode();
+            LPort dummyNodeTargetPort = getFirstOutgoingTargetPortOfNode(n1);
+            LNode dummyNodeTargetNode = dummyNodeTargetPort.getNode();
+            int dummyLayerId = n1.getLayer().id;
+            
+            // Check whether the dummy node is feedback source or feedback target if not return.
+            if (dummyNodeSourceNode.getLayer().id != dummyLayerId && dummyNodeTargetNode.getLayer().id != dummyLayerId) {
+                return 0;
+            }
             // Case the source of the dummy is the same node as n2, than the dummy node is routed below.
             if (dummyNodeSourceNode.equals(n2)) {
                 updateBiggerAndSmallerAssociations(n1, n2);
                 return 1;
             } else {
                 // Calculate whether the dummy node leads to the target node.
-                LPort dummyNodeTargetPort = getFirstOutgoingSourcePortOfNode(n1);
-                LNode dummyNodeTargetNode = dummyNodeTargetPort.getNode();
                 if (dummyNodeTargetNode.equals(n2)) {
                     updateBiggerAndSmallerAssociations(n1, n2);
                     return 1;
@@ -317,17 +329,23 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
                 return this.compare(dummyNodeSourceNode, n2);
             }
         } else if (n1.getType() == NodeType.NORMAL && n2.getType() == NodeType.LONG_EDGE) {
-            // n2 is a long edge node feedback node.
+            // n2 could be a long edge node feedback node.
             LPort dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n2);
             LNode dummyNodeSourceNode = dummyNodeSourcePort.getNode();
+            LPort dummyNodeTargetPort = getFirstOutgoingTargetPortOfNode(n2);
+            LNode dummyNodeTargetNode = dummyNodeTargetPort.getNode();
+            int dummyLayerId = n1.getLayer().id;
+            
+            // Check whether the dummy node is feedback source or feedback target if not return.
+            if (dummyNodeSourceNode.getLayer().id != dummyLayerId && dummyNodeTargetNode.getLayer().id != dummyLayerId) {
+                return 0;
+            }
             // Case the source of the dummy is the same node as n2, than the dummy node is routed below.
             if (dummyNodeSourceNode.equals(n1)) {
                 updateBiggerAndSmallerAssociations(n2, n1);
                 return -1;
             } else {
                 // Calculate whether the dummy node leads to the target node.
-                LPort dummyNodeTargetPort = getFirstOutgoingSourcePortOfNode(n2);
-                LNode dummyNodeTargetNode = dummyNodeTargetPort.getNode();
                 if (dummyNodeTargetNode.equals(n1)) {
                     updateBiggerAndSmallerAssociations(n2, n1);
                     return -1;
@@ -337,41 +355,101 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
                 return this.compare(n1, dummyNodeSourceNode);
             }
         } else if (n1.getType() == NodeType.LONG_EDGE && n2.getType() == NodeType.LONG_EDGE) {
-            // both are long edge feedback nodes.
+            // One of these edges is a feedback edge. This has to be the case since at least one of them is not connected
+            // to the previous layer.
+            // If only one is a long edge feedback node, I have a problem since these are not comparable.
+            // I must find the reference node in the current layer of each edge and use it instead.
             LPort n1dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n1);
+            LPort n1dummyNodeTargetPort = getFirstOutgoingTargetPortOfNode(n1);
+            LNode n1dummySourceNode = n1dummyNodeSourcePort.getNode();
+            LNode n1dummyTargetNode = n1dummyNodeTargetPort.getNode();
+            int n1LayerId = n1.getLayer().id;
+            boolean n1SourceFeedbackNode = false;
+            boolean n1TargetFeedbackNode = false;
+            
             LPort n2dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n2);
-            // Case both are on the same node, sort them in reverse order of their ports.
-            if (n1dummyNodeSourcePort.getNode().equals(n2dummyNodeSourcePort.getNode())) {
-                // Find the first port that occurs on the node. Since it has to be a WEST port (check this) reverse
-                // the order.
-                for (LPort port : n1dummyNodeSourcePort.getNode().getPorts()) {
-                    if (n1dummyNodeSourcePort.equals(port)) {
+            LPort n2dummyNodeTargetPort = getFirstOutgoingTargetPortOfNode(n2);
+            LNode n2dummySourceNode = n2dummyNodeSourcePort.getNode();
+            LNode n2dummyTargetNode = n2dummyNodeTargetPort.getNode();
+            int n2LayerId = n2.getLayer().id;
+            boolean n2SourceFeedbackNode = false;
+            boolean n2TargetFeedbackNode = false;
+            
+            LNode n1ReferenceNode = n1;
+            LNode n2ReferenceNode = n2;
+            if (n1dummySourceNode.getLayer().id == n1LayerId) {
+                // This means that n1dummySourceNode is the reference node that we need to consider for ordering n1;
+                n1SourceFeedbackNode = true;
+                n1ReferenceNode = n1dummySourceNode;
+            } else if (n1dummyTargetNode.getLayer().id == n1LayerId) {
+                // This means that n1dummyNodeTargetPort is the reference node that we need to consider for ordering n1;
+                n1TargetFeedbackNode = true;
+                n1ReferenceNode = n1dummyTargetNode;
+            }
+            if (n2dummySourceNode.getLayer().id == n2LayerId) {
+                // This means that n2dummySourceNode is the reference node that we need to consider for ordering n2;
+                n2SourceFeedbackNode = true;
+                n2ReferenceNode = n2dummySourceNode;
+            } else if (n2dummyTargetNode.getLayer().id == n2LayerId) {
+                // This means that n2dummyNodeTargetPort is the reference node that we need to consider for ordering n2;
+                n2TargetFeedbackNode = true;
+                n2ReferenceNode = n2dummyTargetNode;
+            }
+            
+            // After this each reference node should be a real node in this layer that I can use to compare n1 and n2.
+            
+            // Case both are on the same node.
+            if (n1ReferenceNode.equals(n2ReferenceNode)) {
+                // Find the first port that occurs on the node.
+                // Since we have a feedback node, we need to reverse the decision.
+                // If the side we connect to is WEST. we also have to reverse the decision.
+                // This may be a problem since here the node comparator depends on the port order in the same layer.
+                if (this.beforePorts) {
+                    // The order on the reference node ports may just be wrong since the ports are not yet sorted.
+                    // If both reference nodes are source feedback nodes, then the model order (considering reversing) does the trick.
+                    // If one is source one is target, I will just order them but it will always create a crossing.
+                    // If both are target, I should not have this problem and can never be here, since these nodes
+                    // should have a previous layer node.
+                    if (n1SourceFeedbackNode && n2SourceFeedbackNode) {
+                        int returnValue = new ModelOrderPortComparator(previousLayer, orderingStrategy, null, n2TargetFeedbackNode)
+                            .compare(n1dummyNodeSourcePort, n2dummyNodeSourcePort);
+                        if (returnValue > 0) {
+                            updateBiggerAndSmallerAssociations(n2, n1);
+                            return 1;
+                        } else {
+                            updateBiggerAndSmallerAssociations(n1, n2);
+                            return -1;
+                        }
+                    } else if (n1SourceFeedbackNode && n2TargetFeedbackNode) {
                         updateBiggerAndSmallerAssociations(n2, n1);
-                        return -1;
-                    } else if (n2dummyNodeSourcePort.equals(port)) {
-                        updateBiggerAndSmallerAssociations(n1, n2);
                         return 1;
+                    } else if (n1TargetFeedbackNode && n2SourceFeedbackNode) {
+                        updateBiggerAndSmallerAssociations(n1, n2);
+                        return -1;
+                    } else if (n1TargetFeedbackNode && n2TargetFeedbackNode) {
+                        // In this case, there must be incoming edges that can be used for ordering.
+                        return 0;
+                    }
+                } else {
+                    // In this case, the order of the ports can just be used.
+                    // Since the order of WEST ports is reversed and the order for feedback edges connecting to WEST
+                    // ports is reversed, I may just do nothing here.
+                    for (LPort port : n1ReferenceNode.getPorts()) {
+                        if (n1dummyNodeSourcePort.equals(port)) {
+                            updateBiggerAndSmallerAssociations(n2, n1);
+                            return -1;
+                        } else if (n2dummyNodeSourcePort.equals(port)) {
+                            updateBiggerAndSmallerAssociations(n1, n2);
+                            return 1;
+                        }
                     }
                 }
             }
             
-            // Case both edges connect to separate nodes.
-            // In this case compare the order of their nodes in their layer.
-            LNode n1dummyNodeSourceNode = n1dummyNodeSourcePort.getNode();
-            LNode n2dummyNodeSourceNode = n2dummyNodeSourcePort.getNode();
-            Layer dummySourceLayer = n1dummyNodeSourceNode.getLayer();
-            // Find the first node that occurs in the layer and order the nodes in reverse.
-            for (LNode node : dummySourceLayer) {
-                if (n1dummyNodeSourceNode.equals(node)) {
-                    updateBiggerAndSmallerAssociations(n2, n1);
-                    return -1;
-                } else if (n2dummyNodeSourceNode.equals(node)) {
-                    updateBiggerAndSmallerAssociations(n1, n2);
-                    return 1;
-                }
-            }
-            // This cannot occur.
-            return 0;
+            // If the nodes are different, just compare them since one should be a normal non-feedback dummy now.
+            // Worst case would be that one is a dummy and one a normal dangling node, where this would just create a 
+            // static ordering.
+            return this.compare(n1ReferenceNode, n2ReferenceNode);
         } else {
             // These nodes are just two normal nodes and need to be handled by node model order.
             return 0;
@@ -415,7 +493,7 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
      * @param node The node
      * @return The target port of the first outgoing port.
      */
-    private LPort getFirstOutgoingSourcePortOfNode(LNode node) {
+    private LPort getFirstOutgoingTargetPortOfNode(LNode node) {
         return getFirstOutgoingPortOfNode(node).getOutgoingEdges().get(0).getTarget();
     }
     

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
@@ -213,16 +213,20 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
         }
         // Order nodes by their order in the model.
         // This is also the fallback case if one of the nodes is not connected to the previous layer.
-        int n1ModelOrder = n1.getProperty(InternalProperties.MODEL_ORDER);
-        int n2ModelOrder = n2.getProperty(InternalProperties.MODEL_ORDER);
-        if (n1ModelOrder > n2ModelOrder) {
-            updateBiggerAndSmallerAssociations(n1, n2);
+        if (n1.hasProperty(InternalProperties.MODEL_ORDER) && n2.hasProperty(InternalProperties.MODEL_ORDER)) {
+            int n1ModelOrder = n1.getProperty(InternalProperties.MODEL_ORDER);
+            int n2ModelOrder = n2.getProperty(InternalProperties.MODEL_ORDER);
+            if (n1ModelOrder > n2ModelOrder) {
+                updateBiggerAndSmallerAssociations(n1, n2);
+            } else {
+                updateBiggerAndSmallerAssociations(n2, n1);
+            }
+            return Integer.compare(
+                    n1ModelOrder,
+                    n2ModelOrder);
         } else {
-            updateBiggerAndSmallerAssociations(n2, n1);
+            return 0;
         }
-        return Integer.compare(
-                n1ModelOrder,
-                n2ModelOrder);
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
@@ -180,6 +180,11 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
                 // Check whether one of them is a helper dummy node.
                 int comparedWithLongEdgeFeedback = handleHelperDummyNodes(n1, n2);
                 if (comparedWithLongEdgeFeedback != 0) {
+                    if (comparedWithLongEdgeFeedback > 0) {
+                        updateBiggerAndSmallerAssociations(n1, n2);
+                    } else {
+                        updateBiggerAndSmallerAssociations(n2, n1);
+                    }
                     return comparedWithLongEdgeFeedback;
                 }
                 
@@ -203,6 +208,11 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
                 // Check whether one of them is a helper dummy node.
                 int comparedWithLongEdgeFeedback = handleHelperDummyNodes(n1, n2);
                 if (comparedWithLongEdgeFeedback != 0) {
+                    if (comparedWithLongEdgeFeedback > 0) {
+                        updateBiggerAndSmallerAssociations(n1, n2);
+                    } else {
+                        updateBiggerAndSmallerAssociations(n2, n1);
+                    }
                     return comparedWithLongEdgeFeedback;
                 }
             }
@@ -218,12 +228,11 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
             int n2ModelOrder = n2.getProperty(InternalProperties.MODEL_ORDER);
             if (n1ModelOrder > n2ModelOrder) {
                 updateBiggerAndSmallerAssociations(n1, n2);
+                return 1;
             } else {
                 updateBiggerAndSmallerAssociations(n2, n1);
+                return -1;
             }
-            return Integer.compare(
-                    n1ModelOrder,
-                    n2ModelOrder);
         } else {
             return 0;
         }
@@ -371,5 +380,13 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
     
     private LPort getFirstOutgoingSourcePortOfNode(LNode node) {
         return getFirstOutgoingPortOfNode(node).getOutgoingEdges().get(0).getTarget();
+    }
+    
+    /**
+     * Clears the transitive ordering.
+     */
+    public void clearTransitiveOrdering() {
+        this.biggerThan = new HashMap<>();
+        this.smallerThan = new HashMap<>();
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.graph.Layer;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
@@ -175,23 +176,43 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
             }
             
             // One node has no source port
-            if (!n1.hasProperty(InternalProperties.MODEL_ORDER) || !n2.hasProperty(InternalProperties.MODEL_ORDER)) {
-                int n1ModelOrder = getModelOrderFromConnectedEdges(n1);
-                int n2ModelOrder = getModelOrderFromConnectedEdges(n2);
-                if (n1ModelOrder > n2ModelOrder) {
-                    updateBiggerAndSmallerAssociations(n1, n2);
-                } else {
-                    updateBiggerAndSmallerAssociations(n2, n1);
+            if (p1SourcePort != null && p2SourcePort == null || p1SourcePort == null && p2SourcePort != null) {
+                // Check whether one of them is a helper dummy node.
+                int comparedWithLongEdgeFeedback = handleHelperDummyNodes(n1, n2);
+                if (comparedWithLongEdgeFeedback != 0) {
+                    return comparedWithLongEdgeFeedback;
                 }
-                return Integer.compare(
-                        n1ModelOrder,
-                        n2ModelOrder);
+                
+                // Otherwise use the model order of the connected edges if one of them is no dummy node.
+                if (!n1.hasProperty(InternalProperties.MODEL_ORDER) || !n2.hasProperty(InternalProperties.MODEL_ORDER)) {
+                    int n1ModelOrder = getModelOrderFromConnectedEdges(n1);
+                    int n2ModelOrder = getModelOrderFromConnectedEdges(n2);
+                    if (n1ModelOrder > n2ModelOrder) {
+                        updateBiggerAndSmallerAssociations(n1, n2);
+                    } else {
+                        updateBiggerAndSmallerAssociations(n2, n1);
+                    }
+                    return Integer.compare(
+                            n1ModelOrder,
+                            n2ModelOrder);
+                }
             }
+
+            // Both nodes are not connected to the previous layer
+            if (p1SourcePort == null && p2SourcePort == null) {
+                // Check whether one of them is a helper dummy node.
+                int comparedWithLongEdgeFeedback = handleHelperDummyNodes(n1, n2);
+                if (comparedWithLongEdgeFeedback != 0) {
+                    return comparedWithLongEdgeFeedback;
+                }
+            }
+            
             // Fall through case.
             // Both nodes are not connected to the previous layer. Therefore, they must be normal nodes.
             // The model order shall be used to order them.
         }
         // Order nodes by their order in the model.
+        // This is also the fallback case if one of the nodes is not connected to the previous layer.
         int n1ModelOrder = n1.getProperty(InternalProperties.MODEL_ORDER);
         int n2ModelOrder = n2.getProperty(InternalProperties.MODEL_ORDER);
         if (n1ModelOrder > n2ModelOrder) {
@@ -246,5 +267,105 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
             biggerThan.get(veryBig).add(smaller);
             biggerThan.get(veryBig).addAll(smallerNodeBiggerThan);
         }
+    }
+    
+    private int handleHelperDummyNodes(LNode n1, LNode n2) {
+        if (n1.getType() == NodeType.LONG_EDGE && n2.getType() == NodeType.NORMAL) {
+            // n1 is a long edge node feedback node.
+            
+            LPort dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n1);
+            LNode dummyNodeSourceNode = dummyNodeSourcePort.getNode();
+            // Case the source of the dummy is the same node as n2, than the dummy node is routed below.
+            if (dummyNodeSourceNode.equals(n2)) {
+                updateBiggerAndSmallerAssociations(n1, n2);
+                return 1;
+            } else {
+                // Calculate whether the dummy node leads to the target node.
+                LPort dummyNodeTargetPort = getFirstOutgoingSourcePortOfNode(n1);
+                LNode dummyNodeTargetNode = dummyNodeTargetPort.getNode();
+                if (dummyNodeTargetNode.equals(n2)) {
+                    updateBiggerAndSmallerAssociations(n1, n2);
+                    return 1;
+                }
+                
+                // If the two nodes are not the same, order them based on the source model order.
+                return this.compare(dummyNodeSourceNode, n2);
+            }
+        } else if (n1.getType() == NodeType.NORMAL && n2.getType() == NodeType.LONG_EDGE) {
+            // n2 is a long edge node feedback node.
+            LPort dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n2);
+            LNode dummyNodeSourceNode = dummyNodeSourcePort.getNode();
+            // Case the source of the dummy is the same node as n2, than the dummy node is routed below.
+            if (dummyNodeSourceNode.equals(n1)) {
+                updateBiggerAndSmallerAssociations(n2, n1);
+                return -1;
+            } else {
+                // Calculate whether the dummy node leads to the target node.
+                LPort dummyNodeTargetPort = getFirstOutgoingSourcePortOfNode(n2);
+                LNode dummyNodeTargetNode = dummyNodeTargetPort.getNode();
+                if (dummyNodeTargetNode.equals(n1)) {
+                    updateBiggerAndSmallerAssociations(n2, n1);
+                    return 1;
+                }
+                
+                // If the two nodes are not the same, order them based on the source model order.
+                return this.compare(n1, dummyNodeSourceNode);
+            }
+        } else if (n1.getType() == NodeType.LONG_EDGE && n2.getType() == NodeType.LONG_EDGE) {
+            // both are long edge feedback nodes.
+            LPort n1dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n1);
+            LPort n2dummyNodeSourcePort = getFirstIncomingSourcePortOfNode(n2);
+            // Case both are on the same node, sort them in reverse order of their ports.
+            if (n1dummyNodeSourcePort.getNode().equals(n2dummyNodeSourcePort.getNode())) {
+                // Find the first port that occurs on the node. Since it has to be a WEST port (check this) reverse
+                // the order.
+                for (LPort port : n1dummyNodeSourcePort.getNode().getPorts()) {
+                    if (n1dummyNodeSourcePort.equals(port)) {
+                        updateBiggerAndSmallerAssociations(n2, n1);
+                        return -1;
+                    } else if (n2dummyNodeSourcePort.equals(port)) {
+                        updateBiggerAndSmallerAssociations(n1, n2);
+                        return 1;
+                    }
+                }
+            }
+            
+            // Case both edges connect to separate nodes.
+            // In this case comapare the order of their nodes in their layer.
+            LNode n1dummyNodeSourceNode = n1dummyNodeSourcePort.getNode();
+            LNode n2dummyNodeSourceNode = n2dummyNodeSourcePort.getNode();
+            Layer dummySourceLayer = n1dummyNodeSourceNode.getLayer();
+            // Find the first node that occurs in the layer and order the nodes in reverse.
+            for (LNode node : dummySourceLayer) {
+                if (n1dummyNodeSourceNode.equals(node)) {
+                    updateBiggerAndSmallerAssociations(n2, n1);
+                    return -1;
+                } else if (n2dummyNodeSourceNode.equals(node)) {
+                    updateBiggerAndSmallerAssociations(n1, n2);
+                    return 1;
+                }
+            }
+            // This cannot occur.
+            return 0;
+        } else {
+            // These nodes are just two normal nodes
+            return 0;
+        }
+    }
+    
+    private LPort getFirstIncomingPortOfNode(LNode node) {
+        return node.getPorts().stream().filter(p -> !p.getIncomingEdges().isEmpty()).findFirst().orElse(null);
+    }
+    
+    private LPort getFirstIncomingSourcePortOfNode(LNode node) {
+        return getFirstIncomingPortOfNode(node).getIncomingEdges().get(0).getSource();
+    }
+    
+    private LPort getFirstOutgoingPortOfNode(LNode node) {
+        return node.getPorts().stream().filter(p -> !p.getOutgoingEdges().isEmpty()).findFirst().orElse(null);
+    }
+    
+    private LPort getFirstOutgoingSourcePortOfNode(LNode node) {
+        return getFirstOutgoingPortOfNode(node).getOutgoingEdges().get(0).getTarget();
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderNodeComparator.java
@@ -117,7 +117,7 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
             for (LPort p : n1.getPorts()) {
                 // Get the first port that actually connects to a previous layer.
                 if (!p.getIncomingEdges().isEmpty()) {
-                    if (p.getIncomingEdges().get(0).getSource().getNode().getLayer() != n1.getLayer()) {
+                    if (p.getIncomingEdges().get(0).getSource().getNode().getLayer().id == (n1.getLayer().id - 1)) {
                         p1SourcePort = p.getIncomingEdges().get(0).getSource();
                     }
                 }
@@ -127,7 +127,7 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
             for (LPort p : n2.getPorts()) {
                 // Get the first port that actually connects to a previous layer.
                 if (!p.getIncomingEdges().isEmpty()) {
-                    if (p.getIncomingEdges().get(0).getSource().getNode().getLayer() != n2.getLayer()) {
+                    if (p.getIncomingEdges().get(0).getSource().getNode().getLayer().id == (n2.getLayer().id - 1)) {
                         p2SourcePort = p.getIncomingEdges().get(0).getSource();
                     }
                 }
@@ -318,7 +318,7 @@ public class ModelOrderNodeComparator implements Comparator<LNode> {
                 LNode dummyNodeTargetNode = dummyNodeTargetPort.getNode();
                 if (dummyNodeTargetNode.equals(n1)) {
                     updateBiggerAndSmallerAssociations(n2, n1);
-                    return 1;
+                    return -1;
                 }
                 
                 // If the two nodes are not the same, order them based on the source model order.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -250,16 +250,6 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
             
             // If both ports have the same target nodes, make sure that the backward edge is below the normal edge.
             if (p1TargetNode != null && p1TargetNode.equals(p2TargetNode)) {
-//                // Backward edges below
-//                if (p1.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)
-//                        && !p2.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)) {
-//                    updateBiggerAndSmallerAssociations(p1, p2);
-//                    return 1;
-//                } else if (!p1.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)
-//                        && p2.getOutgoingEdges().get(0).getProperty(InternalProperties.REVERSED)) {
-//                    updateBiggerAndSmallerAssociations(p2, p1);
-//                    return -1;
-//                }
                 // If both edges are reversed or not reversed, just use their model order.
                 if (p1Order > p2Order) {
                     updateBiggerAndSmallerAssociations(p1, p2);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -219,9 +219,7 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
                     || p1.getSide() == PortSide.SOUTH && p2.getSide() == PortSide.SOUTH) {
                 // Some ports are ordered in the way around.
                 // Previously this did not matter, since the north south processor did override the ordering.
-                  LPort temp = p1;
-                  p1 = p2;
-                  p2 = temp;
+                reverseOrder = -reverseOrder;
             }
             LNode p1TargetNode = p1.getProperty(InternalProperties.LONG_EDGE_TARGET_NODE);
             LNode p2TargetNode = p2.getProperty(InternalProperties.LONG_EDGE_TARGET_NODE);
@@ -306,9 +304,19 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
             return -1;
         } else if (p1.hasProperty(InternalProperties.MODEL_ORDER) && p2.hasProperty(InternalProperties.MODEL_ORDER)) {
             // The ports have no edges.
-            // Use the port model order to compare them.
+            // Use the port model order to compare them. This can always be very bad since these unconnected ports
+            // can transitively order nodes that should be ordered differently.
+            // This can only be prevented, if one handles the sorting such that unconnected ports are handled last.
             int p1MO = p1.getProperty(InternalProperties.MODEL_ORDER);
             int p2MO = p2.getProperty(InternalProperties.MODEL_ORDER);
+            // Still check the side, since WEST and SOUTH must be the other way around.
+            if (p1.getSide() == PortSide.WEST && p2.getSide() == PortSide.WEST
+                    || p1.getSide() == PortSide.SOUTH && p2.getSide() == PortSide.SOUTH) {
+                // Some ports are ordered in the way around.
+                // Previously this did not matter, since the north south processor did override the ordering.
+                reverseOrder = -reverseOrder;
+            }
+            
             if (p1MO > p2MO) {
                 updateBiggerAndSmallerAssociations(p1, p2, reverseOrder);
                 return reverseOrder;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -127,36 +127,32 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
         
         // Sort incoming edges by sorting their ports by the order of the nodes they connect to.
         if (!p1.getIncomingEdges().isEmpty() && !p2.getIncomingEdges().isEmpty()) {
-
-            LPort p1SourcePort = p1.getIncomingEdges().get(0).getSource();
-            LPort p2SourcePort = p2.getIncomingEdges().get(0).getSource();
-            LNode p1Node = p1SourcePort.getNode();
-            LNode p2Node = p2SourcePort.getNode();
-            if (p1.getSide() == PortSide.WEST && p2.getSide() == PortSide.WEST && p1SourcePort.getSide() != PortSide.SOUTH
-                    && p2SourcePort.getSide() != PortSide.SOUTH                       
-                    || p1.getSide() == PortSide.NORTH && p2.getSide() == PortSide.NORTH && p1SourcePort.getSide() != PortSide.SOUTH
-                        && p2SourcePort.getSide() != PortSide.SOUTH
-                    || p1.getSide() == PortSide.SOUTH && p2.getSide() == PortSide.SOUTH && p1SourcePort.getSide() != PortSide.SOUTH
-                        && p2SourcePort.getSide() != PortSide.SOUTH
-                    || p1.getSide() == PortSide.EAST && p2.getSide() == PortSide.EAST && p1SourcePort.getSide() != PortSide.SOUTH
-                        && p2SourcePort.getSide() != PortSide.SOUTH) {
+            if (p1.getSide() == PortSide.WEST && p2.getSide() == PortSide.WEST                      
+                    || p1.getSide() == PortSide.NORTH && p2.getSide() == PortSide.NORTH
+                    || p1.getSide() == PortSide.SOUTH && p2.getSide() == PortSide.SOUTH) {
                 // Some ports are ordered in the way around.
                 // Previously this did not matter, since the north south processor did override the ordering.
                 LPort temp = p1;
                 p1 = p2;
                 p2 = temp;
             }
+
+            LPort p1SourcePort = p1.getIncomingEdges().get(0).getSource();
+            LPort p2SourcePort = p2.getIncomingEdges().get(0).getSource();
+            LNode p1Node = p1SourcePort.getNode();
+            LNode p2Node = p2SourcePort.getNode();
             if (p1Node.equals(p2Node)) {
-                
-                int p1MO = p1.getIncomingEdges().get(0).getProperty(InternalProperties.MODEL_ORDER);
-                int p2MO = p2.getIncomingEdges().get(0).getProperty(InternalProperties.MODEL_ORDER);
-                if (p1MO > p2MO) {
-                    updateBiggerAndSmallerAssociations(p1, p2);
-                } else {
-                    updateBiggerAndSmallerAssociations(p2, p1);
+                // If both connect to the same node, check their occurrence order since these ports have to be handled
+                // first and should hence be sorted.
+                for (LPort port : p1Node.getPorts()) {
+                    if (p1SourcePort.equals(port)) {
+                        updateBiggerAndSmallerAssociations(p2, p1);
+                        return -1;
+                    } else if (p2SourcePort.equals(port)) {
+                        updateBiggerAndSmallerAssociations(p1, p2);
+                        return 1;
+                    }
                 }
-                // In this case both incoming edges must have a model order set. Check it.
-                return Integer.compare(p1MO, p2MO);
             }
             // If both ports connect to long edges in the same layer, reverse the order.
             if (p1SourcePort.getNode().getType() == NodeType.LONG_EDGE
@@ -168,17 +164,20 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
                 // |__2__||
                 // ___1___|
                 //
-                // The difference to the other cases above is that a EAST port uses dummy nodes, while a
-                // NORTH or SOUTH port uses none since they are later created by the NorthSouthProcessor.
                 Layer previousLayer = p1Node.getLayer();
                 int inPreviousLayer =  checkReferenceLayer(previousLayer, p1Node, p2Node, p1, p2);
                 if (inPreviousLayer != 0) {
+                    if (inPreviousLayer > 0) {
+                        updateBiggerAndSmallerAssociations(p1, p2);
+                    } else {
+                        updateBiggerAndSmallerAssociations(p1, p2);
+                    }
                     return inPreviousLayer;
                 }
             }
             
             // Check which of the nodes connects first to the previous layer.
-            int inPreviousLayer =  checkReferenceLayer(Arrays.stream(previousLayer).collect(Collectors.toList()), p2Node, p1Node, p2, p1);
+            int inPreviousLayer =  checkReferenceLayer(Arrays.stream(previousLayer).collect(Collectors.toList()), p1Node, p2Node, p1, p2);
             if (inPreviousLayer != 0) {
                 return inPreviousLayer;
             }
@@ -188,9 +187,9 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
             if (portModelOrder) {
                 int result =  checkPortModelOrder(p1, p2);
                 if (result != 0) {
-                    if (result == -1) {
+                    if (result < 0) {
                         updateBiggerAndSmallerAssociations(p2, p1);
-                    } else if (result == 1) {
+                    } else if (result > 0) {
                         updateBiggerAndSmallerAssociations(p1, p2);
                     }
                     return result;
@@ -374,5 +373,13 @@ public class ModelOrderPortComparator implements Comparator<LPort> {
             return Integer.compare(ps1.ordinal(), ps2.ordinal());
         }
         
+    }
+    
+    /**
+     * Clears the transitive ordering.
+     */
+    public void clearTransitiveOrdering() {
+        this.biggerThan = new HashMap<>();
+        this.smallerThan = new HashMap<>();
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/preserveorder/ModelOrderPortComparator.java
@@ -30,6 +30,8 @@ import org.eclipse.elk.core.options.PortSide;
  * This takes into account that ports that connect to the same (long edge) target should be ordered next to each other.
  * Outgoing ports are ordered before incoming ports.
  * Incoming ports choose a position that does not create conflicts with the previous layer.
+ * FIXME optimize this by setting ids on all already handled nodes in the previous and current layer (e.g. after the 
+ * node order was set) to avoid searching for the correct order and using the ids instead to compare.
  */
 public class ModelOrderPortComparator implements Comparator<LPort> {
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LongEdgeOrderingStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LongEdgeOrderingStrategy.java
@@ -38,7 +38,7 @@ public enum LongEdgeOrderingStrategy {
         case DUMMY_NODE_OVER:
             return Integer.MAX_VALUE;
         case DUMMY_NODE_UNDER:
-            return -1;
+            return Integer.MIN_VALUE;
         default:
             return 0;
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -328,7 +328,7 @@ public class LayerSweepCrossingMinimizer
         int wrongModelOrder = 0;
         for (LNode[] layer : layers) {
             ModelOrderNodeComparator comp = new ModelOrderNodeComparator(
-                    previousLayer == -1 ? layers[0] : layers[previousLayer], strategy, LongEdgeOrderingStrategy.EQUAL);
+                    previousLayer == -1 ? layers[0] : layers[previousLayer], strategy, LongEdgeOrderingStrategy.EQUAL, false);
             for (int i = 0; i < layer.length; i++) {
                 for (int j = i + 1; j < layer.length; j++) {
                     if (layer[i].hasProperty(InternalProperties.MODEL_ORDER)

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ConcreteSortByInputModelTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ConcreteSortByInputModelTest.java
@@ -89,6 +89,17 @@ public class ConcreteSortByInputModelTest {
         assertTrue("p1 above p2", p1.getY() < p2.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+        
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
     }
 
     @Test
@@ -142,6 +153,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+        
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
     }
 
     @Test
@@ -189,6 +210,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+        
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
@@ -249,6 +280,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+        
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
     }
 
     @Test
@@ -296,6 +337,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+        
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
@@ -356,6 +407,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
     }
 
     @Test
@@ -405,6 +466,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
@@ -467,6 +538,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
     }
 
     @Test
@@ -514,6 +595,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
@@ -578,6 +669,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
     }
 
     @Test
@@ -625,6 +726,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
@@ -690,6 +801,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
     }
 
     @Test
@@ -739,6 +860,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
@@ -802,6 +933,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
     }
 
     @Test
@@ -853,6 +994,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
@@ -917,6 +1068,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
     }
 
     @Test
@@ -964,6 +1125,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
@@ -1027,6 +1198,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
     }
 
     @Test
@@ -1078,6 +1259,16 @@ public class ConcreteSortByInputModelTest {
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
         layoutProvider.layout(parent, new NullElkProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
         // Assert the ordering of p3 and p4. 
@@ -1141,6 +1332,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
     }
 
     @Test
@@ -1188,6 +1389,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
@@ -1251,6 +1462,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
     }
 
     @Test
@@ -1300,6 +1521,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
@@ -1364,6 +1595,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
     }
 
     @Test
@@ -1412,6 +1653,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
@@ -1473,6 +1724,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
     }
 
     @Test
@@ -1523,6 +1784,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
@@ -1586,6 +1857,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
     }
 
     @Test
@@ -1634,6 +1915,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
@@ -1696,6 +1987,16 @@ public class ConcreteSortByInputModelTest {
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 before p3", p4.getX() < p3.getX());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
     }
 
     @Test
@@ -1744,6 +2045,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
@@ -1802,6 +2113,16 @@ public class ConcreteSortByInputModelTest {
         ElkGraphUtil.createSimpleEdge(p2, p3);
         
         LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+        
+        // Check for port model order, which should result in the same graph.
+
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, true);
+
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of n1 and ni.
         assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ConcreteSortByInputModelTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ConcreteSortByInputModelTest.java
@@ -92,6 +92,59 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingEastIncomingWestMultipleNodes() {
+        // n1:p1--->p4
+        //            n2
+        //       |--p3
+        // ni:p2<-
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+    }
+
+    @Test
     public void testOutgoingEastIncomingNorth() {
         //   p1---------
         // n1           |
@@ -144,6 +197,61 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingEastIncomingNorthMultipleNodes() {
+        //n1:p1---------
+        //              |
+        //ni:p2<----    |
+        //         |    v
+        //         p3  p4
+        //           n2
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
     public void testOutgoingEastIncomingSouth() {
         //           n2
         //         p4  p3
@@ -191,6 +299,61 @@ public class ConcreteSortByInputModelTest {
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+    }
+
+    @Test
+    public void testOutgoingEastIncomingSouthMultipleNodes() {
+        //           n2
+        //         p4  p3
+        //         A    |
+        //n1:p1-----    |
+        //              |
+        //ni:p2<--------
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 before p3", p4.getX() < p3.getX());
     }
@@ -250,6 +413,63 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingEastIncomingEastMultipleNodes() {
+        //        p3<----
+        //      n2      |
+        //        p4<-  |
+        //           |  |
+        //           |  |
+        //n1:p1------   |
+        //              |
+        //ni:p2<--------
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+    }
+
+    @Test
     public void testOutgoingNorthIncomingWest() {
         //  ------>p4
         // |         n2
@@ -302,6 +522,65 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingNorthIncomingWestMultipleNodes() {
+        //  |--|
+        //  |  |
+        // p1  |
+        // n1  |
+        //     |--->p4
+        //            n2
+        //  |-------p3
+        //  v
+        // p2
+        // ni
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+    }
+
+    @Test
     public void testOutgoingNorthIncomingNorth() {
         //  ----------
         // |          |
@@ -349,6 +628,66 @@ public class ConcreteSortByInputModelTest {
         layoutProvider.layout(parent, new BasicProgressMonitor());
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
+    public void testOutgoingNorthIncomingNorthMultipleNodes() {
+        //  |--|
+        //  |  |
+        // p1  |
+        // n1  |
+        //     |-------
+        //            |
+        //  |------|  |
+        //  |     p3  p4
+        //  v       n2
+        // p2
+        // ni
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 before p4", p3.getX() < p4.getX());
     }
@@ -408,6 +747,64 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingNorthIncomingSouthMultipleNodes() {
+        //          n2
+        //        p4  p3
+        //  |------|  |
+        // p1         |
+        // n1         |
+        //  |---------|
+        //  v
+        // p2
+        // ni
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+    }
+
+    @Test
     public void testOutgoingNorthIncomingEast() {
         //    p3----
         //  n2      |
@@ -460,7 +857,66 @@ public class ConcreteSortByInputModelTest {
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
         // Assert the ordering of p3 and p4. 
-        assertTrue("p3 above p3", p3.getY() < p4.getY());
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+    }
+
+    @Test
+    public void testOutgoingNorthIncomingEastMultipleNodes() {
+        //      p3----|
+        //    n1      |
+        //      p4<|  |
+        //  |------|  |
+        // p1         |
+        // n1         |
+        //  |---------|
+        //  v
+        // p2
+        // ni
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
     }
 
     @Test
@@ -513,6 +969,64 @@ public class ConcreteSortByInputModelTest {
         assertTrue("p1 before p2", p1.getX() < p2.getX());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 above p4", p3.getY() < p4.getY());
+    }
+
+    @Test
+    public void testOutgoingSouthIncomingWestMultipleNodes() {
+        // n1
+        // p1
+        // |----->p4
+        // ni       n2
+        // p2  |--p3
+        // A---|
+        //
+        //
+        //
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
     }
 
     @Test
@@ -571,6 +1085,65 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingSouthIncomingNorthMultipleNodes() {
+        // n1
+        // p1
+        // |-----------
+        //             |
+        // ni          |
+        // p2          |
+        // A--------|  |
+        //         p3  p4
+        //           n2
+        //
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new NullElkProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
     public void testOutgoingSouthIncomingSouth() {
         //  n1     n2
         //p1  p2 p3  p4
@@ -620,6 +1193,64 @@ public class ConcreteSortByInputModelTest {
         assertTrue("p1 before p2", p1.getX() < p2.getX());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
+    public void testOutgoingSouthIncomingSouthMultipleNodes() {
+        //n1       n2
+        //p1     p4  p3
+        // |      |  A
+        // |------|  |
+        //           |
+        //ni         |
+        //p2         |
+        //A          |
+        //-----------|
+        
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
     }
 
     @Test
@@ -673,7 +1304,66 @@ public class ConcreteSortByInputModelTest {
         // Assert the ordering of p1 and p2.
         assertTrue("p1 before p2", p1.getX() < p2.getX());
         // Assert the ordering of p3 and p4. 
-        assertTrue("p4 abive p3", p4.getY() < p3.getY());
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+    }
+
+    @Test
+    public void testOutgoingSouthIncomingEastMultipleNodes() {
+        //       p3--|
+        //n1   n2    |
+        //p1     p4< |
+        // |       | |
+        // |-------- |
+        //           |
+        //ni         |
+        //p2         |
+        //A          |
+        //-----------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
     }
 
     @Test
@@ -727,6 +1417,62 @@ public class ConcreteSortByInputModelTest {
         assertTrue("p1 above p2", p1.getY() < p2.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p3 above p4", p3.getY() < p4.getY());
+    }
+
+    @Test
+    public void testOutgoingWestIncomingWestMultipleNodes() {
+        // |-p1:n1
+        // |       
+        // |-------->p4
+        //             n2
+        // |>p2:ni |-p3
+        // |       |
+        // |-------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
     }
 
     @Test
@@ -785,6 +1531,64 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingWestIncomingNorthMultipleNodes() {
+        // |-p1:n1
+        // |       
+        // |-----------|
+        //             |
+        // |>p2:ni     |
+        // |           |
+        // |--------|  v
+        //         p3  p4
+        //           n2
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
     public void testOutgoingWestIncomingSouth() {
         // |-----p1
         // |       n1
@@ -838,6 +1642,63 @@ public class ConcreteSortByInputModelTest {
     }
 
     @Test
+    public void testOutgoingWestIncomingSouthMultipleNodes() {
+        // |-----p1:n1    n2
+        // |            p4  p3
+        // |            A   |
+        // |------------|   |
+        //                  |
+        // |-----p2:ni      |
+        // |                |
+        // |----------------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+    }
+
+    @Test
     public void testOutgoingWestIncomingEast() {
         // |-----p1     p4<----|
         // |       n1 n2       |
@@ -888,5 +1749,63 @@ public class ConcreteSortByInputModelTest {
         assertTrue("p1 above p2", p1.getY() < p2.getY());
         // Assert the ordering of p3 and p4. 
         assertTrue("p4 above p3", p4.getY() < p3.getY());
+    }
+
+    @Test
+    public void testOutgoingWestIncomingEastMultipleNodes() {
+        //                 p3-----|
+        //               n2       |
+        //    |--p1:n1     p4<-|  |
+        //    |                |  |
+        //    |----------------|  |
+        //                        |
+        //    |->p2:ni            |
+        //    |                   |
+        //    |-------------------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode ni = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        ni.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        ni.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(ni);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of n1 and ni.
+        assertTrue("Node order of n1 and ni", n1.getY() < ni.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
     }
 }

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ConcreteSortByInputModelTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/ConcreteSortByInputModelTest.java
@@ -1,0 +1,892 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Kiel University.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.intermediate;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.elk.alg.layered.LayeredLayoutProvider;
+import org.eclipse.elk.alg.layered.options.CrossingMinimizationStrategy;
+import org.eclipse.elk.alg.layered.options.CycleBreakingStrategy;
+import org.eclipse.elk.alg.layered.options.GreedySwitchType;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.OrderingStrategy;
+import org.eclipse.elk.alg.test.PlainJavaInitialization;
+import org.eclipse.elk.core.math.ElkPadding;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.options.PortConstraints;
+import org.eclipse.elk.core.options.PortSide;
+import org.eclipse.elk.core.util.BasicProgressMonitor;
+import org.eclipse.elk.core.util.NullElkProgressMonitor;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.ElkPort;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test whether these concrete example did not break while using the consider model order strategy.
+ *
+ */
+public class ConcreteSortByInputModelTest {
+
+    @BeforeClass
+    public static void init() {
+        PlainJavaInitialization.initializePlainJavaLayout();
+    }
+
+    @Test
+    public void testOutgoingEastIncomingWest() {
+        //   p1--->p4
+        // n1        n2
+        //   p2<---p3
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+    }
+
+    @Test
+    public void testOutgoingEastIncomingNorth() {
+        //   p1---------
+        // n1           |
+        //   p2<----    |
+        //         |    v
+        //         p3  p4
+        //           n2
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
+    public void testOutgoingEastIncomingSouth() {
+        //           n2
+        //         p4  p3
+        //         A    |
+        //   p1-----    |
+        // n1           |
+        //   p2<--------
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+    }
+
+    @Test
+    public void testOutgoingEastIncomingEast() {
+        //        p3<----
+        //      n2      |
+        //        p4<-  |
+        //           |  |
+        //           |  |
+        //   p1------   |
+        // n1           |
+        //   p2<--------
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+    }
+
+    @Test
+    public void testOutgoingNorthIncomingWest() {
+        //  ------>p4
+        // |         n2
+        // |  |----p3
+        // |  v
+        //p1  p2
+        //  n1
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+    }
+
+    @Test
+    public void testOutgoingNorthIncomingNorth() {
+        //  ----------
+        // |          |
+        // |  |----|  |
+        // |  v    |  v
+        //p1  p2  p3  p4
+        //  n1      n2
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
+    public void testOutgoingNorthIncomingSouth() {
+        //      n2
+        //    p4  p3
+        // ____A  |
+        // |  ____|     
+        // |  |
+        // |  v
+        //p1  p2
+        //  n1
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+    }
+
+    @Test
+    public void testOutgoingNorthIncomingEast() {
+        //    p3----
+        //  n2      |
+        //    p4<-  |
+        //        | |
+        //  ------  |
+        // |   -----     
+        // |  |
+        // |  v
+        //p1  p2
+        //  n1
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p3", p3.getY() < p4.getY());
+    }
+
+    @Test
+    public void testOutgoingSouthIncomingWest() {
+        //  n1
+        //p1  p2
+        // |  A
+        // |  |---p3
+        // |        n2
+        // |----->p4
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+    }
+
+    @Test
+    public void testOutgoingSouthIncomingNorth() {
+        //  n1
+        //p1  p2
+        // |  A
+        // |  |---|
+        // |      |
+        // |---|  |
+        //     v  |
+        //    p4  p3
+        //      n2
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new NullElkProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+    }
+
+    @Test
+    public void testOutgoingSouthIncomingSouth() {
+        //  n1     n2
+        //p1  p2 p3  p4
+        // |  A   |  A
+        // |  |---|  |
+        // |         |
+        // |---------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
+    public void testOutgoingSouthIncomingEast() {
+        //
+        //          p4<-|
+        //  n1    n2    |
+        //p1  p2    p3  |
+        // |  A      |  |
+        // |  |------|  |  
+        // |            |
+        // |------------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 before p2", p1.getX() < p2.getX());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 abive p3", p4.getY() < p3.getY());
+    }
+
+    @Test
+    public void testOutgoingWestIncomingWest() {
+        // |-----p1
+        // |       n1
+        // |  |->p2
+        // |  |
+        // |  |------p3
+        // |           n2
+        // |-------->p4
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 above p4", p3.getY() < p4.getY());
+    }
+
+    @Test
+    public void testOutgoingWestIncomingNorth() {
+        // |-----p1
+        // |       n1
+        // |  |->p2
+        // |  |
+        // |  |----------|
+        // |             |
+        // |---------v   |
+        //           p4  p3
+        //             n2
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.NORTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 before p3", p4.getX() < p3.getX());
+    }
+
+    @Test
+    public void testOutgoingWestIncomingSouth() {
+        // |-----p1
+        // |       n1
+        // |  |->p2    n2
+        // |  |      p3  p4
+        // |  |-------|  A
+        // |             |
+        // |-------------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.SOUTH);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p3 before p4", p3.getX() < p4.getX());
+    }
+
+    @Test
+    public void testOutgoingWestIncomingEast() {
+        // |-----p1     p4<----|
+        // |       n1 n2       |
+        // |  |->p2     p3--|  |
+        // |  |             |  |
+        // |  |-------------|  |
+        // |                   |
+        // |-------------------|
+
+        ElkNode parent = ElkGraphUtil.createGraph();
+        ElkNode n1 = ElkGraphUtil.createNode(parent);
+        ElkNode n2 = ElkGraphUtil.createNode(parent);
+        n1.setDimensions(20, 20);
+        n2.setDimensions(20, 20);
+
+        parent.setProperty(CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        // Model order configuration.
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY, OrderingStrategy.PREFER_EDGES);
+        parent.setProperty(LayeredOptions.CONSIDER_MODEL_ORDER_PORT_MODEL_ORDER, false);
+        // No crossing minimization, hence only model order is used.
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
+        parent.setProperty(LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);
+        // For presentation.
+        parent.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        parent.setProperty(CoreOptions.PADDING, new ElkPadding(0.0));
+        parent.setProperty(CoreOptions.SPACING_NODE_NODE, 10.0);
+        parent.setProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS, 20.0);
+        n1.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        n2.setProperty(LayeredOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_SIDE);
+        // Make sure that the order is correct.
+        parent.setProperty(LayeredOptions.CYCLE_BREAKING_STRATEGY, CycleBreakingStrategy.MODEL_ORDER);
+        
+        ElkPort p1 = ElkGraphUtil.createPort(n1);
+        p1.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p2 = ElkGraphUtil.createPort(n1);
+        p2.setProperty(LayeredOptions.PORT_SIDE, PortSide.WEST);
+        ElkPort p3 = ElkGraphUtil.createPort(n2);
+        p3.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+        ElkPort p4 = ElkGraphUtil.createPort(n2);
+        p4.setProperty(LayeredOptions.PORT_SIDE, PortSide.EAST);
+
+        ElkGraphUtil.createSimpleEdge(p1, p4);
+        ElkGraphUtil.createSimpleEdge(p2, p3);
+        
+        LayeredLayoutProvider layoutProvider = new LayeredLayoutProvider();
+        layoutProvider.layout(parent, new BasicProgressMonitor());
+        // Assert the ordering of p1 and p2.
+        assertTrue("p1 above p2", p1.getY() < p2.getY());
+        // Assert the ordering of p3 and p4. 
+        assertTrue("p4 above p3", p4.getY() < p3.getY());
+    }
+}


### PR DESCRIPTION
Make sure that the order of incoming ports matches the order given by the previous layer.

Updated WEST side handling to fix the main issue. Moreover, there was a p1/p2 typo as well. 

This also makes port model order non-constraining for input ports same as the edge model order.
If one wants to constrain the port order one should use portConstraints.

- [x] I want to check whether I can also fix feedback edges with model order
- [x] Check the used examples into elk-models to document how it should behave.