### PR TITLE
Topdown node sizes

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
@@ -255,6 +255,16 @@ public class RecursiveGraphLayoutEngine implements IGraphLayoutEngine {
                                 ElkPadding padding = childNode.getProperty(CoreOptions.PADDING);
                                 childNode.setDimensions(Math.max(childNode.getWidth(), size.x + padding.left + padding.right),
                                         Math.max(childNode.getHeight(), size.y + padding.top + padding.bottom));
+                            } else {
+                                // If no approximator is set, use the set sizes for atomic nodes and use the properties
+                                // that have been set for nodes containing further children
+                                if (childNode.getChildren().size() != 0) {
+                                    childNode.setDimensions(
+                                            childNode.getProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_WIDTH),
+                                            childNode.getProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_WIDTH) /
+                                            childNode.getProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_ASPECT_RATIO)
+                                    );
+                                }
                             }
                         }
                     }

--- a/test/org.eclipse.elk.alg.topdown.test/src/org/eclipse/elk/alg/topdown/test/TopdownLayoutTest.java
+++ b/test/org.eclipse.elk.alg.topdown.test/src/org/eclipse/elk/alg/topdown/test/TopdownLayoutTest.java
@@ -51,8 +51,9 @@ public class TopdownLayoutTest {
         toplevel.setProperty(CoreOptions.ALGORITHM, "org.eclipse.elk.fixed");
         toplevel.setProperty(CoreOptions.PADDING, new ElkPadding());
         toplevel.setProperty(CoreOptions.SPACING_NODE_NODE, 0.0);
-        // set size of node so that children will be scaled down
-        toplevel.setDimensions(20, 50);
+        // set size of node so that children will be scaled down 
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_WIDTH, 20.0);
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_ASPECT_RATIO, 0.4);
         
         ElkNode child1 = ElkGraphUtil.createNode(toplevel);
         child1.setProperty(CoreOptions.TOPDOWN_LAYOUT, true);
@@ -105,7 +106,8 @@ public class TopdownLayoutTest {
         toplevel.setProperty(CoreOptions.PADDING, new ElkPadding());
         toplevel.setProperty(CoreOptions.SPACING_NODE_NODE, 0.0);
         // set size of node so that children will be scaled down
-        toplevel.setDimensions(40, 30);
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_WIDTH, 40.0);
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_ASPECT_RATIO, 1.33333);
         
         ElkNode child1 = ElkGraphUtil.createNode(toplevel);
         child1.setProperty(CoreOptions.TOPDOWN_LAYOUT, true);
@@ -159,7 +161,8 @@ public class TopdownLayoutTest {
         toplevel.setProperty(CoreOptions.PADDING, new ElkPadding());
         toplevel.setProperty(CoreOptions.SPACING_NODE_NODE, 0.0);
         // set size of node so that children will be scaled down
-        toplevel.setDimensions(300, 300);
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_WIDTH, 300.0);
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_ASPECT_RATIO, 1.0);
         
         ElkNode child1 = ElkGraphUtil.createNode(toplevel);
         child1.setProperty(CoreOptions.TOPDOWN_LAYOUT, true);
@@ -212,7 +215,8 @@ public class TopdownLayoutTest {
         toplevel.setProperty(CoreOptions.PADDING, new ElkPadding());
         toplevel.setProperty(CoreOptions.SPACING_NODE_NODE, 0.0);
         // set size of node so that children will be scaled down
-        toplevel.setDimensions(300, 300);
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_WIDTH, 300.0);
+        toplevel.setProperty(CoreOptions.TOPDOWN_HIERARCHICAL_NODE_ASPECT_RATIO, 1.0);
         
         ElkNode child1 = ElkGraphUtil.createNode(toplevel);
         child1.setProperty(CoreOptions.TOPDOWN_LAYOUT, true);


### PR DESCRIPTION
The properties TOPDOWN_HIERARCHICAL_NODE_WIDTH and TOPDOWN_HIERARCHICAL_ASPECT_RATIO should always apply to the node they are set on rather than to their children. Prior to this change, in the NULL approximator case this was handled differently and thus led to inconsistent and confusing behaviour.