### PR TITLE
Fix typo in meta model section

### DIFF
--- a/docs/content/documentation/tooldevelopers/graphdatastructure.md
+++ b/docs/content/documentation/tooldevelopers/graphdatastructure.md
@@ -66,7 +66,7 @@ Inclusion trees capture the hierarchical structure of a graph. See below for the
 
 ### The Meta Model
 
-The ELK Graph meta modelh looks like this:
+The ELK Graph meta model looks like this:
 
 {{< image src="graph_metamodel.png" alt="The ELK Graph meta model." >}}
 


### PR DESCRIPTION
This PR fixes a simple typo in the metal model section of the docs. "modelh" -> "model"