### PR TITLE
Update condition for layer splitting logic

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/unzipping/AlternatingLayerUnzipper.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/unzipping/AlternatingLayerUnzipper.java
@@ -96,10 +96,10 @@ public class AlternatingLayerUnzipper implements ILayoutProcessor<LGraph> {
                 
             }
             
-            // only split if there are more nodes than the resulting sub-layers
+            // only split if there enough nodes to fill the resulting sub-layers
             // an alternative would be to reduce N for this layer, this may or may
             // not be desirable
-            if (graph.getLayers().get(i).getNodes().size() > N) {
+            if (graph.getLayers().get(i).getNodes().size() >= N) {
                 
                 List<Layer> subLayers = new ArrayList<>();
                 // add current layer as first sub-layer


### PR DESCRIPTION
allow putting each node in a split layer alone in a sublayer
removes an unnecessary restriction in the layer splitting option