### PR TITLE
Remove re-exports in MANIFEST.MF and use Import-Package where suitable

### DIFF
--- a/plugins/org.eclipse.elk.alg.common/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.common/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.ecore;bundle-version="2.10.0",
  org.eclipse.elk.core,
  org.eclipse.elk.graph
 Export-Package: org.eclipse.elk.alg.common,

--- a/plugins/org.eclipse.elk.alg.disco.debug/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.disco.debug/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
  org.eclipse.ui,
  org.eclipse.core.runtime,
+ org.eclipse.emf.ecore;bundle-version="2.10.0",
  org.eclipse.elk.core,
  org.eclipse.elk.core.debug,
  org.eclipse.elk.core.ui,

--- a/plugins/org.eclipse.elk.alg.disco/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.disco/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-Name: ELK Disconnected Components Compaction
 Bundle-SymbolicName: org.eclipse.elk.alg.disco;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common;bundle-version="2.10.0",
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common

--- a/plugins/org.eclipse.elk.alg.force/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.force/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common;bundle-version="2.10.0",
  org.eclipse.elk.alg.common,
  org.eclipse.elk.core,
  org.eclipse.elk.graph

--- a/plugins/org.eclipse.elk.alg.layered/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.layered/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.ecore;bundle-version="2.10.0",
  org.eclipse.xtext.xbase.lib;bundle-version="2.10.0",
  org.eclipse.elk.graph,
  org.eclipse.elk.core,

--- a/plugins/org.eclipse.elk.alg.libavoid/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.libavoid/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: Eclipse Layout Kernel
 Bundle-Activator: org.eclipse.elk.alg.libavoid.LibavoidPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common;bundle-version="2.10.0",
  org.eclipse.core.runtime,
  org.eclipse.elk.graph,
  org.eclipse.elk.core,

--- a/plugins/org.eclipse.elk.alg.mrtree/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.mrtree/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-SymbolicName: org.eclipse.elk.alg.mrtree;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.elk.alg.common,
+Require-Bundle: org.eclipse.emf.common;bundle-version="2.10.0",
+ org.eclipse.elk.alg.common,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.xtext.xbase.lib

--- a/plugins/org.eclipse.elk.alg.radial/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.radial/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-SymbolicName: org.eclipse.elk.alg.radial;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common;bundle-version="2.10.0",
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common

--- a/plugins/org.eclipse.elk.alg.rectpacking/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.rectpacking/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-SymbolicName: org.eclipse.elk.alg.rectpacking;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.elk.alg.common,
+Require-Bundle: org.eclipse.emf.common;bundle-version="2.10.0",
+ org.eclipse.elk.alg.common,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  com.google.guava,

--- a/plugins/org.eclipse.elk.alg.spore/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.spore/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common;bundle-version="2.10.0",
  org.eclipse.elk.graph,
  org.eclipse.elk.core,
  org.eclipse.elk.alg.common

--- a/plugins/org.eclipse.elk.alg.topdownpacking/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-SymbolicName: org.eclipse.elk.alg.topdownpacking;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.elk.core,
+Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.0",
+ org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common,
  com.google.guava

--- a/plugins/org.eclipse.elk.conn.gmf/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.conn.gmf/META-INF/MANIFEST.MF
@@ -10,7 +10,9 @@ Export-Package: org.eclipse.elk.conn.gmf
 Require-Bundle: org.eclipse.gef;bundle-version="3.5.0",
  org.eclipse.gmf.runtime.diagram.ui;bundle-version="1.2.0",
  org.eclipse.gmf.runtime.diagram.ui.render;bundle-version="1.2.0",
+ com.google.inject;bundle-version="3.0.0",
  com.google.guava,
  org.eclipse.elk.graph,
+ org.eclipse.elk.core,
  org.eclipse.elk.core.service
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.elk.core.debug/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.debug/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-SymbolicName: org.eclipse.elk.core.debug;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-Activator: org.eclipse.elk.core.debug.ElkDebugPlugin
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.ecore;bundle-version="2.10.0",
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.elk.core,

--- a/plugins/org.eclipse.elk.core.service/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.service/META-INF/MANIFEST.MF
@@ -6,13 +6,13 @@ Bundle-SymbolicName: org.eclipse.elk.core.service;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava,
- com.google.inject;bundle-version="3.0.0";visibility:=reexport,
- org.eclipse.core.runtime;bundle-version=3.26.0,
+ com.google.inject;bundle-version="3.0.0",
+ org.eclipse.core.runtime;bundle-version="3.26.0",
  org.eclipse.jface,
  org.eclipse.ui.workbench,
  org.eclipse.emf.edit;bundle-version="2.5.0",
  org.eclipse.elk.graph,
- org.eclipse.elk.core;visibility:=reexport,
+ org.eclipse.elk.core,
  org.eclipse.e4.ui.css.core;bundle-version="0.13.300"
 Eclipse-RegisterBuddy: org.eclipse.elk.core
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/plugins/org.eclipse.elk.core.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core.ui/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.4.0",
  org.eclipse.emf.ecore.xmi;bundle-version="2.9.0",
  org.eclipse.emf.transaction;bundle-version="1.3.0",
  com.google.guava,
+ com.google.inject;bundle-version="3.0.0",
  org.eclipse.elk.graph,
  org.eclipse.elk.core,
  org.eclipse.elk.core.service

--- a/plugins/org.eclipse.elk.graph.json/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph.json/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Vendor: Eclipse Modeling Project
 Bundle-Version: 0.10.0.qualifier
 Bundle-SymbolicName: org.eclipse.elk.graph.json;singleton:=true
 Require-Bundle: com.google.guava,
- com.google.gson;bundle-version="2.8.2";visibility:=reexport,
+ com.google.gson;bundle-version="2.8.2",
+ org.eclipse.emf.ecore;bundle-version="2.10.0",
  org.eclipse.elk.graph,
  org.eclipse.elk.core,
  org.eclipse.xtext.xbase.lib,

--- a/plugins/org.eclipse.elk.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Export-Package: org.eclipse.elk.graph,
  org.eclipse.elk.graph.impl,
  org.eclipse.elk.graph.properties,
  org.eclipse.elk.graph.util
-Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.0";visibility:=reexport,
+Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.0",
  com.google.guava
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/test/org.eclipse.elk.alg.common.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.common.test/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Automatic-Module-Name: org.eclipse.elk.alg.common.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common,
  org.eclipse.elk.core,
  org.eclipse.elk.alg.common,
  org.eclipse.elk.alg.force,

--- a/test/org.eclipse.elk.alg.force.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.force.test/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Automatic-Module-Name: org.eclipse.elk.alg.force.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common,

--- a/test/org.eclipse.elk.alg.layered.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.layered.test/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Automatic-Module-Name: org.eclipse.elk.alg.layered.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common,

--- a/test/org.eclipse.elk.alg.spore.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.spore.test/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava;bundle-version="18.0.0",
+ org.eclipse.emf.ecore,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common,

--- a/test/org.eclipse.elk.alg.topdown.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.topdown.test/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Automatic-Module-Name: org.eclipse.elk.alg.topdown.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common,

--- a/test/org.eclipse.elk.core.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.core.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.eclipse.elk.core.test;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.ecore,
  org.junit;bundle-version="4.12.0",
  org.eclipse.elk.core,
  org.eclipse.elk.graph,

--- a/test/org.eclipse.elk.graph.json.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.graph.json.test/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava,
  com.google.gson;bundle-version="2.8.2",
+ org.eclipse.emf.common,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.graph.json,

--- a/test/org.eclipse.elk.graph.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.graph.test/META-INF/MANIFEST.MF
@@ -6,5 +6,6 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.common,
  org.eclipse.elk.graph,
  org.junit;bundle-version="4.12.0"

--- a/test/org.eclipse.elk.shared.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.shared.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.eclipse.elk.shared.test;singleton:=true
 Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: com.google.guava,
+ org.eclipse.emf.ecore,
  org.junit;bundle-version="4.12.0",
  org.eclipse.elk.core,
  org.eclipse.elk.graph,


### PR DESCRIPTION
Re-exporting required bundles is convenient in the first place but can cause a lot of trouble on the long run.
When reexporting a required bundle that bundle effectively becomes part of the exporting bundle's API with all the consequences regarding versioning. Additionally in an OSGi runtime it can cause resolution errors if multiple versions are available.
Because of all that using reexports is not recommended and should be avoided.

This PR suggests to do that for ELK and removes all reexports and adds the therefore necessary explicit requirements instead.