### PR TITLE
Docs: Do not use legacy `properties` in JSON example

### DIFF
--- a/docs/content/documentation/tooldevelopers/graphdatastructure/jsonformat.md
+++ b/docs/content/documentation/tooldevelopers/graphdatastructure/jsonformat.md
@@ -177,7 +177,7 @@ an edge's representation might look like the following after layout.
 ```json
 {
   id: "root",
-  properties: { "elk.direction": "RIGHT" },
+  layoutOptions: { "elk.direction": "RIGHT" },
   children: [
     { id: "n1", width: 10, height: 10 },
     { id: "n2", width: 10, height: 10 }


### PR DESCRIPTION
The [docs page](https://eclipse.dev/elk/documentation/tooldevelopers/graphdatastructure/jsonformat.html) on the JSON graph format still shows use of the legacy `properties` field in the "Small Example".

We update it to use `layoutOptions` instead.