### PR TITLE
Use deterministic side ordering for opposing self-loops

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/routing/RoutingDirector.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/routing/RoutingDirector.java
@@ -142,7 +142,7 @@ public class RoutingDirector {
      * loop is routed through. The exact routing we choose determines the number of edge crossings.
      */
     private void determineTwoSideOpposingLoopRoutes(final SelfHyperLoop slLoop) {
-        PortSide[] sides = slLoop.getSLPortsBySide().keySet().toArray(new PortSide[2]);
+        PortSide[] sides = PortRestorer.sortedTwoSideLoopPortSides(slLoop);
         assert sides.length == 2;
 
         SelfLoopHolder slHolder = slLoop.getSLHolder();

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/loops/routing/RoutingDirectorTest.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/intermediate/loops/routing/RoutingDirectorTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Kiel University and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.intermediate.loops.routing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.EnumSet;
+
+import org.eclipse.elk.alg.layered.graph.LGraph;
+import org.eclipse.elk.alg.layered.graph.LNode;
+import org.eclipse.elk.alg.layered.graph.LPort;
+import org.eclipse.elk.alg.layered.intermediate.loops.SelfHyperLoop;
+import org.eclipse.elk.alg.layered.intermediate.loops.SelfLoopHolder;
+import org.eclipse.elk.alg.layered.intermediate.loops.SelfLoopPort;
+import org.eclipse.elk.alg.layered.intermediate.loops.SelfLoopTestGraphCreator;
+import org.eclipse.elk.core.options.PortSide;
+import org.junit.Test;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+
+/**
+ * Tests whether {@link RoutingDirector} determines opposing two-side self-loop routes independent of multimap key
+ * iteration order.
+ */
+public class RoutingDirectorTest {
+
+    @Test
+    public void testOpposingTwoSideLoopUsesDeterministicSideOrder() throws Exception {
+        LGraph graph = new LGraph();
+        LNode node = SelfLoopTestGraphCreator.node(graph);
+
+        // Create one unconnected port on each side in the default clockwise order. This makes the penalties for the two
+        // possible east-west loop routes equal, so the chosen route depends only on side ordering.
+        SelfLoopTestGraphCreator.ports(node, 1, 1, 1, 1);
+
+        LPort eastPort = node.getPorts().get(1);
+        LPort westPort = node.getPorts().get(3);
+        SelfLoopTestGraphCreator.edge(eastPort, westPort);
+
+        SelfLoopHolder slHolder = SelfLoopHolder.install(node);
+        SelfHyperLoop slLoop = slHolder.getSLHyperLoops().get(0);
+        slLoop.computePortsPerSide();
+
+        // Simulate an arbitrary key-set iteration order opposite to the deterministic clockwise order.
+        ListMultimap<PortSide, SelfLoopPort> reversedSides = ArrayListMultimap.create();
+        reversedSides.putAll(PortSide.WEST, slLoop.getSLPortsBySide(PortSide.WEST));
+        reversedSides.putAll(PortSide.EAST, slLoop.getSLPortsBySide(PortSide.EAST));
+        setPortsBySide(slLoop, reversedSides);
+
+        new RoutingDirector().determineLoopRoutes(slHolder);
+
+        assertSame(eastPort, slLoop.getLeftmostPort().getLPort());
+        assertSame(westPort, slLoop.getRightmostPort().getLPort());
+        assertEquals(EnumSet.of(PortSide.EAST, PortSide.SOUTH, PortSide.WEST), slLoop.getOccupiedPortSides());
+    }
+
+    private static void setPortsBySide(final SelfHyperLoop slLoop, final ListMultimap<PortSide, SelfLoopPort> portsBySide)
+            throws Exception {
+        Field field = SelfHyperLoop.class.getDeclaredField("slPortsBySide");
+        field.setAccessible(true);
+        field.set(slLoop, portsBySide);
+    }
+}


### PR DESCRIPTION
During work on elkjs, layout results for the models below were not stable. 

The self-loop router is deriving the two sides of an opposing two-side self-loop from map key iteration order (`.keySet()` of an `ArrayListMultimap`). That order is not guaranteed to be stable across runtimes, so equivalent graphs could choose different loop directions and produce different layouts.


```
Layout equality smoke summary: 517/550 graph(s) matched.
Mismatched graphs: 33
- elk-models/realworld/ptolemy/flattened/backtrack_trialmodule_TrialModule.json
- elk-models/realworld/ptolemy/flattened/backtrack_trialmodule_TrialModuleNonBacktrack.json
- elk-models/realworld/ptolemy/flattened/de_printingpress_PrintingPress-Validation.json
- elk-models/realworld/ptolemy/flattened/ptera_adaptivecarwash_AdaptiveCarWash.json
- elk-models/realworld/ptolemy/flattened/ptera_adaptivecarwash_AdaptiveCarWashFSM.json
- elk-models/realworld/ptolemy/flattened/ptera_simultaneouscarwash_SimultaneousCarWash.json
- elk-models/realworld/ptolemy/flattened/ptera_trafficlight_TrafficLight.json
- elk-models/realworld/ptolemy/flattened/ptides_distributedpowerplant_DistributedPowerPlant.json
- elk-models/realworld/ptolemy/flattened/ptides_multiplatformtdma_MultiPlatformTDMA.json
- elk-models/realworld/ptolemy/flattened/ptides_powerplant_PowerPlant.json
- elk-models/realworld/ptolemy/flattened/ptides_printingpress_PrintingPress.json
- elk-models/realworld/ptolemy/flattened/ptides_trex_TREX.json
- elk-models/realworld/ptolemy/flattened/ptides_trex_TREXNoNetworkAllDigital.json
- elk-models/realworld/ptolemy/flattened/ptolemy_test_auto_ChannelFaultModel.json
- elk-models/realworld/ptolemy/flattened/rendezvous_trialmodule_TrialModule.json
- elk-models/realworld/ptolemy/flattened/rendezvous_trialmodule_TrialModuleNonBacktrack.json
- elk-models/realworld/ptolemy/hierarchical/backtrack_trialmodule_TrialModule.json
- elk-models/realworld/ptolemy/hierarchical/backtrack_trialmodule_TrialModuleNonBacktrack.json
- elk-models/realworld/ptolemy/hierarchical/de_printingpress_PrintingPress-Validation.json
- elk-models/realworld/ptolemy/hierarchical/gt_sinewaveoptimization_SinewaveOptimization.json
- elk-models/realworld/ptolemy/hierarchical/ptera_adaptivecarwash_AdaptiveCarWash.json
- elk-models/realworld/ptolemy/hierarchical/ptera_adaptivecarwash_AdaptiveCarWashFSM.json
- elk-models/realworld/ptolemy/hierarchical/ptera_carwash_CarWashDE.json
- elk-models/realworld/ptolemy/hierarchical/ptera_simultaneouscarwash_SimultaneousCarWash.json
- elk-models/realworld/ptolemy/hierarchical/ptera_trafficlight_TrafficLight.json
- elk-models/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPatternComplex1.json
- elk-models/realworld/ptolemy/hierarchical/ptides_distributedpowerplant_DistributedPowerPlant.json
- elk-models/realworld/ptolemy/hierarchical/ptides_multiplatformtdma_MultiPlatformTDMA.json
- elk-models/realworld/ptolemy/hierarchical/ptides_powerplant_PowerPlant.json
- elk-models/realworld/ptolemy/hierarchical/ptides_printingpress_PrintingPress.json
- elk-models/realworld/ptolemy/hierarchical/ptolemy_probabilisticmodels_ChannelFaultModel.json
- elk-models/realworld/ptolemy/hierarchical/rendezvous_trialmodule_TrialModule.json
- elk-models/realworld/ptolemy/hierarchical/rendezvous_trialmodule_TrialModuleNonBacktrack.json
```