### PR TITLE
rm com.google.guava from main bundles

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.alg.layered/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-SymbolicName: org.eclipse.elk.alg.layered;singleton:=true
 Bundle-Version: 0.12.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: com.google.guava,
- org.eclipse.emf.ecore;bundle-version="2.10.0",
+Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.0",
  org.eclipse.xtext.xbase.lib;bundle-version="2.10.0",
  org.eclipse.elk.graph,
  org.eclipse.elk.core,

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/JsonDebugUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/JsonDebugUtil.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -30,8 +31,6 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.graph.properties.IProperty;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 
 /**
  * A utility class for debugging of ELK Layered.
@@ -82,8 +81,8 @@ public final class JsonDebugUtil {
         beginGraph(writer, layeredGraph);
         beginChildNodeList(writer, 1);
 
-        String indent1 = Strings.repeat(INDENT, 2);
-        String indent2 = Strings.repeat(INDENT, 3); // SUPPRESS CHECKSTYLE MagicNumber
+        String indent1 = (INDENT).repeat(2);
+        String indent2 = (INDENT).repeat(3); // SUPPRESS CHECKSTYLE MagicNumber
         int edgeId = 0;
         
         Iterator<LinearSegment> segmentIterator = segmentList.iterator();
@@ -143,8 +142,8 @@ public final class JsonDebugUtil {
         beginGraph(writer, layeredGraph);
         beginChildNodeList(writer, 1);
 
-        String indent1 = Strings.repeat(INDENT, 2);
-        String indent2 = Strings.repeat(INDENT, 3); // SUPPRESS CHECKSTYLE MagicNumber
+        String indent1 = (INDENT).repeat(2);
+        String indent2 = (INDENT).repeat(3); // SUPPRESS CHECKSTYLE MagicNumber
         int edgeId = 0;
         
         Iterator<HyperEdgeSegment> hypernodeIterator = hypernodes.iterator();
@@ -286,7 +285,7 @@ public final class JsonDebugUtil {
         KVector offset = new KVector(lgraph.getOffset())
                 .add(lgraph.getPadding().left, lgraph.getPadding().top);
         
-        List<LEdge> edges = Lists.newLinkedList();
+        List<LEdge> edges = new LinkedList<>();
         beginChildNodeList(writer, indentation);
         
         // Write layerless nodes and collect edges
@@ -325,7 +324,7 @@ public final class JsonDebugUtil {
      *            the indentation level to use.
      */
     private static void beginChildNodeList(final StringWriter writer, final int indentation) {
-        writer.write(",\n" + Strings.repeat(INDENT, indentation) + "\"children\": [");
+        writer.write(",\n" + (INDENT).repeat(indentation) + "\"children\": [");
     }
 
 
@@ -338,7 +337,7 @@ public final class JsonDebugUtil {
      *            the indentation level to use.
      */
     private static void endChildNodeList(final StringWriter writer, final int indentation) {
-        writer.write("\n" + Strings.repeat(INDENT, indentation) + "],\n");
+        writer.write("\n" + (INDENT).repeat(indentation) + "],\n");
     }
 
 
@@ -372,12 +371,12 @@ public final class JsonDebugUtil {
             final int indentation, final KVector offset) {
         
         if (nodes.isEmpty()) {
-            return Lists.newLinkedList();
+            return new LinkedList<>();
         }
         
         writeNodes(writer, nodes, indentation, layerNumber, offset);
         
-        List<LEdge> edges = Lists.newLinkedList();
+        List<LEdge> edges = new LinkedList<>();
         
         // Collect the edges
         for (LNode node : nodes) {
@@ -408,8 +407,8 @@ public final class JsonDebugUtil {
     private static void writeNodes(final StringWriter writer, final List<LNode> nodes, final int indentation,
             final int layerNumber, final KVector offset) {
         
-        String indent0 = Strings.repeat(INDENT, indentation);
-        String indent1 = Strings.repeat(INDENT, indentation + 1);
+        String indent0 = (INDENT).repeat(indentation);
+        String indent1 = (INDENT).repeat(indentation + 1);
         int nodeNumber = -1;
         Iterator<LNode> nodesIterator = nodes.iterator();
         while (nodesIterator.hasNext()) {
@@ -454,9 +453,9 @@ public final class JsonDebugUtil {
     private static void writeEdges(final StringWriter writer, final List<LEdge> edges, final int indentation,
             final KVector offset) {
     
-        String indent0 = Strings.repeat(INDENT, indentation);
-        String indent1 = Strings.repeat(INDENT, indentation + 1);
-        String indent2 = Strings.repeat(INDENT, indentation + 2);
+        String indent0 = (INDENT).repeat(indentation);
+        String indent1 = (INDENT).repeat(indentation + 1);
+        String indent2 = (INDENT).repeat(indentation + 2);
         writer.write(indent0 + "\"edges\": [");
         Iterator<LEdge> edgesIterator = edges.iterator();
         while (edgesIterator.hasNext()) {
@@ -500,8 +499,8 @@ public final class JsonDebugUtil {
     private static void writeBendPoints(final StringWriter writer, final KVectorChain bendPoints,
             final int indentation, final KVector offset) {
         
-        String indent0 = Strings.repeat(INDENT, indentation);
-        String indent1 = Strings.repeat(INDENT, indentation + 1);
+        String indent0 = (INDENT).repeat(indentation);
+        String indent1 = (INDENT).repeat(indentation + 1);
         writer.write(indent0 + "\"bendPoints\": [");
         Iterator<KVector> pointsIterator = bendPoints.iterator();
         while (pointsIterator.hasNext()) {
@@ -525,9 +524,9 @@ public final class JsonDebugUtil {
      *            the indentation level to use.
      */
     private static void writePorts(final StringWriter writer, final List<LPort> ports, final int indentation) {
-            String indent0 = Strings.repeat(INDENT, indentation);
-            String indent1 = Strings.repeat(INDENT, indentation + 1);
-            String indent2 = Strings.repeat(INDENT, indentation + 2);
+            String indent0 = (INDENT).repeat(indentation);
+            String indent1 = (INDENT).repeat(indentation + 1);
+            String indent2 = (INDENT).repeat(indentation + 2);
             writer.write(indent0 + "\"ports\": [");
             Iterator<LPort> portsIterator = ports.iterator();
             while (portsIterator.hasNext()) {
@@ -561,8 +560,8 @@ public final class JsonDebugUtil {
     private static void writeProperties(final StringWriter writer, final Map<IProperty<?>, Object> properties,
             final int indentation) {
         
-        String indent0 = Strings.repeat(INDENT, indentation);
-        String indent1 = Strings.repeat(INDENT, indentation + 1);
+        String indent0 = (INDENT).repeat(indentation);
+        String indent1 = (INDENT).repeat(indentation + 1);
         writer.write(indent0 + "\"properties\": {");
         Iterator<Entry<IProperty<?>, Object>> propertiesIterator =
                 properties.entrySet().iterator();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/components/ComponentsToCGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/components/ComponentsToCGraphTransformer.java
@@ -24,7 +24,10 @@ import static org.eclipse.elk.core.options.PortSide.SIDES_SOUTH;
 import static org.eclipse.elk.core.options.PortSide.SIDES_SOUTH_WEST;
 import static org.eclipse.elk.core.options.PortSide.SIDES_WEST;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -39,9 +42,7 @@ import org.eclipse.elk.core.options.Direction;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
+import java.util.EnumMap;
 
 /**
  * Transforms {@link IConnectedComponents} into a representing {@link CGraph} which can be passed to
@@ -62,16 +63,16 @@ public class ComponentsToCGraphTransformer<N, E> implements
     private double spacing;
 
     // internal mappings 
-    private Map<IComponent<N, E>, KVector> oldPosition = Maps.newHashMap();
-    private Map<IComponent<N, E>, CRectNode> offsets = Maps.newHashMap();
+    private Map<IComponent<N, E>, KVector> oldPosition = new HashMap<>();
+    private Map<IComponent<N, E>, CRectNode> offsets = new HashMap<>();
     
     // a global offset and the new graph size after layout
     private KVector globalOffset;
     private KVector graphSize;
 
     // maps the external extension to the CNodes by which they are represented
-    private Map<IExternalExtension<E>, Pair<CGroup, CNode>> externalExtensions = Maps.newHashMap();
-    private Multimap<Direction, Pair<CGroup, CNode>> externalPlaceholder = HashMultimap.create();
+    private Map<IExternalExtension<E>, Pair<CGroup, CNode>> externalExtensions = new HashMap<>();
+    private Map<Direction, List<Pair<CGroup, CNode>>> externalPlaceholder = new EnumMap<>(Direction.class);
     
     /**
      * @param spacing required spacing between connected IComponents.
@@ -114,7 +115,7 @@ public class ComponentsToCGraphTransformer<N, E> implements
     /**
      * @return the externalPlaceholder
      */
-    public Multimap<Direction, Pair<CGroup, CNode>> getExternalPlaceholder() {
+    public Map<Direction, List<Pair<CGroup, CNode>>> getExternalPlaceholder() {
         return externalPlaceholder;
     }
     
@@ -160,7 +161,8 @@ public class ComponentsToCGraphTransformer<N, E> implements
                     setLock(rectPlaceholder, comp.getExternalExtensionSides());
                     CGroup dummyGroup = new CGroup();
                     dummyGroup.addCNode(rectPlaceholder);
-                    externalPlaceholder.put(ee.getDirection(), Pair.of(group, rectPlaceholder));
+                    externalPlaceholder.computeIfAbsent(ee.getDirection(), k -> new ArrayList<>())
+                            .add(Pair.of(group, rectPlaceholder));
                 }
             }
         }
@@ -258,12 +260,14 @@ public class ComponentsToCGraphTransformer<N, E> implements
         
         // note that placeholdes "can move" during compaction and are _not_ fixed to the boundary
         // which allows to use them to determine the maximum position
-        for (Pair<CGroup, CNode> placeholder : externalPlaceholder.values()) {
-            CNode cNode = placeholder.getSecond();
-            topLeft.x = Math.min(topLeft.x, cNode.hitbox.x);
-            topLeft.y = Math.min(topLeft.y, cNode.hitbox.y);
-            bottomRight.x = Math.max(bottomRight.x, cNode.hitbox.x + cNode.hitbox.width);
-            bottomRight.y = Math.max(bottomRight.y, cNode.hitbox.y + cNode.hitbox.height);
+        for (List<Pair<CGroup, CNode>> placeholders : externalPlaceholder.values()) {
+            for (Pair<CGroup, CNode> placeholder : placeholders) {
+                CNode cNode = placeholder.getSecond();
+                topLeft.x = Math.min(topLeft.x, cNode.hitbox.x);
+                topLeft.y = Math.min(topLeft.y, cNode.hitbox.y);
+                bottomRight.x = Math.max(bottomRight.x, cNode.hitbox.x + cNode.hitbox.width);
+                bottomRight.y = Math.max(bottomRight.y, cNode.hitbox.y + cNode.hitbox.height);
+            }
         }
         
         globalOffset = topLeft.clone().negate();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/components/OneDimensionalComponentsCompaction.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/components/OneDimensionalComponentsCompaction.java
@@ -12,6 +12,8 @@ package org.eclipse.elk.alg.layered.compaction.components;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashSet;
 
 import org.eclipse.elk.alg.layered.compaction.oned.CGraph;
 import org.eclipse.elk.alg.layered.compaction.oned.CGroup;
@@ -22,8 +24,6 @@ import org.eclipse.elk.core.options.Direction;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Compacts connected components using a {@link OneDimensionalCompactor}. Consecutively applies
@@ -57,8 +57,8 @@ public final class OneDimensionalComponentsCompaction<N, E> {
         HORZ,
         VERT
     }
-    private static final Set<Direction> LEFT_RIGHT = Sets.newHashSet(Direction.LEFT, Direction.RIGHT);
-    private static final Set<Direction> UP_DOWN = Sets.newHashSet(Direction.UP, Direction.DOWN);
+    private static final Set<Direction> LEFT_RIGHT = new HashSet<>(java.util.Arrays.asList(Direction.LEFT, Direction.RIGHT));
+    private static final Set<Direction> UP_DOWN = new HashSet<>(java.util.Arrays.asList(Direction.UP, Direction.DOWN));
     
     /** Use {@link #init(IConnectedComponents, double)}. */
     private OneDimensionalComponentsCompaction() { }
@@ -97,9 +97,9 @@ public final class OneDimensionalComponentsCompaction<N, E> {
     public void compact(final IElkProgressMonitor monitor) {
         
         // separate vertical and horizontal extensions
-        List<CNode> allNodes = Lists.newArrayList();
-        verticalExternalExtensions = Lists.newArrayList();
-        horizontalExternalExtensions = Lists.newArrayList();
+        List<CNode> allNodes = new ArrayList<>();
+        verticalExternalExtensions = new ArrayList<>();
+        horizontalExternalExtensions = new ArrayList<>();
 
         for (Entry<IExternalExtension<E>, Pair<CGroup, CNode>> entry : transformer
                 .getExternalExtensions().entrySet()) {
@@ -319,7 +319,8 @@ public final class OneDimensionalComponentsCompaction<N, E> {
     private void addPlaceholders(final Dir dir) {
         Set<Direction> dirs = (dir == Dir.VERT) ? UP_DOWN : LEFT_RIGHT;
         for (Direction d : dirs) {
-            for (Pair<CGroup, CNode> pair : transformer.getExternalPlaceholder().get(d)) {
+            for (Pair<CGroup, CNode> pair : transformer.getExternalPlaceholder()
+                    .getOrDefault(d, java.util.Collections.emptyList())) {
                 compactionGraph.cNodes.add(pair.getSecond());
                 compactionGraph.cGroups.add(pair.getSecond().cGroup);
             }
@@ -329,7 +330,8 @@ public final class OneDimensionalComponentsCompaction<N, E> {
     private void removePlaceholders(final Dir dir) {
         Set<Direction> dirs = (dir == Dir.VERT) ? UP_DOWN : LEFT_RIGHT;
         for (Direction d : dirs) {
-            for (Pair<CGroup, CNode> pair : transformer.getExternalPlaceholder().get(d)) {
+            for (Pair<CGroup, CNode> pair : transformer.getExternalPlaceholder()
+                    .getOrDefault(d, java.util.Collections.emptyList())) {
                 compactionGraph.cNodes.remove(pair.getSecond());
                 compactionGraph.cGroups.remove(pair.getSecond().cGroup);
             }
@@ -339,7 +341,8 @@ public final class OneDimensionalComponentsCompaction<N, E> {
     private void updatePlaceholders(final Dir dir) {
         Set<Direction> dirs = (dir == Dir.VERT) ? UP_DOWN : LEFT_RIGHT;
         for (Direction d : dirs) {
-            for (Pair<CGroup, CNode> pair : transformer.getExternalPlaceholder().get(d)) {
+            for (Pair<CGroup, CNode> pair : transformer.getExternalPlaceholder()
+                    .getOrDefault(d, java.util.Collections.emptyList())) {
                 CNode cNode = pair.getSecond();
                 CGroup parentComponentGroup = pair.getFirst();
                 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CGraph.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CGraph.java
@@ -11,10 +11,10 @@ package org.eclipse.elk.alg.layered.compaction.oned;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.core.options.Direction;
 
-import com.google.common.collect.Lists;
 
 /**
  * Internal representation of a constraint graph.
@@ -25,9 +25,9 @@ public final class CGraph {
     // Variables are public for convenience reasons since this class is used internally only.
     // SUPPRESS CHECKSTYLE NEXT 4 VisibilityModifier
     /** the list of {@link CNode}s modeling the constraints in this graph. */
-    public List<CNode> cNodes = Lists.newArrayList();
+    public List<CNode> cNodes = new ArrayList<>();
     /** groups of elements that are supposed to stay in the configuration they are. */
-    public List<CGroup> cGroups = Lists.newArrayList();
+    public List<CGroup> cGroups = new ArrayList<>();
     /** the directions that are supported for compaction. */
     private EnumSet<Direction> supportedDirections;
     

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CGroup.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CGroup.java
@@ -10,8 +10,9 @@
 package org.eclipse.elk.alg.layered.compaction.oned;
 
 import java.util.Set;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 
-import com.google.common.collect.Sets;
 
 /**
  * Represents a group of {@link CNode}s whose relative distances to each other are preserved.
@@ -59,8 +60,8 @@ public final class CGroup {
      *            the {@link CNode}s to add
      */
     public CGroup(final CNode... inputCNodes) {
-        cNodes = Sets.newLinkedHashSet();
-        incomingConstraints = Sets.newHashSet();
+        cNodes = new LinkedHashSet<>();
+        incomingConstraints = new HashSet<>();
         outDegree = 0;
         for (CNode cNode : inputCNodes) {
             if (reference == null) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CNode.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CNode.java
@@ -10,12 +10,12 @@
 package org.eclipse.elk.alg.layered.compaction.oned;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraphElement;
 import org.eclipse.elk.core.math.ElkRectangle;
 import org.eclipse.elk.core.math.KVector;
 
-import com.google.common.collect.Lists;
 
 
 /**
@@ -36,7 +36,7 @@ public abstract class CNode {
     /** refers to the parent node of a north/south segment. */
     public CNode parentNode = null;
     /** representation of constraints. */
-    public List<CNode> constraints = Lists.newArrayList();
+    public List<CNode> constraints = new ArrayList<>();
     /** the area occupied by this element including margins for ports and labels. */
     public ElkRectangle hitbox;
     /** offset to the root position of the containing {@link CGroup} . */

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CompareFuzzy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/CompareFuzzy.java
@@ -9,35 +9,55 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.compaction.oned;
 
-import com.google.common.math.DoubleMath;
 
 /**
  * Internal Class for tolerance affected double comparisons.
  */
 public final class CompareFuzzy {
-    static final double TOLERANCE = 0.0001;
-    
+    /** Default fuzzy comparison tolerance. */
+    public static final double TOLERANCE = 0.0001;
+
     private CompareFuzzy() {
+    }
+
+    /** Tolerance-aware equality: {@code true} iff |a-b| &le; tolerance, with NaN handling. */
+    public static boolean fuzzyEquals(final double a, final double b, final double tolerance) {
+        return Math.abs(a - b) <= tolerance
+                || Double.valueOf(a).equals(Double.valueOf(b));
+    }
+
+    /** Tolerance-aware comparison consistent with {@link #fuzzyEquals}. */
+    public static int fuzzyCompare(final double a, final double b, final double tolerance) {
+        if (fuzzyEquals(a, b, tolerance)) {
+            return 0;
+        }
+        if (a < b) {
+            return -1;
+        }
+        if (a > b) {
+            return 1;
+        }
+        return Boolean.compare(Double.isNaN(a), Double.isNaN(b));
     }
 
     // SUPPRESS CHECKSTYLE NEXT 20 Javadoc
     public static boolean eq(final double d1, final double d2) {
-        return DoubleMath.fuzzyEquals(d1, d2, TOLERANCE);
+        return fuzzyEquals(d1, d2, TOLERANCE);
     }
 
     public static boolean gt(final double d1, final double d2) {
-        return DoubleMath.fuzzyCompare(d1, d2, TOLERANCE) > 0;
+        return fuzzyCompare(d1, d2, TOLERANCE) > 0;
     }
 
     public static boolean lt(final double d1, final double d2) {
-        return DoubleMath.fuzzyCompare(d1, d2, TOLERANCE) < 0;
+        return fuzzyCompare(d1, d2, TOLERANCE) < 0;
     }
 
     public static boolean ge(final double d1, final double d2) {
-        return DoubleMath.fuzzyCompare(d1, d2, TOLERANCE) >= 0;
+        return fuzzyCompare(d1, d2, TOLERANCE) >= 0;
     }
 
     public static boolean le(final double d1, final double d2) {
-        return DoubleMath.fuzzyCompare(d1, d2, TOLERANCE) <= 0;
+        return fuzzyCompare(d1, d2, TOLERANCE) <= 0;
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/OneDimensionalCompactor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/OneDimensionalCompactor.java
@@ -23,9 +23,9 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.core.util.LoggedGraph.Type;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * Implements the compaction of a {@link CGraph}. This includes the creation of a constraint graph
@@ -508,9 +508,9 @@ public final class OneDimensionalCompactor {
     private void reverseConstraints() {
 
         // maps CNodes to temporary lists of incoming constraints
-        Map<CNode, List<CNode>> incMap = Maps.newHashMap();
+        Map<CNode, List<CNode>> incMap = new HashMap<>();
         for (CNode cNode : cGraph.cNodes) {
-            incMap.put(cNode, Lists.newArrayList());
+            incMap.put(cNode, new ArrayList<>());
         }
         
         // resetting fields of CNodes and reversing constraints

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/LongestPathCompaction.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/LongestPathCompaction.java
@@ -10,13 +10,13 @@
 package org.eclipse.elk.alg.layered.compaction.oned.algs;
 
 import java.util.Queue;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.layered.compaction.oned.CGroup;
 import org.eclipse.elk.alg.layered.compaction.oned.CNode;
 import org.eclipse.elk.alg.layered.compaction.oned.OneDimensionalCompactor;
 import org.eclipse.elk.core.options.Direction;
 
-import com.google.common.collect.Lists;
 
 /**
  * Compacts a previously calculated constraint graph (
@@ -39,7 +39,7 @@ public class LongestPathCompaction implements ICompactionAlgorithm {
         }
         
         // finding the sinks of the constraint graph
-        Queue<CGroup> sinks = Lists.newLinkedList();
+        Queue<CGroup> sinks = new LinkedList<>();
         for (CGroup group : compactor.cGraph.cGroups) {
             group.startPos = minStartPos;
             if (group.outDegree == 0) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ScanlineConstraintCalculator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/oned/algs/ScanlineConstraintCalculator.java
@@ -18,10 +18,9 @@ import org.eclipse.elk.alg.layered.compaction.oned.OneDimensionalCompactor;
 import org.eclipse.elk.alg.layered.compaction.recthull.Scanline;
 import org.eclipse.elk.alg.layered.compaction.recthull.Scanline.EventHandler;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.ArrayList;
 
 /**
  * Scanline-procedure to calculate the constraint graph in O(nlogn) time, n being the number of
@@ -66,9 +65,9 @@ public class ScanlineConstraintCalculator implements IConstraintCalculationAlgor
         blowUpHitboxes(filterFun, spacingFun);
         
         // add all nodes twice (once for the lower, once for the upper border)
-        List<Timestamp> points = Lists.newArrayList();
+        List<Timestamp> points = new ArrayList<>();
         for (CNode n : compactor.cGraph.cNodes) {
-            if (filterFun.apply(n)) {
+            if (filterFun.test(n)) {
                 points.add(new Timestamp(n, true));
                 points.add(new Timestamp(n, false));
             }
@@ -89,7 +88,7 @@ public class ScanlineConstraintCalculator implements IConstraintCalculationAlgor
 
         for (CNode n : compactor.cGraph.cNodes) {
         
-            if (!filter.apply(n)) {
+            if (!filter.test(n)) {
                 continue;
             }
             
@@ -112,7 +111,7 @@ public class ScanlineConstraintCalculator implements IConstraintCalculationAlgor
             final Function<CNode, Double> spacingFun) {
         for (CNode n : compactor.cGraph.cNodes) {
             
-            if (!filter.apply(n)) {
+            if (!filter.test(n)) {
                 continue;
             }
             
@@ -193,7 +192,7 @@ public class ScanlineConstraintCalculator implements IConstraintCalculationAlgor
          * Note: the methods to query for neighbor elements (e.g., {@link TreeSet#lower(Object)})
          * are not constant time.
          */
-        private TreeSet<CNode> intervals = Sets.newTreeSet((c1, c2) -> Double.compare(
+        private TreeSet<CNode> intervals = new TreeSet<>((c1, c2) -> Double.compare(
                 c1.hitbox.x + (c1.hitbox.width / 2), c2.hitbox.x + (c2.hitbox.width / 2)));
         /** Candidate array with possible constraints. */
         private CNode[] cand;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/RectilinearConvexHull.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/RectilinearConvexHull.java
@@ -13,12 +13,13 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.compaction.recthull.Point.Quadrant;
 import org.eclipse.elk.alg.layered.compaction.recthull.Scanline.EventHandler;
 import org.eclipse.elk.core.math.ElkRectangle;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * The rectilinear convex hull is represented by four staircases.
@@ -30,7 +31,7 @@ import com.google.common.collect.Lists;
 public final class RectilinearConvexHull {
 
     /** This hull's determined points. */
-    private List<Point> hull = Lists.newArrayList();
+    private List<Point> hull = new ArrayList<>();
 
     @SuppressWarnings("unused")
     private Point xMax1 = null, xMax2 = null;
@@ -97,9 +98,9 @@ public final class RectilinearConvexHull {
             // print clockwise
             System.out.println("The four stairs (no concaves):");
             System.out.println(q1.points);
-            System.out.println(Lists.reverse(q2.points));
+            System.out.println(LGraphUtil.reversed(q2.points));
             System.out.println(q3.points);
-            System.out.println(Lists.reverse(q4.points));
+            System.out.println(LGraphUtil.reversed(q4.points));
         }
         
         // the scanline algorithm detected all convex corners, 
@@ -113,18 +114,18 @@ public final class RectilinearConvexHull {
         if (DEBUG) {
             System.out.println("The four stairs (with concaves):");
             System.out.println(q1.points);
-            System.out.println(Lists.reverse(q2.points));
+            System.out.println(LGraphUtil.reversed(q2.points));
             System.out.println(q3.points);
-            System.out.println(Lists.reverse(q4.points));
+            System.out.println(LGraphUtil.reversed(q4.points));
         }
         
         // ... and add everything to the hull list
         // (in clockwise order, q1..q4)
         rch.getHull().clear();
         rch.getHull().addAll(q1.points);
-        rch.getHull().addAll(Lists.reverse(q2.points));
+        rch.getHull().addAll(LGraphUtil.reversed(q2.points));
         rch.getHull().addAll(q3.points);
-        rch.getHull().addAll(Lists.reverse(q4.points));
+        rch.getHull().addAll(LGraphUtil.reversed(q4.points));
 
         return rch;
     }
@@ -218,7 +219,7 @@ public final class RectilinearConvexHull {
         // SUPPRESS CHECKSTYLE NEXT 10 VisibilityModifier
         private Quadrant quadrant;
         /** The points this handler determined after the execution of the scanline. */
-        public List<Point> points = Lists.newArrayList();
+        public List<Point> points = new ArrayList<>();
         private double maximalY;
         private Comparator<Double> compare;
 
@@ -300,7 +301,7 @@ public final class RectilinearConvexHull {
      */
     private class RectangleEventHandler implements EventHandler<Point> {
 
-        private List<ElkRectangle> rects = Lists.newArrayList();
+        private List<ElkRectangle> rects = new ArrayList<>();
 
         private Point minY = null;
         private Point maxY = null;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/Scanline.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compaction/recthull/Scanline.java
@@ -13,8 +13,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.ArrayList;
 
-import com.google.common.collect.Lists;
 
 /**
  * Simple scaffold for a scanline algorithm.
@@ -35,7 +35,8 @@ public final class Scanline<T> {
             final Iterable<EventHandler<T>> eventHandlers) {
         this.comparator = comparator;
         this.points = points;
-        this.eventHandlers = Lists.newArrayList(eventHandlers);
+        this.eventHandlers = new ArrayList<>();
+        eventHandlers.forEach(this.eventHandlers::add);
     }
 
     /**
@@ -52,7 +53,8 @@ public final class Scanline<T> {
     public static <T> void execute(final Iterable<T> points, final Comparator<T> comparator,
             final Iterable<EventHandler<T>> eventHandlers) {
         // copy the points! we will resort them!
-        List<T> copy = Lists.newArrayList(points);
+        List<T> copy = new ArrayList<>();
+        points.forEach(copy::add);
         new Scanline<T>(copy, comparator, eventHandlers).go();
     }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroup.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroup.java
@@ -26,16 +26,18 @@ import static org.eclipse.elk.core.options.PortSide.SIDES_SOUTH;
 import static org.eclipse.elk.core.options.PortSide.SIDES_SOUTH_WEST;
 import static org.eclipse.elk.core.options.PortSide.SIDES_WEST;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.core.options.PortSide;
-
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 
 /**
  * Represents a group of connected components grouped for layout purposes.
@@ -88,83 +90,87 @@ public class ComponentGroup {
      * port sides to a list of port side sets that must not already exist in this group for a
      * component to be added.</p>
      */
-    protected static final Multimap<Set<PortSide>, Set<PortSide>> CONSTRAINTS = HashMultimap.create();
+    protected static final Map<Set<PortSide>, Set<Set<PortSide>>> CONSTRAINTS = new HashMap<>();
+
+    private static void putConstraint(final Set<PortSide> key, final Set<PortSide> value) {
+        CONSTRAINTS.computeIfAbsent(key, k -> new HashSet<>()).add(value);
+    }
     
     static {
         // Setup constraints
-        CONSTRAINTS.put(SIDES_NONE, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_SOUTH, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_SOUTH, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_NORTH_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NORTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NORTH_EAST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_SOUTH_WEST, SIDES_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH, SIDES_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH_SOUTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_EAST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NONE);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_SOUTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_EAST_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH);
-        CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NONE, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_EAST, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_EAST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_SOUTH, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_SOUTH, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_SOUTH, SIDES_EAST_WEST);
+        putConstraint(SIDES_NORTH_SOUTH, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_SOUTH, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_NORTH_SOUTH, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_EAST_WEST, SIDES_NORTH_SOUTH);
+        putConstraint(SIDES_EAST_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_EAST_WEST, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_EAST_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_WEST, SIDES_NORTH_WEST);
+        putConstraint(SIDES_NORTH_WEST, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_NORTH_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST, SIDES_NORTH_EAST);
+        putConstraint(SIDES_NORTH_EAST, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_NORTH_EAST, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_SOUTH_WEST, SIDES_SOUTH_WEST);
+        putConstraint(SIDES_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_EAST_SOUTH, SIDES_EAST_SOUTH);
+        putConstraint(SIDES_EAST_SOUTH, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_EAST_SOUTH, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH_SOUTH);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_WEST, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_SOUTH);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_SOUTH_WEST);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_EAST_SOUTH);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_EAST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_SOUTH);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_NORTH_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NONE);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_SOUTH);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_EAST_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_SOUTH_WEST);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH);
+        putConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
     }
     
     
@@ -174,7 +180,7 @@ public class ComponentGroup {
     /**
      * A map mapping external port side combinations to components in this group.
      */
-    protected Multimap<Set<PortSide>, LGraph> components = ArrayListMultimap.create();
+    protected Map<Set<PortSide>, List<LGraph>> components = new HashMap<>();
     
     
     ///////////////////////////////////////////////////////////////////////////////
@@ -211,9 +217,10 @@ public class ComponentGroup {
      */
     public boolean add(final LGraph component) {
         if (canAdd(component)) {
-            components.put(
-                component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS),
-                component);
+            components
+                .computeIfAbsent(component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS),
+                        k -> new ArrayList<>())
+                .add(component);
             return true;
         } else {
             return false;
@@ -230,10 +237,10 @@ public class ComponentGroup {
     protected boolean canAdd(final LGraph component) {
         // Check if we have a component with incompatible external port sides
         Set<PortSide> candidateSides = component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS);
-        Collection<Set<PortSide>> constraints = CONSTRAINTS.get(candidateSides);
-        
+        Set<Set<PortSide>> constraints = CONSTRAINTS.getOrDefault(candidateSides, Collections.emptySet());
+
         for (Set<PortSide> constraint : constraints) {
-            if (!components.get(constraint).isEmpty()) {
+            if (!components.getOrDefault(constraint, Collections.emptyList()).isEmpty()) {
                 // A component with a conflicting external port side combination exists
                 return false;
             }
@@ -249,7 +256,14 @@ public class ComponentGroup {
      * @return all port sides in this component group.
      */
     public Collection<Set<PortSide>> getPortSides() {
-        return components.keys();
+        // Mirrors Multimap.keys(): each key appears with its multiplicity (one occurrence per value).
+        List<Set<PortSide>> result = new ArrayList<>();
+        for (Map.Entry<Set<PortSide>, List<LGraph>> entry : components.entrySet()) {
+            for (int i = 0; i < entry.getValue().size(); i++) {
+                result.add(entry.getKey());
+            }
+        }
+        return result;
     }
     
     /**
@@ -258,7 +272,11 @@ public class ComponentGroup {
      * @return the components in this component group.
      */
     public Collection<LGraph> getComponents() {
-        return components.values();
+        List<LGraph> result = new ArrayList<>();
+        for (List<LGraph> bucket : components.values()) {
+            result.addAll(bucket);
+        }
+        return result;
     }
     
     /**
@@ -270,6 +288,6 @@ public class ComponentGroup {
      *         returned.
      */
     public Collection<LGraph> getComponents(final Set<PortSide> connections) {
-        return components.get(connections);
+        return components.getOrDefault(connections, Collections.emptyList());
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupGraphPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentGroupGraphPlacer.java
@@ -28,6 +28,7 @@ import static org.eclipse.elk.core.options.PortSide.SIDES_WEST;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
@@ -35,7 +36,6 @@ import org.eclipse.elk.core.math.ElkMath;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.EdgeRouting;
 
-import com.google.common.collect.Lists;
 
 /**
  * A graph placer that tries to place the components of a graph with taking connections to external
@@ -57,7 +57,7 @@ class ComponentGroupGraphPlacer extends AbstractGraphPlacer {
     /**
      * List of component groups holding the different components.
      */
-    protected final List<ComponentGroup> componentGroups = Lists.newArrayList();
+    protected final List<ComponentGroup> componentGroups = new ArrayList<>();
     
     
     ///////////////////////////////////////////////////////////////////////////////

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsCompactor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsCompactor.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.elk.alg.layered.compaction.components.IComponent;
@@ -40,11 +42,9 @@ import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.BasicProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
-import com.google.common.math.DoubleMath;
+import java.util.EnumMap;
+
+import org.eclipse.elk.alg.layered.compaction.oned.CompareFuzzy;
 
 /**
  * Contains implementations of the {@link IConnectedComponents} and {@link IComponent} interfaces
@@ -153,10 +153,10 @@ public class ComponentsCompactor {
                         last = v;
                         continue;
                     }
-                    if (DoubleMath.fuzzyEquals(last.x, v.x, EPSILON)) {
+                    if (CompareFuzzy.fuzzyEquals(last.x, v.x, EPSILON)) {
                         yetAnotherOffset.x = Math.min(yetAnotherOffset.x, last.x);
                         compactedGraphSize.x = Math.max(compactedGraphSize.x, last.x);
-                    } else if (DoubleMath.fuzzyEquals(last.y, v.y, EPSILON)) {
+                    } else if (CompareFuzzy.fuzzyEquals(last.y, v.y, EPSILON)) {
                         yetAnotherOffset.y = Math.min(yetAnotherOffset.y, last.y);
                         compactedGraphSize.y = Math.max(compactedGraphSize.y, last.y);
                     }
@@ -207,21 +207,22 @@ public class ComponentsCompactor {
         // #2 convert external edges,
         //    while doing this, add further hull points contributed by inner segments
         //    and remember extreme points of external segments
-        Multimap<Direction, LEdge> externalExtensions = HashMultimap.create();
+        Map<Direction, Set<LEdge>> externalExtensions = new EnumMap<>(Direction.class);
         OuterSegments outerSegments = new OuterSegments();
         
         for (LNode node : graph.getLayerlessNodes()) {
             for (LEdge edge : node.getOutgoingEdges()) {
                 if (isExternalEdge(edge)) {
                     IExternalExtension<LEdge> iee = transformLEdge(edge, hullPoints, outerSegments);
-                    externalExtensions.put(iee.getDirection(), iee.getRepresentative());
+                    externalExtensions.computeIfAbsent(iee.getDirection(), k -> new HashSet<>())
+                            .add(iee.getRepresentative());
                 }
             }
         }
 
         // #3 create the common external extensions for this component
         //    (there can be 4 per component, one in each direction)
-        List<InternalUnionExternalExtension> extensions = Lists.newArrayList();
+        List<InternalUnionExternalExtension> extensions = new ArrayList<>();
         for (PortSide ps : component.getExternalExtensionSides()) {
             double min = outerSegments.min[ps.ordinal()];
             double max = outerSegments.max[ps.ordinal()];
@@ -288,7 +289,8 @@ public class ComponentsCompactor {
                 iuee.side = ps;
                 iuee.extension = extension;
                 iuee.placeholder = placeholder;
-                iuee.edges = Sets.newHashSet(externalExtensions.get(portSideToDirection(ps)));
+                iuee.edges = new HashSet<>(externalExtensions.getOrDefault(portSideToDirection(ps),
+                        java.util.Collections.emptySet()));
                 extensions.add(iuee);
             }
             
@@ -587,7 +589,7 @@ public class ComponentsCompactor {
      */
     private class InternalConnectedComponents implements IConnectedComponents<LNode, Set<LEdge>> {
 
-        private List<IComponent<LNode, Set<LEdge>>> components = Lists.newArrayList();
+        private List<IComponent<LNode, Set<LEdge>>> components = new ArrayList<>();
         private boolean containsExternalPorts = false;
         
         InternalConnectedComponents() { }
@@ -618,7 +620,7 @@ public class ComponentsCompactor {
         private boolean containsRegularNodes;
 
         private List<ElkRectangle> rectilinearConvexHull;
-        private List<IExternalExtension<Set<LEdge>>> externalExtensions = Lists.newArrayList();
+        private List<IExternalExtension<Set<LEdge>>> externalExtensions = new ArrayList<>();
         
         InternalComponent(final LGraph graph) {
             this.graph = graph;
@@ -649,7 +651,7 @@ public class ComponentsCompactor {
         }
         
         private List<LEdge> getExternalEdges() {
-            List<LEdge> edges = Lists.newArrayList();
+            List<LEdge> edges = new ArrayList<>();
             for (IExternalExtension<Set<LEdge>> ee : externalExtensions) {
                 edges.addAll(ee.getRepresentative());
             }
@@ -662,7 +664,7 @@ public class ComponentsCompactor {
      */
     private final class InternalUnionExternalExtension implements IExternalExtension<Set<LEdge>> {
 
-        private Set<LEdge> edges = Sets.newHashSet();
+        private Set<LEdge> edges = new HashSet<>();
         private PortSide side;
         private ElkRectangle extension;
         private ElkRectangle placeholder;
@@ -797,7 +799,7 @@ public class ComponentsCompactor {
      * Internal collector for inner and outer segments.
      */
     private static final class Segments {
-        private List<Pair<KVector, KVector>> innerSegments = Lists.newArrayList();
+        private List<Pair<KVector, KVector>> innerSegments = new ArrayList<>();
         private Pair<KVector, KVector> outerSegment;
     }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ComponentsProcessor.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LGraphUtil;
@@ -27,7 +28,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Lists;
 
 /**
  * A processor that is able to split an input graph into connected components and to pack those
@@ -112,7 +112,7 @@ public final class ComponentsProcessor {
             }
             
             // Perform DFS starting on each node, collecting connected components
-            result = Lists.newArrayList();
+            result = new ArrayList<>();
             for (LNode node : graph.getLayerlessNodes()) {
                 Pair<List<LNode>, Set<PortSide>> componentData = dfs(node, null);
                 
@@ -187,7 +187,7 @@ public final class ComponentsProcessor {
             // Check if we already have a list of nodes for the connected component
             Pair<List<LNode>, Set<PortSide>> mutableData = data;
             if (mutableData == null) {
-                List<LNode> component = Lists.newArrayList();
+                List<LNode> component = new ArrayList<>();
                 Set<PortSide> extPortSides = EnumSet.noneOf(PortSide.class);
                 
                 mutableData = new Pair<List<LNode>, Set<PortSide>>(component, extPortSides);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ModelOrderComponentGroup.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/components/ModelOrderComponentGroup.java
@@ -26,17 +26,19 @@ import static org.eclipse.elk.core.options.PortSide.SIDES_SOUTH;
 import static org.eclipse.elk.core.options.PortSide.SIDES_SOUTH_WEST;
 import static org.eclipse.elk.core.options.PortSide.SIDES_WEST;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.core.options.PortSide;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 
 /**
  * Model order component group that saves additionally to the port side the order of the components.
@@ -48,139 +50,143 @@ public class ModelOrderComponentGroup extends ComponentGroup {
      * Update constraints map with all constraints that occur if the key is inserted in a component group with the 
      * value already in it. This contains only additional sides to the CONSTRAINTS of the super class.
      */
-    protected static final Multimap<Set<PortSide>, Set<PortSide>> MODEL_ORDER_CONSTRAINTS = HashMultimap.create();
-    
+    protected static final Map<Set<PortSide>, Set<Set<PortSide>>> MODEL_ORDER_CONSTRAINTS = new HashMap<>();
+
+    private static void putModelOrderConstraint(final Set<PortSide> key, final Set<PortSide> value) {
+        MODEL_ORDER_CONSTRAINTS.computeIfAbsent(key, k -> new HashSet<>()).add(value);
+    }
+
     static {
         // Key is inserted in component group with value
         // E.g. NORTH can not be put in the same component group as NONE since it would be placed above NONE, which
         // is against the model order.
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_NONE);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_NONE);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NONE);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NONE);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_NONE);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_NONE);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_NONE);
+        putModelOrderConstraint(SIDES_WEST, SIDES_NONE);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_NONE);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_NONE);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_NONE);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_NONE);
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NORTH);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_NORTH);
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NONE, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_EAST); // XXX
+        putModelOrderConstraint(SIDES_NONE, SIDES_EAST);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_EAST);
+        putModelOrderConstraint(SIDES_WEST, SIDES_EAST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_EAST);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_EAST);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_EAST);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_EAST);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_EAST);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_EAST); // XXX
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NONE, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_SOUTH_WEST, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NONE, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_EAST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_WEST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_SOUTH_WEST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_SOUTH);
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_WEST);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_WEST);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_WEST);
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_NORTH_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_NORTH_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NORTH_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NORTH_EAST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_EAST);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_NORTH_EAST);
+        putModelOrderConstraint(SIDES_WEST, SIDES_NORTH_EAST);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_NORTH_EAST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_NORTH_EAST);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_NORTH_EAST);
         
         // NW has nothing since it is in the first slot
 
         // Only conflicts since it is in the last slot
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NONE, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_SOUTH, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_SOUTH_WEST, SIDES_EAST_SOUTH);
-//        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_SOUTH, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_EAST_SOUTH);
-//        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_SOUTH);
-//        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_SOUTH_WEST, SIDES_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NONE, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_EAST, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_SOUTH, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_WEST, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_SOUTH_WEST, SIDES_EAST_SOUTH);
+//        putModelOrderConstraint(SIDES_EAST_SOUTH, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_EAST_SOUTH);
+//        putModelOrderConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_SOUTH);
+//        putModelOrderConstraint(SIDES_EAST_SOUTH_WEST, SIDES_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_EAST_SOUTH);
 
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NONE, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH, SIDES_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NONE, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_EAST, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_WEST, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST_SOUTH, SIDES_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST_SOUTH_WEST, SIDES_SOUTH_WEST);
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_EAST_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_EAST_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_EAST_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_EAST_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_SOUTH_WEST, SIDES_EAST_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_EAST_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_WEST);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_EAST_WEST);
+        putModelOrderConstraint(SIDES_WEST, SIDES_EAST_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_EAST_WEST);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_EAST_WEST);
+        putModelOrderConstraint(SIDES_SOUTH_WEST, SIDES_EAST_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_EAST_WEST);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH_WEST, SIDES_EAST_WEST);
 
         // NEW no additional conflicts
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NONE, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST_WEST, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NONE, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_EAST, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_WEST, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST_WEST, SIDES_EAST_SOUTH_WEST);
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_NORTH_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST, SIDES_NORTH_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_SOUTH, SIDES_NORTH_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NORTH_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_NORTH_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_EAST, SIDES_NORTH_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_SOUTH, SIDES_NORTH_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_NORTH_SOUTH_WEST);
         
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NONE, SIDES_NORTH_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH, SIDES_NORTH_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_SOUTH, SIDES_NORTH_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_WEST, SIDES_NORTH_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NORTH_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_NORTH_EAST_SOUTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NORTH_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NONE, SIDES_NORTH_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH, SIDES_NORTH_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_SOUTH, SIDES_NORTH_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_WEST, SIDES_NORTH_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_NORTH_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_NORTH_EAST_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_NORTH_EAST_SOUTH);
 
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_EAST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_WEST, SIDES_NORTH_EAST_SOUTH_WEST);
+        putModelOrderConstraint(SIDES_NORTH_EAST, SIDES_NORTH_EAST_SOUTH_WEST);
         
         // Conflicts that seem solvable but that arise since the order of C, EW, W, E is fix
         // EW is before C and W and E
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_NONE);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_WEST);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_EAST_WEST, SIDES_EAST);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_NONE);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_WEST);
+        putModelOrderConstraint(SIDES_EAST_WEST, SIDES_EAST);
         
         // Conflicts that seem solvable but that arise since the order of C, NS, N, S is fix
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_NONE);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_NORTH);
-        MODEL_ORDER_CONSTRAINTS.put(SIDES_NORTH_SOUTH, SIDES_SOUTH);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_NONE);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_NORTH);
+        putModelOrderConstraint(SIDES_NORTH_SOUTH, SIDES_SOUTH);
         
     }
     
     
     
-    private List<LGraph> componentOrder = Lists.newLinkedList();
+    private List<LGraph> componentOrder = new LinkedList<>();
     ///////////////////////////////////////////////////////////////////////////////
     // Constructors
     
@@ -216,9 +222,10 @@ public class ModelOrderComponentGroup extends ComponentGroup {
      */
     public boolean add(final LGraph component) {
         if (canAdd(component)) {
-            components.put(
-                component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS),
-                component);
+            components
+                .computeIfAbsent(component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS),
+                        k -> new ArrayList<>())
+                .add(component);
             getComponentOrder().add(component);
             return true;
         } else {
@@ -236,17 +243,18 @@ public class ModelOrderComponentGroup extends ComponentGroup {
     protected boolean canAdd(final LGraph component) {
         // Check if we have a component with incompatible external port sides
         Set<PortSide> candidateSides = component.getProperty(InternalProperties.EXT_PORT_CONNECTIONS);
-        Collection<Set<PortSide>> constraints = CONSTRAINTS.get(candidateSides);
-        Collection<Set<PortSide>> modelOrderConstraints = MODEL_ORDER_CONSTRAINTS.get(candidateSides);
-        
+        Set<Set<PortSide>> constraints = CONSTRAINTS.getOrDefault(candidateSides, Collections.emptySet());
+        Set<Set<PortSide>> modelOrderConstraints = MODEL_ORDER_CONSTRAINTS.getOrDefault(candidateSides,
+                Collections.emptySet());
+
         for (Set<PortSide> constraint : constraints) {
-            if (!components.get(constraint).isEmpty()) {
+            if (!components.getOrDefault(constraint, Collections.emptyList()).isEmpty()) {
                 // A component with a conflicting external port side combination exists
                 return false;
             }
         }
         for (Set<PortSide> constraint : modelOrderConstraints) {
-            if (!components.get(constraint).isEmpty()) {
+            if (!components.getOrDefault(constraint, Collections.emptyList()).isEmpty()) {
                 // A component with a conflicting external port side combination exists considering model order
                 return false;
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPostprocessor.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -29,10 +30,8 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.function.Predicate;
 
 /**
  * Postprocess a compound graph by restoring cross-hierarchy edges that have previously been split
@@ -55,14 +54,9 @@ public class CompoundGraphPostprocessor implements ILayoutProcessor<LGraph> {
     /**
      * A predicate that checks if a given cross hierarchy edge has junction points.
      */
-    private static final Predicate<CrossHierarchyEdge> HAS_JUNCTION_POINTS_PREDICATE =
-            new Predicate<CrossHierarchyEdge>() {
-        
-        public boolean apply(final CrossHierarchyEdge chEdge) {
-            KVectorChain jps = chEdge.getEdge().getProperty(LayeredOptions.JUNCTION_POINTS);
-            return jps != null && !jps.isEmpty();
-        }
-        
+    private static final Predicate<CrossHierarchyEdge> HAS_JUNCTION_POINTS_PREDICATE = chEdge -> {
+        KVectorChain jps = chEdge.getEdge().getProperty(LayeredOptions.JUNCTION_POINTS);
+        return jps != null && !jps.isEmpty();
     };
     
     
@@ -74,11 +68,11 @@ public class CompoundGraphPostprocessor implements ILayoutProcessor<LGraph> {
         boolean addUnnecessaryBendpoints = graph.getProperty(LayeredOptions.UNNECESSARY_BENDPOINTS);
         
         // restore the cross-hierarchy map that was built by the preprocessor
-        Multimap<LEdge, CrossHierarchyEdge> crossHierarchyMap = graph.getProperty(
+        Map<LEdge, Set<CrossHierarchyEdge>> crossHierarchyMap = graph.getProperty(
                 InternalProperties.CROSS_HIERARCHY_MAP);
         
         // remember all dummy edges we encounter; these need to be removed at the end
-        Set<LEdge> dummyEdges = Sets.newHashSet();
+        Set<LEdge> dummyEdges = new HashSet<>();
         
         // iterate over all original edges
         for (LEdge origEdge : crossHierarchyMap.keySet()) {
@@ -200,7 +194,7 @@ public class CompoundGraphPostprocessor implements ILayoutProcessor<LGraph> {
             final List<CrossHierarchyEdge> crossHierarchyEdges) {
         
         KVectorChain junctionPoints = origEdge.getProperty(LayeredOptions.JUNCTION_POINTS);
-        if (Iterables.any(crossHierarchyEdges, HAS_JUNCTION_POINTS_PREDICATE)) {
+        if (java.util.stream.StreamSupport.stream(crossHierarchyEdges.spliterator(), false).anyMatch(HAS_JUNCTION_POINTS_PREDICATE)) {
             // if so, make sure the original edge has an empty non-null junction point list
             if (junctionPoints == null) {
                 junctionPoints = new KVectorChain();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/compound/CompoundGraphPreprocessor.java
@@ -11,10 +11,13 @@ package org.eclipse.elk.alg.layered.compound;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -36,11 +39,6 @@ import org.eclipse.elk.core.util.ElkUtil;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
 import org.eclipse.elk.graph.properties.MapPropertyHolder;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
 
 /**
  * Preprocess a compound graph by splitting cross-hierarchy edges. The result is stored in
@@ -86,9 +84,9 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
     // Variables
     
     /** map of original edges to generated cross-hierarchy edges. */
-    private Multimap<LEdge, CrossHierarchyEdge> crossHierarchyMap;
+    private Map<LEdge, Set<CrossHierarchyEdge>> crossHierarchyMap;
     /** map of ports to their assigned dummy nodes in the nested graphs. */
-    private final Map<LPort, LNode> dummyNodeMap = Maps.newHashMap();
+    private final Map<LPort, LNode> dummyNodeMap = new HashMap<>();
 
     
     ////////////////////////////////////////////////////////////////////////////////////////////
@@ -99,7 +97,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         monitor.begin("Compound graph preprocessor", 1);
         
         // This can be a HashMultimap since the values are sorted prior to working with them
-        crossHierarchyMap = HashMultimap.create();
+        crossHierarchyMap = new HashMap<>();
         
         // create new dummy edges at hierarchy bounds and move the labels around accordingly
         transformHierarchyEdges(graph, null);
@@ -148,7 +146,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
      */
     private List<ExternalPort> transformHierarchyEdges(final LGraph graph, final LNode parentNode) {
         // process all children and recurse down to gather their external ports
-        List<ExternalPort> containedExternalPorts = Lists.newArrayList();
+        List<ExternalPort> containedExternalPorts = new ArrayList<>();
         
         for (LNode node : graph.getLayerlessNodes()) {
             LGraph nestedGraph = node.getNestedGraph();
@@ -220,7 +218,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         }
         
         // this will be the list of external ports we will export
-        List<ExternalPort> exportedExternalPorts = Lists.newArrayList();
+        List<ExternalPort> exportedExternalPorts = new ArrayList<>();
         
         // process the cross-hierarchy edges connected to the inside of the child nodes
         processInnerHierarchicalEdgeSegments(graph, parentNode, containedExternalPorts,
@@ -355,7 +353,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         // we remember the ports and the dummy nodes we create to add them to the graph afterwards
         // (this is not strictly necessary, but allows us to reuse methods we also use for outer
         // hierarchy edge segments)
-        List<ExternalPort> createdExternalPorts = Lists.newArrayList();
+        List<ExternalPort> createdExternalPorts = new ArrayList<>();
         
         // iterate over the list of contained external ports
         for (ExternalPort externalPort : containedExternalPorts) {
@@ -474,8 +472,8 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         dummyEdge.setSource(sourcePort);
         dummyEdge.setTarget(targetPort);
         
-        crossHierarchyMap.put(origEdge,
-                new CrossHierarchyEdge(dummyEdge, graph, externalPort.type));
+        crossHierarchyMap.computeIfAbsent(origEdge, k -> new HashSet<>())
+                .add(new CrossHierarchyEdge(dummyEdge, graph, externalPort.type));
     }
 
     /**
@@ -512,8 +510,8 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         dummyEdge.setSource(externalOutputPort.dummyPort);
         dummyEdge.setTarget(targetExternalPort.dummyPort);
         
-        crossHierarchyMap.put(origEdge,
-                new CrossHierarchyEdge(dummyEdge, graph, externalOutputPort.type));
+        crossHierarchyMap.computeIfAbsent(origEdge, k -> new HashSet<>())
+                .add(new CrossHierarchyEdge(dummyEdge, graph, externalOutputPort.type));
     }
     
     
@@ -538,7 +536,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
         
         // we need to remember the ports and the dummy nodes we create to add them to the graph
         // afterwards (to avoid concurrent modification exceptions)
-        List<ExternalPort> createdExternalPorts = Lists.newArrayList();
+        List<ExternalPort> createdExternalPorts = new ArrayList<>();
         
         // iterate over all ports of the graph's child nodes
         for (LNode childNode : graph.getLayerlessNodes()) {
@@ -668,8 +666,8 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
                     dummyEdge.setTarget(targetExtPortDummy.getPorts().get(0));
                     
                     // Remember the new edge
-                    crossHierarchyMap.put(outEdge,
-                            new CrossHierarchyEdge(dummyEdge, nestedGraph, PortType.OUTPUT));
+                    crossHierarchyMap.computeIfAbsent(outEdge, k -> new HashSet<>())
+                            .add(new CrossHierarchyEdge(dummyEdge, nestedGraph, PortType.OUTPUT));
                     
                     nestedGraph.getProperty(InternalProperties.GRAPH_PROPERTIES).add(
                             GraphProperties.EXTERNAL_PORTS);
@@ -789,8 +787,8 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
             externalPort.newEdge.setProperty(LayeredOptions.EDGE_THICKNESS, thickness);
         }
 
-        crossHierarchyMap.put(origEdge,
-                new CrossHierarchyEdge(externalPort.newEdge, graph, portType));
+        crossHierarchyMap.computeIfAbsent(origEdge, k -> new HashSet<>())
+                .add(new CrossHierarchyEdge(externalPort.newEdge, graph, portType));
         
         return externalPort;
     }
@@ -999,7 +997,7 @@ public class CompoundGraphPreprocessor implements ILayoutProcessor<LGraph> {
      */
     private static class ExternalPort {
         /** the list of original edges for which the port is created. */
-        private List<LEdge> origEdges = Lists.newArrayList();
+        private List<LEdge> origEdges = new ArrayList<>();
         /** the new edge by which the original edge is replaced. */
         private LEdge newEdge;
         /** the dummy node used by the algorithm as representative for the external port. */

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LEdge.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LEdge.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.graph;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.PortType;
@@ -18,8 +19,6 @@ import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.EdgeLabelPlacement;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 
 /**
  * An edge in a layered graph. Edges may only be connected to ports of a node, which represent the point where the edge
@@ -37,7 +36,7 @@ public final class LEdge extends LGraphElement {
     /** the target port. */
     private LPort target;
     /** labels assigned to this edge. */
-    private final List<LLabel> labels = Lists.newArrayListWithCapacity(3);
+    private final List<LLabel> labels = new ArrayList<>(3);
 
     /**
      * Reverses the edge, including its bend points. Negates the {@code REVERSED} property. (an edge that was marked as
@@ -255,7 +254,7 @@ public final class LEdge extends LGraphElement {
 
     @Override
     public String getDesignation() {
-        if (!labels.isEmpty() && !Strings.isNullOrEmpty(labels.get(0).getText())) {
+        if (!labels.isEmpty() && !(labels.get(0).getText() == null || labels.get(0).getText().isEmpty())) {
             return labels.get(0).getText();
         }
         return super.getDesignation();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraph.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraph.java
@@ -12,10 +12,10 @@ package org.eclipse.elk.alg.layered.graph;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.ArrayList;
 
 import org.eclipse.elk.core.math.KVector;
 
-import com.google.common.collect.Lists;
 
 /**
  * A layered graph has a set of layers that contain the nodes, as well as a
@@ -58,12 +58,12 @@ public final class LGraph extends LGraphElement implements Iterable<Layer> {
     /**
      * Nodes that are not currently part of a layer.
      */
-    private final List<LNode> layerlessNodes = Lists.newArrayList();
+    private final List<LNode> layerlessNodes = new ArrayList<>();
     
     /**
      * The layers of the layered graph.
      */
-    private final List<Layer> layers = Lists.newArrayList();
+    private final List<Layer> layers = new ArrayList<>();
     
     /**
      * The parent node in which this graph is nested, or {@code null}.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphAdapters.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphAdapters.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.intermediate.loops.SelfLoopEdge;
@@ -33,7 +34,6 @@ import org.eclipse.elk.core.util.adapters.GraphAdapters.NodeAdapter;
 import org.eclipse.elk.core.util.adapters.GraphAdapters.PortAdapter;
 import org.eclipse.elk.graph.properties.IProperty;
 
-import com.google.common.collect.Lists;
 
 /**
  * Provides implementations of the {@link org.eclipse.elk.core.util.adapters.GraphAdapters
@@ -269,7 +269,7 @@ public final class LGraphAdapters {
         @Override
         public Iterable<NodeAdapter<?>> getNodes() {
             if (nodeAdapters == null) {
-                nodeAdapters = Lists.newArrayList();
+                nodeAdapters = new ArrayList<>();
                 // We completely ignore layerless nodes here since they are currently not of interest
                 // to anyone using these adapters
                 for (Layer l : element.getLayers()) {
@@ -350,7 +350,7 @@ public final class LGraphAdapters {
         @Override
         public Iterable<LabelAdapter<?>> getLabels() {
             if (labelAdapters == null) {
-                labelAdapters = Lists.newArrayListWithCapacity(element.getLabels().size());
+                labelAdapters = new ArrayList<>(element.getLabels().size());
                 for (LLabel l : element.getLabels()) {
                     labelAdapters.add(new LLabelAdapter(l));
                 }
@@ -361,7 +361,7 @@ public final class LGraphAdapters {
         @Override
         public Iterable<PortAdapter<?>> getPorts() {
             if (portAdapters == null) {
-                portAdapters = Lists.newArrayListWithCapacity(element.getPorts().size());
+                portAdapters = new ArrayList<>(element.getPorts().size());
                 for (LPort p : element.getPorts()) {
                     portAdapters.add(new LPortAdapter(p, transparentNorthSouthEdges));
                 }
@@ -468,7 +468,7 @@ public final class LGraphAdapters {
         @Override
         public Iterable<LabelAdapter<?>> getLabels() {
             if (labelAdapters == null) {
-                labelAdapters = Lists.newArrayListWithCapacity(element.getLabels().size());
+                labelAdapters = new ArrayList<>(element.getLabels().size());
                 for (LLabel l : element.getLabels()) {
                     labelAdapters.add(new LLabelAdapter(l));
                 }
@@ -495,7 +495,7 @@ public final class LGraphAdapters {
             if (transparentNorthSouthEdges && element.getNode().getType() == NodeType.NORTH_SOUTH_PORT) {
                 return Collections.emptyList();
             } else if (incomingEdgeAdapters == null) {
-                incomingEdgeAdapters = Lists.newArrayList();
+                incomingEdgeAdapters = new ArrayList<>();
                 for (LEdge e : element.getIncomingEdges()) {
                     incomingEdgeAdapters.add(new LEdgeAdapter(e));
                 }
@@ -526,7 +526,7 @@ public final class LGraphAdapters {
             if (transparentNorthSouthEdges && element.getNode().getType() == NodeType.NORTH_SOUTH_PORT) {
                 return Collections.emptyList();
             } else if (outgoingEdgeAdapters == null) {
-                outgoingEdgeAdapters = Lists.newArrayList();
+                outgoingEdgeAdapters = new ArrayList<>();
                 for (LEdge e : element.getOutgoingEdges()) {
                     outgoingEdgeAdapters.add(new LEdgeAdapter(e));
                 }
@@ -610,7 +610,7 @@ public final class LGraphAdapters {
         @Override
         public Iterable<LabelAdapter<?>> getLabels() {
             if (labelAdapters == null) {
-                labelAdapters = Lists.newArrayListWithCapacity(element.getLabels().size());
+                labelAdapters = new ArrayList<>(element.getLabels().size());
                 for (LLabel l : element.getLabels()) {
                     labelAdapters.add(new LLabelAdapter(l));
                 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphElement.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphElement.java
@@ -12,7 +12,6 @@ package org.eclipse.elk.alg.layered.graph;
 import org.eclipse.elk.alg.layered.graph.transform.ElkGraphTransformer;
 import org.eclipse.elk.graph.properties.MapPropertyHolder;
 
-import com.google.common.base.Strings;
 
 /**
  * Abstract superclass for the layers, nodes, ports, and edges of a layered graph
@@ -45,7 +44,7 @@ public abstract class LGraphElement extends MapPropertyHolder {
      */
     public String getDesignation() {
         String identifier = ElkGraphTransformer.getOriginIdentifier(this);
-        if (!Strings.isNullOrEmpty(identifier)) {
+        if (!(identifier == null || identifier.isEmpty())) {
             return identifier;
         }
         return null;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
@@ -52,21 +52,31 @@ public final class LGraphUtil {
      */
     private LGraphUtil() { }
 
-    /** Returns a fresh list with the same elements as {@code list} in reverse order. */
-    public static <T> List<T> reversed(final List<? extends T> list) {
-        List<T> copy = new ArrayList<>(list);
-        Collections.reverse(copy);
-        return copy;
-    }
-
-    /** Returns a zero-copy reverse view of {@code list}. Reads are O(1); structural changes
-     *  to the backing list are reflected here. */
-    public static <T> List<T> reversedView(final List<T> list) {
+    /**
+     * Returns a live, mutable reverse view of {@code list}. Reads are O(1) and modifications
+     * (set, add, remove) propagate to the backing list. Replacement for Guava's {@code Lists.reverse}.
+     */
+    public static <T> List<T> reversed(final List<T> list) {
         Objects.requireNonNull(list);
         return new AbstractList<T>() {
             @Override
             public T get(final int index) {
-                return list.get(list.size() - 1 - index);
+                return list.get(reverseIndex(index, list.size()));
+            }
+
+            @Override
+            public T set(final int index, final T element) {
+                return list.set(reverseIndex(index, list.size()), element);
+            }
+
+            @Override
+            public void add(final int index, final T element) {
+                list.add(reverseInsertIndex(index, list.size()), element);
+            }
+
+            @Override
+            public T remove(final int index) {
+                return list.remove(reverseIndex(index, list.size()));
             }
 
             @Override
@@ -74,6 +84,28 @@ public final class LGraphUtil {
                 return list.size();
             }
         };
+    }
+
+    private static int reverseIndex(final int index, final int size) {
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+        return size - 1 - index;
+    }
+
+    private static int reverseInsertIndex(final int index, final int size) {
+        if (index < 0 || index > size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+        return size - index;
+    }
+
+    /**
+     * @deprecated use {@link #reversed(List)} which is also a live view.
+     */
+    @Deprecated
+    public static <T> List<T> reversedView(final List<T> list) {
+        return reversed(list);
     }
 
     /** Lazy filtering iterable backed by a predicate (replacement for {@code Iterables.filter}). */

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LGraphUtil.java
@@ -9,8 +9,18 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.graph;
 
+import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.options.EdgeConstraint;
@@ -41,6 +51,144 @@ public final class LGraphUtil {
      * Hidden constructor to avoid instantiation.
      */
     private LGraphUtil() { }
+
+    /** Returns a fresh list with the same elements as {@code list} in reverse order. */
+    public static <T> List<T> reversed(final List<? extends T> list) {
+        List<T> copy = new ArrayList<>(list);
+        Collections.reverse(copy);
+        return copy;
+    }
+
+    /** Returns a zero-copy reverse view of {@code list}. Reads are O(1); structural changes
+     *  to the backing list are reflected here. */
+    public static <T> List<T> reversedView(final List<T> list) {
+        Objects.requireNonNull(list);
+        return new AbstractList<T>() {
+            @Override
+            public T get(final int index) {
+                return list.get(list.size() - 1 - index);
+            }
+
+            @Override
+            public int size() {
+                return list.size();
+            }
+        };
+    }
+
+    /** Lazy filtering iterable backed by a predicate (replacement for {@code Iterables.filter}). */
+    public static <T> Iterable<T> filter(final Iterable<T> source, final Predicate<? super T> predicate) {
+        Objects.requireNonNull(source);
+        Objects.requireNonNull(predicate);
+        return () -> new Iterator<T>() {
+            private final Iterator<T> it = source.iterator();
+            private T next;
+            private boolean computed;
+
+            @Override
+            public boolean hasNext() {
+                if (computed) {
+                    return next != null;
+                }
+                computed = true;
+                while (it.hasNext()) {
+                    T candidate = it.next();
+                    if (predicate.test(candidate)) {
+                        next = candidate;
+                        return true;
+                    }
+                }
+                next = null;
+                return false;
+            }
+
+            @Override
+            public T next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                computed = false;
+                T result = next;
+                next = null;
+                return result;
+            }
+        };
+    }
+
+    /** Lazily concatenates the given iterables (replacement for {@code Iterables.concat}). */
+    @SafeVarargs
+    public static <T> Iterable<T> concat(final Iterable<? extends T>... iterables) {
+        Objects.requireNonNull(iterables);
+        return () -> new Iterator<T>() {
+            private int index;
+            private Iterator<? extends T> current = Collections.emptyIterator();
+
+            @Override
+            public boolean hasNext() {
+                while (!current.hasNext()) {
+                    if (index >= iterables.length) {
+                        return false;
+                    }
+                    current = iterables[index++].iterator();
+                }
+                return true;
+            }
+
+            @Override
+            public T next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return current.next();
+            }
+        };
+    }
+
+    /** Lazily concatenates a sequence of iterables. */
+    public static <T> Iterable<T> concat(final Iterable<? extends Iterable<? extends T>> iterables) {
+        Objects.requireNonNull(iterables);
+        return () -> new Iterator<T>() {
+            private final Iterator<? extends Iterable<? extends T>> outer = iterables.iterator();
+            private Iterator<? extends T> current = Collections.emptyIterator();
+
+            @Override
+            public boolean hasNext() {
+                while (!current.hasNext()) {
+                    if (!outer.hasNext()) {
+                        return false;
+                    }
+                    current = outer.next().iterator();
+                }
+                return true;
+            }
+
+            @Override
+            public T next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return current.next();
+            }
+        };
+    }
+
+    /** Counts elements in an iterable (replacement for {@code Iterables.size}). */
+    public static int size(final Iterable<?> iterable) {
+        if (iterable instanceof Collection<?> c) {
+            return c.size();
+        }
+        int count = 0;
+        for (Object ignored : iterable) {
+            count++;
+        }
+        return count;
+    }
+
+    /** Returns a sequential stream over the given iterable. */
+    public static <T> Stream<T> stream(final Iterable<T> iterable) {
+        Objects.requireNonNull(iterable);
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
     
     /**
      * Create a new array by copying the content of the given node collection.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LLabel.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LLabel.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package org.eclipse.elk.alg.layered.graph;
 
-import com.google.common.base.Strings;
 
 /**
  * A label in the layered graph structure.
@@ -59,7 +58,7 @@ public final class LLabel extends LShape {
 
     @Override
     public String getDesignation() {
-        if (!Strings.isNullOrEmpty(text)) {
+        if (!(text == null || text.isEmpty())) {
             return text;
         }
         return super.getDesignation();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LNode.java
@@ -20,12 +20,8 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.function.Predicate;
 
 /**
  * A node in a layered graph.
@@ -84,9 +80,9 @@ public final class LNode extends LShape {
     /** the node's node type. */
     private NodeType type = NodeType.NORMAL;
     /** the ports of the node. */
-    private final List<LPort> ports = Lists.newArrayListWithCapacity(6);
+    private final List<LPort> ports = new ArrayList<>(6);
     /** this node's labels. */
-    private final List<LLabel> labels = Lists.newArrayListWithCapacity(2);
+    private final List<LLabel> labels = new ArrayList<>(2);
     /** the nested graph, or @{code null}. */
     private LGraph nestedGraph;
     /** the margin area around this node. */
@@ -239,9 +235,9 @@ public final class LNode extends LShape {
     public Iterable<LPort> getPorts(final PortType portType) {
         switch (portType) {
         case INPUT:
-            return Iterables.filter(ports, LPort.INPUT_PREDICATE);
+            return LGraphUtil.filter(ports, LPort.INPUT_PREDICATE);
         case OUTPUT:
-            return Iterables.filter(ports, LPort.OUTPUT_PREDICATE);
+            return LGraphUtil.filter(ports, LPort.OUTPUT_PREDICATE);
         default:
             return Collections.emptyList();
         }
@@ -256,13 +252,13 @@ public final class LNode extends LShape {
     public Iterable<LPort> getPorts(final PortSide side) {
         switch (side) {
         case NORTH:
-            return Iterables.filter(ports, LPort.NORTH_PREDICATE);
+            return LGraphUtil.filter(ports, LPort.NORTH_PREDICATE);
         case EAST:
-            return Iterables.filter(ports, LPort.EAST_PREDICATE);
+            return LGraphUtil.filter(ports, LPort.EAST_PREDICATE);
         case SOUTH:
-            return Iterables.filter(ports, LPort.SOUTH_PREDICATE);
+            return LGraphUtil.filter(ports, LPort.SOUTH_PREDICATE);
         case WEST:
-            return Iterables.filter(ports, LPort.WEST_PREDICATE);
+            return LGraphUtil.filter(ports, LPort.WEST_PREDICATE);
         default:
             return Collections.emptyList();
         }
@@ -329,7 +325,7 @@ public final class LNode extends LShape {
         }
         
         if (typePredicate != null && sidePredicate != null) {
-            return Iterables.filter(ports, Predicates.and(typePredicate, sidePredicate));
+            return LGraphUtil.filter(ports, typePredicate.and(sidePredicate));
         } else {
             return Collections.emptyList();
         }
@@ -341,12 +337,12 @@ public final class LNode extends LShape {
      * @return an iterable for all incoming edges.
      */
     public Iterable<LEdge> getIncomingEdges() {
-        List<Iterable<LEdge>> iterables = Lists.newArrayList();
+        List<Iterable<LEdge>> iterables = new ArrayList<>();
         for (LPort port : ports) {
             iterables.add(port.getIncomingEdges());
         }
         
-        return Iterables.concat(iterables);
+        return LGraphUtil.concat(iterables);
     }
     
     /**
@@ -355,12 +351,12 @@ public final class LNode extends LShape {
      * @return an iterable for all outgoing edges.
      */
     public Iterable<LEdge> getOutgoingEdges() {
-        List<Iterable<LEdge>> iterables = Lists.newArrayList();
+        List<Iterable<LEdge>> iterables = new ArrayList<>();
         for (LPort port : ports) {
             iterables.add(port.getOutgoingEdges());
         }
         
-        return Iterables.concat(iterables);
+        return LGraphUtil.concat(iterables);
     }
     
     /**
@@ -369,12 +365,12 @@ public final class LNode extends LShape {
      * @return an iterable for all connected edges.
      */
     public Iterable<LEdge> getConnectedEdges() {
-        List<Iterable<LEdge>> iterables = Lists.newArrayList();
+        List<Iterable<LEdge>> iterables = new ArrayList<>();
         for (LPort port : ports) {
             iterables.add(port.getConnectedEdges());
         }
         
-        return Iterables.concat(iterables);
+        return LGraphUtil.concat(iterables);
     }
     
     /**
@@ -510,7 +506,7 @@ public final class LNode extends LShape {
     }
 
     private void findPortIndices() {
-        portSideIndices = Maps.newEnumMap(PortSide.class);
+        portSideIndices = new EnumMap<>(PortSide.class);
         int firstIndexForCurrentSide = 0;
         PortSide currentSide = PortSide.NORTH;
         int currentIndex = 0;
@@ -530,7 +526,7 @@ public final class LNode extends LShape {
 
     @Override
     public String getDesignation() {
-        if (!labels.isEmpty() && !Strings.isNullOrEmpty(labels.get(0).getText())) {
+        if (!labels.isEmpty() && !(labels.get(0).getText() == null || labels.get(0).getText().isEmpty())) {
             return labels.get(0).getText();
         }
         String id = super.getDesignation();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LPort.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/LPort.java
@@ -16,10 +16,8 @@ import org.eclipse.elk.alg.layered.intermediate.LabelAndNodeSizeProcessor;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.function.Predicate;
 
 /**
  * A port in a layered graph. The position of the port is relative to the upper left corner
@@ -61,12 +59,12 @@ public final class LPort extends LShape {
     /** the margin area around this port. */
     private final LMargin margin = new LMargin();
     /** this port's labels. */
-    private final List<LLabel> labels = Lists.newArrayListWithCapacity(2);
+    private final List<LLabel> labels = new ArrayList<>(2);
 
     /** the edges going into the port. */
-    private final List<LEdge> incomingEdges = Lists.newArrayListWithCapacity(4);
+    private final List<LEdge> incomingEdges = new ArrayList<>(4);
     /** the edges going out of the port. */
-    private final List<LEdge> outgoingEdges = Lists.newArrayListWithCapacity(4);
+    private final List<LEdge> outgoingEdges = new ArrayList<>(4);
     /** All connected edges in a combined iterable. */
     private Iterable<LEdge> connectedEdges = new CombineIter<LEdge>(incomingEdges, outgoingEdges);
     
@@ -345,7 +343,7 @@ public final class LPort extends LShape {
      * @return an iterable over the connected ports
      */
     public Iterable<LPort> getConnectedPorts() {
-        return Iterables.concat(getPredecessorPorts(), getSuccessorPorts());
+        return LGraphUtil.concat(getPredecessorPorts(), getSuccessorPorts());
     }
     
     /**
@@ -365,7 +363,7 @@ public final class LPort extends LShape {
 
     @Override
     public String getDesignation() {
-        if (!labels.isEmpty() && !Strings.isNullOrEmpty(labels.get(0).getText())) {
+        if (!labels.isEmpty() && !(labels.get(0).getText() == null || labels.get(0).getText().isEmpty())) {
             return labels.get(0).getText();
         }
         String id = super.getDesignation();
@@ -396,8 +394,8 @@ public final class LPort extends LShape {
     }
 
     /**
-     * Combines two Iterables. We use this instead of {@link com.google.common.collect.Iterables#concat} because it is
-     * faster.
+     * Combines two Iterables. Local fast-path replacement for a generic {@code concat} because the
+     * lazy implementation here is faster for the small inputs seen in this hot path.
      * 
      * @param <T>
      */

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/Layer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/Layer.java
@@ -11,10 +11,10 @@ package org.eclipse.elk.alg.layered.graph;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.core.math.KVector;
 
-import com.google.common.collect.Lists;
 
 /**
  * A layer in a layered graph. A layer contains a list of nodes, which are
@@ -30,7 +30,7 @@ public final class Layer extends LGraphElement implements Iterable<LNode> {
     /** the size of the layer as drawn horizontally. */
     private final KVector size = new KVector();
     /** the nodes of the layer. */
-    private final List<LNode> nodes = Lists.newArrayList();
+    private final List<LNode> nodes = new ArrayList<>();
     
     /**
      * Creates a layer for the given layered graph. The layer is not added to the

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphImporter.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.HashMap;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.common.nodespacing.NodeLabelAndSizeCalculator;
 import org.eclipse.elk.alg.layered.components.ComponentOrderingStrategy;
@@ -65,9 +67,6 @@ import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * Implements the graph import aspect of {@link ElkGraphTransformer}.
@@ -75,7 +74,7 @@ import com.google.common.collect.Maps;
 class ElkGraphImporter {
     
     /** map between ElkGraph nodes / ports and the LGraph nodes / ports created for them. */
-    private final Map<ElkGraphElement, LGraphElement> nodeAndPortMap = Maps.newHashMap();
+    private final Map<ElkGraphElement, LGraphElement> nodeAndPortMap = new HashMap<>();
     
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -302,7 +301,7 @@ class ElkGraphImporter {
      *            graph to add the direct children of the current hierarchy level to.
      */
     private void importHierarchicalGraph(final ElkNode elkgraph, final LGraph lgraph) {
-        final Queue<ElkNode> elkGraphQueue = Lists.newLinkedList();
+        final Queue<ElkNode> elkGraphQueue = new LinkedList<>();
         
         Direction parentGraphDirection = lgraph.getProperty(LayeredOptions.DIRECTION);
 
@@ -760,7 +759,7 @@ class ElkGraphImporter {
 
         // Transform all of the port's labels
         for (ElkLabel elklabel : elkport.getLabels()) {
-            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !Strings.isNullOrEmpty(elklabel.getText())) {
+            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !(elklabel.getText() == null || elklabel.getText().isEmpty())) {
                 LLabel llabel = transformLabel(elklabel);
                 dummyPort.getLabels().add(llabel);
                 
@@ -941,7 +940,7 @@ class ElkGraphImporter {
 
         // add the node's labels
         for (ElkLabel elklabel : elknode.getLabels()) {
-            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !Strings.isNullOrEmpty(elklabel.getText())) {
+            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !(elklabel.getText() == null || elklabel.getText().isEmpty())) {
                 lnode.getLabels().add(transformLabel(elklabel));
             }
         }
@@ -1040,7 +1039,7 @@ class ElkGraphImporter {
 
         // create the port's labels
         for (ElkLabel elklabel : elkport.getLabels()) {
-            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !Strings.isNullOrEmpty(elklabel.getText())) {
+            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !(elklabel.getText() == null || elklabel.getText().isEmpty())) {
                 lport.getLabels().add(transformLabel(elklabel));
             }
         }
@@ -1195,7 +1194,7 @@ class ElkGraphImporter {
 
         // Transform the edge's labels
         for (ElkLabel elklabel : elkedge.getLabels()) {
-            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !Strings.isNullOrEmpty(elklabel.getText())) {
+            if (!elklabel.getProperty(LayeredOptions.NO_LAYOUT) && !(elklabel.getText() == null || elklabel.getText().isEmpty())) {
                 LLabel llabel = transformLabel(elklabel);
                 ledge.getLabels().add(llabel);
                 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphLayoutTransferrer.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.graph.transform;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -43,7 +44,6 @@ import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * Implements the graph layout application aspect of {@link ElkGraphTransformer}.
@@ -90,7 +90,7 @@ public class ElkGraphLayoutTransferrer {
         }
 
         // Along the way, we collect the list of edges to be processed later
-        List<LEdge> edgeList = Lists.newArrayList();
+        List<LEdge> edgeList = new ArrayList<>();
 
         // Process the nodes
         for (LNode lnode : lgraph.getLayerlessNodes()) {
@@ -461,7 +461,7 @@ public class ElkGraphLayoutTransferrer {
         }
 
         // Along the way, we collect the list of edges to be processed later
-        List<LEdge> edgeList = Lists.newArrayList();
+        List<LEdge> edgeList = new ArrayList<>();
 
         // Process the nodes
         for (LNode lnode : collectNodes(lgraph)) {
@@ -529,7 +529,7 @@ public class ElkGraphLayoutTransferrer {
      * @return A list of all nodes that represent a node in the original ELK graph.
      */
     private static List<LNode> collectNodes(LGraph lgraph) {
-        List<LNode> nodes = Lists.newArrayList();
+        List<LNode> nodes = new ArrayList<>();
         for (Layer layer : lgraph.getLayers()) {
             for (LNode lNode : layer.getNodes()) {
                 if (representsNode(lNode)) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/graph/transform/ElkGraphTransformer.java
@@ -16,7 +16,6 @@ import org.eclipse.elk.graph.ElkGraphElement;
 import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.emf.ecore.EObject;
 
-import com.google.common.base.Strings;
 
 /**
  * Manages the transformation of ELK Graphs to LayeredGraphs. Sets the
@@ -60,7 +59,7 @@ public class ElkGraphTransformer implements IGraphTransformer<ElkNode> {
     
     private static String getIdentifier(final ElkGraphElement element) {
         String id = element.getIdentifier();
-        if (!Strings.isNullOrEmpty(id)) {
+        if (!(id == null || id.isEmpty())) {
             EObject container = element.eContainer();
             if (container instanceof ElkGraphElement) {
                 String parentId = getIdentifier((ElkGraphElement) container);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/CommentPostprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/CommentPostprocessor.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -24,7 +25,6 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * Post-processor for comment boxes. If any comments are found that were removed by the
@@ -50,7 +50,7 @@ public final class CommentPostprocessor implements ILayoutProcessor<LGraph> {
         monitor.begin("Comment post-processing", 1);
         
         for (Layer layer : layeredGraph) {
-            List<LNode> boxes = Lists.newArrayList();
+            List<LNode> boxes = new ArrayList<>();
             for (LNode node : layer) {
                 List<LNode> topBoxes = node.getProperty(InternalProperties.TOP_COMMENTS);
                 List<LNode> bottomBoxes = node.getProperty(InternalProperties.BOTTOM_COMMENTS);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/CommentPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/CommentPreprocessor.java
@@ -11,6 +11,7 @@ package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -24,7 +25,6 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * A pre-processor for comment boxes. Looks for comments that have exactly one connection
@@ -80,7 +80,7 @@ public final class CommentPreprocessor implements ILayoutProcessor<LGraph> {
                     nodeIter.remove();
                 } else {
                     // reverse edges that are oddly connected
-                    List<LEdge> revEdges = Lists.newArrayList();
+                    List<LEdge> revEdges = new ArrayList<>();
                     for (LPort port : node.getPorts()) {
                         for (LEdge outedge : port.getOutgoingEdges()) {
                             if (!outedge.getTarget().getOutgoingEdges().isEmpty()) {
@@ -155,14 +155,14 @@ public final class CommentPreprocessor implements ILayoutProcessor<LGraph> {
             // determine the position to use, favoring the top position
             List<LNode> topBoxes = realNode.getProperty(InternalProperties.TOP_COMMENTS);
             if (topBoxes == null) {
-                boxList = Lists.newArrayList();
+                boxList = new ArrayList<>();
                 realNode.setProperty(InternalProperties.TOP_COMMENTS, boxList);
             } else if (onlyTop) {
                 boxList = topBoxes;
             } else {
                 List<LNode> bottomBoxes = realNode.getProperty(InternalProperties.BOTTOM_COMMENTS);
                 if (bottomBoxes == null) {
-                    boxList = Lists.newArrayList();
+                    boxList = new ArrayList<>();
                     realNode.setProperty(InternalProperties.BOTTOM_COMMENTS, boxList);
                 } else {
                     if (topBoxes.size() <= bottomBoxes.size()) {
@@ -176,14 +176,14 @@ public final class CommentPreprocessor implements ILayoutProcessor<LGraph> {
             // determine the position to use, favoring the bottom position
             List<LNode> bottomBoxes = realNode.getProperty(InternalProperties.BOTTOM_COMMENTS);
             if (bottomBoxes == null) {
-                boxList = Lists.newArrayList();
+                boxList = new ArrayList<>();
                 realNode.setProperty(InternalProperties.BOTTOM_COMMENTS, boxList);
             } else if (onlyBottom) {
                 boxList = bottomBoxes;
             } else {
                 List<LNode> topBoxes = realNode.getProperty(InternalProperties.TOP_COMMENTS);
                 if (topBoxes == null) {
-                    boxList = Lists.newArrayList();
+                    boxList = new ArrayList<>();
                     realNode.setProperty(InternalProperties.TOP_COMMENTS, boxList);
                 } else {
                     if (bottomBoxes.size() <= topBoxes.size()) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/DummySelfLoopProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/DummySelfLoopProcessor.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -25,7 +26,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * This processor does some work to ensure that other phases and processors can handle
@@ -66,7 +66,7 @@ public final class DummySelfLoopProcessor implements ILayoutProcessor<LGraph> {
         monitor.begin("Self-loop processing", 1);
         
         // Iterate through all nodes
-        List<LNode> createdDummies = Lists.newArrayList();
+        List<LNode> createdDummies = new ArrayList<>();
         
         for (Layer layer : layeredGraph) {
             createdDummies.clear();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/EndLabelPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/EndLabelPreprocessor.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.HorizontalLabelAlignment;
 import org.eclipse.elk.alg.common.nodespacing.cellsystem.LabelCell;
@@ -37,7 +38,6 @@ import org.eclipse.elk.core.options.LabelSide;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * <p>Puts all end labels into {@link LabelCell label cells} stored for each node using the
@@ -162,7 +162,7 @@ public final class EndLabelPreprocessor implements ILayoutProcessor<LGraph> {
      * <p>This method is also used by {@link LabelSideSelector}.</p>
      */
     static List<LLabel> gatherLabels(final LPort port) {
-        List<LLabel> labels = Lists.newArrayList();
+        List<LLabel> labels = new ArrayList<>();
         
         // Gather labels of the port itself
         double maxEdgeThickness = gatherLabels(port, labels);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/GraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/GraphTransformer.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.intermediate;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -36,7 +37,6 @@ import org.eclipse.elk.core.options.NodeLabelPlacement;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * A layout processor that is able to perform transformations on the coordinates of a graph.
@@ -69,7 +69,7 @@ public final class GraphTransformer implements ILayoutProcessor<LGraph> {
         
         // We need to add all layerless nodes as well as all nodes in layers since this processor
         // is run twice -- once before layering, and once afterwards
-        List<LNode> nodes = Lists.newArrayList(layeredGraph.getLayerlessNodes());
+        List<LNode> nodes = new ArrayList<>(layeredGraph.getLayerlessNodes());
         for (Layer layer : layeredGraph.getLayers()) {
             nodes.addAll(layer.getNodes());
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortConstraintProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortConstraintProcessor.java
@@ -31,8 +31,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * Processes constraints imposed on hierarchical node dummies.
@@ -207,8 +205,8 @@ public final class HierarchicalPortConstraintProcessor implements ILayoutProcess
         // again.
         // We keep enough space to hold layerCount + 2 instances of each data structure because we
         // might have to add a new first and last layer, even though that shouldn't normally happen
-        List<Map<Object, LNode>> extPortToDummyNodeMap = Lists.newArrayListWithExpectedSize(layerCount + 2);
-        List<List<LNode>> newDummyNodes = Lists.newArrayListWithExpectedSize(layerCount + 2);
+        List<Map<Object, LNode>> extPortToDummyNodeMap = new ArrayList<>(layerCount + 2);
+        List<List<LNode>> newDummyNodes = new ArrayList<>(layerCount + 2);
         
         // Add maps and lists for a new first layer that might have to be created as well as for the
         // current first layer. A map for the next layer is added on each iteration of the for loop
@@ -218,7 +216,7 @@ public final class HierarchicalPortConstraintProcessor implements ILayoutProcess
         newDummyNodes.add(new ArrayList<LNode>());
         
         // We remember each original external port dummy we encounter (they must be removed from the layers later)
-        List<LNode> originalExternalPortDummies = Lists.newArrayList();
+        List<LNode> originalExternalPortDummies = new ArrayList<>();
         
         // Iterate through each layer
         for (int currLayerIdx = 0; currLayerIdx < layerCount; currLayerIdx++) {
@@ -226,11 +224,11 @@ public final class HierarchicalPortConstraintProcessor implements ILayoutProcess
             
             // Dummy node maps and lists for the next and previous layer
             Map<Object, LNode> prevExtPortToDummyNodesMap = extPortToDummyNodeMap.get(currLayerIdx);
-            Map<Object, LNode> nextExtPortToDummyNodesMap = Maps.newHashMap();
+            Map<Object, LNode> nextExtPortToDummyNodesMap = new HashMap<>();
             extPortToDummyNodeMap.add(nextExtPortToDummyNodesMap);
             
             List<LNode> prevNewDummyNodes = newDummyNodes.get(currLayerIdx);
-            List<LNode> nextNewDummyNodes = Lists.newArrayList();
+            List<LNode> nextNewDummyNodes = new ArrayList<>();
             newDummyNodes.add(nextNewDummyNodes);
             
             // Iterate through the layer's nodes, looking for normal nodes connected to

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortDummySizeProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortDummySizeProcessor.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -23,7 +24,6 @@ import org.eclipse.elk.core.options.Alignment;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * Sets the width of hierarchical port dummies and sets the layer alignment of North/South port dummies
@@ -55,8 +55,8 @@ public final class HierarchicalPortDummySizeProcessor implements ILayoutProcesso
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Hierarchical port dummy size processing", 1);
 
-        List<LNode> northernDummies = Lists.newArrayList();
-        List<LNode> southernDummies = Lists.newArrayList();
+        List<LNode> northernDummies = new ArrayList<>();
+        List<LNode> southernDummies = new ArrayList<>();
         
         // Calculate the width difference (this assumes CENTER node alignment)
         //  The idea behind this is that ports are stacked on top of each other at the center of the 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HierarchicalPortOrthogonalEdgeRouter.java
@@ -13,6 +13,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 
 import org.eclipse.elk.alg.common.nodespacing.NodeDimensionCalculation;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -39,8 +41,6 @@ import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.options.SizeConstraint;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * This processor does the job of routing edges connected to hierarchical ports.
@@ -153,7 +153,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
      * @return the list of restored external port dummies.
      */
     private List<LNode> restoreNorthSouthDummies(final LGraph layeredGraph) {
-        List<LNode> restoredDummies = Lists.newArrayList();
+        List<LNode> restoredDummies = new ArrayList<>();
         
         if (!layeredGraph.hasProperty(InternalProperties.EXT_PORT_REPLACED_DUMMIES)) {
             return restoredDummies;
@@ -284,8 +284,8 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
         double southY = graphSize.y + graphPadding.top + graphPadding.bottom - layeredGraph.getOffset().y;
         
         // Lists of northern and southern external port dummies
-        List<LNode> northernDummies = Lists.newArrayList();
-        List<LNode> southernDummies = Lists.newArrayList();
+        List<LNode> northernDummies = new ArrayList<>();
+        List<LNode> southernDummies = new ArrayList<>();
         
         for (LNode dummy : northSouthDummies) {
             // Set x coordinate
@@ -507,10 +507,10 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
             final Iterable<LNode> northSouthDummies) {
         
         // Prepare south and target layers for northern and southern routing
-        Set<LNode> northernSourceLayer = Sets.newLinkedHashSet();
-        Set<LNode> northernTargetLayer = Sets.newLinkedHashSet();
-        Set<LNode> southernSourceLayer = Sets.newLinkedHashSet();
-        Set<LNode> southernTargetLayer = Sets.newLinkedHashSet();
+        Set<LNode> northernSourceLayer = new LinkedHashSet<>();
+        Set<LNode> northernTargetLayer = new LinkedHashSet<>();
+        Set<LNode> southernSourceLayer = new LinkedHashSet<>();
+        Set<LNode> southernTargetLayer = new LinkedHashSet<>();
         
         // Find some routing parameters
         double nodeSpacing = layeredGraph.getProperty(LayeredOptions.SPACING_NODE_NODE).doubleValue();
@@ -591,7 +591,7 @@ public final class HierarchicalPortOrthogonalEdgeRouter implements ILayoutProces
      * @param layeredGraph the layered graph.
      */
     private void removeTemporaryNorthSouthDummies(final LGraph layeredGraph) {
-        List<LNode> nodesToRemove = Lists.newArrayList();
+        List<LNode> nodesToRemove = new ArrayList<>();
         
         // Iterate through all layers
         for (Layer layer : layeredGraph) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HighDegreeNodeLayeringProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HighDegreeNodeLayeringProcessor.java
@@ -21,9 +21,8 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import java.util.function.Function;
+import java.util.ArrayList;
 
 /**
  * Tries to improve the legibility of graphs that contain nodes of a very high degree. With such
@@ -81,7 +80,7 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
             // -----------------------------------------------------------------------
             //  #1 find high degree nodes and find their incoming and outgoing trees
             // -----------------------------------------------------------------------
-            List<Pair<LNode, HighDegreeNodeInformation>> highDegreeNodes = Lists.newArrayList();
+            List<Pair<LNode, HighDegreeNodeInformation>> highDegreeNodes = new ArrayList<>();
             int incMax = -1;
             int outMax = -1;
             for (LNode n : lay.getNodes()) {
@@ -96,7 +95,7 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
             // -----------------------------------------------------------------------
             //  #2 insert layers before the current layer and move the trees
             // -----------------------------------------------------------------------
-            List<Layer> preLayers = Lists.newArrayList();
+            List<Layer> preLayers = new ArrayList<>();
             for (int i = 0; i < incMax; ++i) {
                 preLayers.add(0, prependLayer(layerIt));
             }
@@ -115,7 +114,7 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
             // -----------------------------------------------------------------------
             //  #2 insert layers after the current layer and move the trees
             // -----------------------------------------------------------------------
-            List<Layer> afterLayers = Lists.newArrayList();
+            List<Layer> afterLayers = new ArrayList<>();
             for (int i = 0; i < outMax; ++i) {
                 afterLayers.add(appendLayer(layerIt));
             }
@@ -179,7 +178,7 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
 
                 // remember the tree root for later processing
                 if (hdni.incTreeRoots == null) {
-                    hdni.incTreeRoots = Lists.newArrayList();
+                    hdni.incTreeRoots = new ArrayList<>();
                 }
                 hdni.incTreeRoots.add(src);
             }
@@ -205,7 +204,7 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
                 hdni.outTreesMaxHeight = Math.max(hdni.outTreesMaxHeight, treeHeight);
 
                 if (hdni.outTreeRoots == null) {
-                    hdni.outTreeRoots = Lists.newArrayList();
+                    hdni.outTreeRoots = new ArrayList<>();
                 }
                 hdni.outTreeRoots.add(tgt);
             }
@@ -265,7 +264,7 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
     }
     
     private static int degree(final LNode node, final Function<LNode, Iterable<LEdge>> edgeSelector) {
-        return Iterables.size(edgeSelector.apply(node));
+        return ((int) java.util.stream.StreamSupport.stream(edgeSelector.apply(node).spliterator(), false).count());
     }
 
     /**
@@ -339,7 +338,7 @@ public class HighDegreeNodeLayeringProcessor implements ILayoutProcessor<LGraph>
         }
         
         // is it a leaf?
-        if (Iterables.isEmpty(descendantEdges.apply(root))) {
+        if (!descendantEdges.apply(root).iterator().hasNext()) {
             return 1;
         }
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HypernodesProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/HypernodesProcessor.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -23,7 +24,6 @@ import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * Improves the placement of hypernodes by moving them such that they replace the join
@@ -86,7 +86,7 @@ public final class HypernodesProcessor implements ILayoutProcessor<LGraph> {
     private void moveHypernode(final LGraph layeredGraph, final LNode hypernode,
             final boolean right) {
         // find edges that constitute the first join point of the hyperedge
-        List<LEdge> bendEdges = Lists.newArrayList();
+        List<LEdge> bendEdges = new ArrayList<>();
         double bendx = Integer.MAX_VALUE, diffx = Integer.MAX_VALUE, diffy = Integer.MAX_VALUE;
         if (right) {
             bendx = layeredGraph.getSize().x;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InLayerConstraintProcessor.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LGraphUtil;
@@ -20,7 +21,6 @@ import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * Makes sure that in-layer constraints are respected. This processor is only necessary
@@ -59,7 +59,7 @@ public final class InLayerConstraintProcessor implements ILayoutProcessor<LGraph
              */
             
             int topInsertionIndex = -1;
-            List<LNode> bottomConstrainedNodes = Lists.newArrayList();
+            List<LNode> bottomConstrainedNodes = new ArrayList<>();
             
             // Iterate through an array of its nodes
             LNode[] nodes = LGraphUtil.toNodeArray(layer.getNodes());

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InteractiveExternalPortPositioner.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InteractiveExternalPortPositioner.java
@@ -24,8 +24,8 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.math.ElkMargin;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
+import java.util.function.Function;
+import java.util.Optional;
 
 /**
  * Interactive layout, for instance using
@@ -88,7 +88,7 @@ public class InteractiveExternalPortPositioner implements ILayoutProcessor<LGrap
                         // it's a WEST port
                         node.getPosition().x = minX - ARBITRARY_SPACING;
                         findYCoordinate(node, (e) -> e.getTarget().getNode())
-                            .transform((d) -> node.getPosition().y = d);
+                            .ifPresent(d -> node.getPosition().y = d);
                         break;
                     }
                     
@@ -96,21 +96,21 @@ public class InteractiveExternalPortPositioner implements ILayoutProcessor<LGrap
                         // it's a EAST port
                         node.getPosition().x = maxX + ARBITRARY_SPACING;
                         findYCoordinate(node, (e) -> e.getSource().getNode())
-                            .transform((d) -> node.getPosition().y = d);
+                            .ifPresent(d -> node.getPosition().y = d);
                         break;
                     }
 
                     InLayerConstraint ilc = node.getProperty(InternalProperties.IN_LAYER_CONSTRAINT);
                     if (ilc == InLayerConstraint.TOP) {
                         findNorthSouthPortXCoordinate(node)
-                            .transform((x) -> node.getPosition().x = x + ARBITRARY_SPACING);
+                            .ifPresent(x -> node.getPosition().x = x + ARBITRARY_SPACING);
                         node.getPosition().y = minY - ARBITRARY_SPACING;
                         break;
                     }
                     
                     if (ilc == InLayerConstraint.BOTTOM) {
                         findNorthSouthPortXCoordinate(node)
-                            .transform((x) -> node.getPosition().x = x + ARBITRARY_SPACING);
+                            .ifPresent(x -> node.getPosition().x = x + ARBITRARY_SPACING);
                         node.getPosition().y = maxY + ARBITRARY_SPACING;
                         break;
                     }
@@ -131,7 +131,7 @@ public class InteractiveExternalPortPositioner implements ILayoutProcessor<LGrap
             return Optional.of(other.getPosition().y + other.getSize().y / 2);
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
     
     private Optional<Double> findNorthSouthPortXCoordinate(final LNode dummy) {
@@ -169,6 +169,6 @@ public class InteractiveExternalPortPositioner implements ILayoutProcessor<LGrap
         }
         
         // we should never reach here
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/InvertedPortProcessor.java
@@ -11,6 +11,7 @@ package org.eclipse.elk.alg.layered.intermediate;
 
 import java.util.List;
 import java.util.ListIterator;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -29,7 +30,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * Inserts dummy nodes to cope with inverted ports.
@@ -87,7 +87,7 @@ public final class InvertedPortProcessor implements ILayoutProcessor<LGraph> {
         // modification exceptions)
         ListIterator<Layer> layerIterator = layers.listIterator();
         Layer currentLayer = null;
-        List<LNode> unassignedNodes = Lists.newArrayList();
+        List<LNode> unassignedNodes = new ArrayList<>();
         
         while (layerIterator.hasNext()) {
             // Update previous and current layers

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyInserter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyInserter.java
@@ -27,9 +27,8 @@ import org.eclipse.elk.core.options.EdgeLabelPlacement;
 import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import java.util.function.Predicate;
+import java.util.ArrayList;
 
 /**
  * Processor that inserts dummy nodes into edges that have center labels to reserve space for them.
@@ -50,18 +49,15 @@ import com.google.common.collect.Lists;
 public final class LabelDummyInserter implements ILayoutProcessor<LGraph> {
     
     /** Predicate that checks for center labels. */
-    private static final Predicate<LLabel> CENTER_LABEL = new Predicate<LLabel>() {
-        public boolean apply(final LLabel label) {
-            return label.getProperty(LayeredOptions.EDGE_LABELS_PLACEMENT) == EdgeLabelPlacement.CENTER;
-        }
-    };
+    private static final Predicate<LLabel> CENTER_LABEL =
+            label -> label.getProperty(LayeredOptions.EDGE_LABELS_PLACEMENT) == EdgeLabelPlacement.CENTER;
     
     @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         monitor.begin("Label dummy insertions", 1);
         
         // We cannot add the nodes to the graph while we're iterating over it, so remember the dummy nodes we create
-        List<LNode> newDummyNodes = Lists.newArrayList();
+        List<LNode> newDummyNodes = new ArrayList<>();
         
         double edgeLabelSpacing = layeredGraph.getProperty(LayeredOptions.SPACING_EDGE_LABEL);
         double labelLabelSpacing = layeredGraph.getProperty(LayeredOptions.SPACING_LABEL_LABEL);
@@ -73,7 +69,7 @@ public final class LabelDummyInserter implements ILayoutProcessor<LGraph> {
                     double thickness = retrieveThickness(edge);
                     
                     // Create dummy node and remember represented labels (to be filled below)
-                    List<LLabel> representedLabels = Lists.newArrayListWithCapacity(edge.getLabels().size());
+                    List<LLabel> representedLabels = new ArrayList<>(edge.getLabels().size());
                     LNode dummyNode = createLabelDummy(layeredGraph, edge, thickness, representedLabels);
                     newDummyNodes.add(dummyNode);
                     
@@ -124,7 +120,7 @@ public final class LabelDummyInserter implements ILayoutProcessor<LGraph> {
      */
     private boolean edgeNeedsToBeProcessed(final LEdge edge) {
         return edge.getSource().getNode() != edge.getTarget().getNode()
-                && Iterables.any(edge.getLabels(), CENTER_LABEL);
+                && java.util.stream.StreamSupport.stream(edge.getLabels().spliterator(), false).anyMatch(CENTER_LABEL);
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemover.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummyRemover.java
@@ -26,8 +26,8 @@ import org.eclipse.elk.core.options.Direction;
 import org.eclipse.elk.core.options.EdgeRouting;
 import org.eclipse.elk.core.options.LabelSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * <p>Processor that removes the inserted center label dummies and places the labels on their
@@ -149,7 +149,7 @@ public final class LabelDummyRemover implements ILayoutProcessor<LGraph> {
         // reverse the label order in the final result. Thus, in that case we iterate over the reversed label list
         List<LLabel> effectiveLabels = labels;
         if (layoutDirection == Direction.UP) {
-            effectiveLabels = Lists.reverse(effectiveLabels);
+            effectiveLabels = LGraphUtil.reversed(effectiveLabels);
         }
         
         for (LLabel label : effectiveLabels) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummySwitcher.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelDummySwitcher.java
@@ -34,7 +34,6 @@ import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.Property;
 
-import com.google.common.collect.Lists;
 
 
 /**
@@ -704,7 +703,7 @@ public final class LabelDummySwitcher implements ILayoutProcessor<LGraph> {
             } while (source.getType() == NodeType.LONG_EDGE);
             
             // The list is currently not in the order we would expect, so produce a reversed version
-            leftLongEdgeDummies = Lists.reverse(leftLongEdgeDummies);
+            leftLongEdgeDummies = LGraphUtil.reversed(leftLongEdgeDummies);
         }
         
         /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/LabelSideSelector.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.Queue;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -30,7 +31,6 @@ import org.eclipse.elk.core.options.LabelSide;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * <p>Decides for each edge label whether to place it above or below its respective edge. How the decision is made
@@ -239,7 +239,7 @@ public final class LabelSideSelector implements ILayoutProcessor<LGraph> {
             final LabelSide defaultSide) {
         
         // We keep track of runs of consecutive label dummy nodes that connect the same two nodes
-        List<LNode> labelDummyRun = Lists.newArrayListWithCapacity(dummyNodes.size());
+        List<LNode> labelDummyRun = new ArrayList<>(dummyNodes.size());
         LNode prevLongEdgeSource = null;
         LNode prevLongEdgeTarget = null;
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NodePromotion.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NodePromotion.java
@@ -29,9 +29,8 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import java.util.function.Function;
+import java.util.ArrayList;
 
 /**
  * An approach that is implementing the node promotion heuristic of Nikola S. Nikolov and Alexandre
@@ -276,8 +275,8 @@ public class NodePromotion implements ILayoutProcessor<LGraph> {
         int nodeID = 0;
         maxWidth = 0;
         maxWidthPixel = 0.0;
-        currentWidth = Lists.newArrayList(new Integer[maxHeight]);
-        currentWidthPixel = Lists.newArrayList(new Double[maxHeight]);
+        currentWidth = new ArrayList<>(java.util.Arrays.asList(new Integer[maxHeight]));
+        currentWidthPixel = new ArrayList<>(java.util.Arrays.asList(new Double[maxHeight]));
 
         // Set IDs for all layers and nodes.
         // Layer IDs are reversed for easier handling in the heuristic.
@@ -295,8 +294,8 @@ public class NodePromotion implements ILayoutProcessor<LGraph> {
 
         layers = new int[nodeID];
         degreeDiff = new int[nodeID][3]; // SUPPRESS CHECKSTYLE MagicNumber
-        nodes = Lists.newArrayList();
-        nodesWithIncomingEdges = Lists.newArrayList();
+        nodes = new ArrayList<>();
+        nodesWithIncomingEdges = new ArrayList<>();
         int dummyBaggage = 0; // Will contain number of dummy nodes between the layers.
         dummyNodeCount = 0;
 
@@ -313,8 +312,8 @@ public class NodePromotion implements ILayoutProcessor<LGraph> {
                 layers[nodeID] = node.getLayer().id;
                 layerSizePixel += node.getSize().y + nodeSizeAffix; // Accumulate width of every
                                                                     // node.
-                int inDegree = Iterables.size(node.getIncomingEdges());
-                int outDegree = Iterables.size(node.getOutgoingEdges());
+                int inDegree = ((int) java.util.stream.StreamSupport.stream(node.getIncomingEdges().spliterator(), false).count());
+                int outDegree = ((int) java.util.stream.StreamSupport.stream(node.getOutgoingEdges().spliterator(), false).count());
                 degreeDiff[nodeID][0] = outDegree - inDegree;
                 degreeDiff[nodeID][1] = inDegree;
                 degreeDiff[nodeID][2] = outDegree;
@@ -584,13 +583,13 @@ public class NodePromotion implements ILayoutProcessor<LGraph> {
                     reducedDummies += dummyBackup - dummyNodeCount;
                     dummyBackup = dummyNodeCount + promotionPair.getFirst();
                     heightBackup = maxHeight;
-                    currentWidthBackup = Lists.newArrayList(currentWidth);
-                    currentWidthPixelBackup = Lists.newArrayList(currentWidthPixel);
+                    currentWidthBackup = new ArrayList<>(currentWidth);
+                    currentWidthPixelBackup = new ArrayList<>(currentWidthPixel);
                 } else { // Promotion is invalid and the last valid state will be restored.
                     layers = Arrays.copyOf(layeringBackup, layeringBackup.length);
                     dummyNodeCount = dummyBackup;
-                    currentWidth = Lists.newArrayList(currentWidthBackup);
-                    currentWidthPixel = Lists.newArrayList(currentWidthPixelBackup);
+                    currentWidth = new ArrayList<>(currentWidthBackup);
+                    currentWidthPixel = new ArrayList<>(currentWidthPixelBackup);
                     maxHeight = heightBackup;
                 }
             }
@@ -693,7 +692,7 @@ public class NodePromotion implements ILayoutProcessor<LGraph> {
         // our layering. It is added to the layeredGraph with reversed IDs so they fit to the IDs
         // stored in the nodes but can also be properly assigned compliant with the layering used in
         // ELK Layered.
-        List<Layer> layList = Lists.newArrayList();
+        List<Layer> layList = new ArrayList<>();
         for (int i = 0; i <= maxHeight; i++) {
             Layer laLaLayer = new Layer(layeredGraph);
             laLaLayer.id = maxHeight - i;
@@ -724,7 +723,7 @@ public class NodePromotion implements ILayoutProcessor<LGraph> {
      * @param layeredGraph The graph to which the calculated new layering is applied.
      */
     private void setNewLayeringModelOrder(final LGraph layeredGraph) {
-        List<Layer> layerList = Lists.newArrayList();
+        List<Layer> layerList = new ArrayList<>();
         layeredGraph.getLayers().clear();
         // Get the layer indices.
         List<Integer> keySet = biLayerMap.keySet().stream().sorted().collect(Collectors.toList());

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/NorthSouthPortPreprocessor.java
@@ -29,8 +29,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Inserts dummy nodes to cope with northern and southern ports.
@@ -147,8 +145,8 @@ public final class NorthSouthPortPreprocessor implements ILayoutProcessor<LGraph
         monitor.begin("Odd port side processing", 1);
 
         int pointer;
-        List<LNode> northDummyNodes = Lists.newArrayList();
-        List<LNode> southDummyNodes = Lists.newArrayList();
+        List<LNode> northDummyNodes = new ArrayList<>();
+        List<LNode> southDummyNodes = new ArrayList<>();
 
         // Iterate through the layers
         for (Layer layer : layeredGraph) {
@@ -183,12 +181,12 @@ public final class NorthSouthPortPreprocessor implements ILayoutProcessor<LGraph
                 southDummyNodes.clear();
 
                 // Create a list of barycenter associates for the node
-                List<LNode> barycenterAssociates = Lists.newArrayList();
+                List<LNode> barycenterAssociates = new ArrayList<>();
 
                 // Prepare a list of ports on the northern side, sorted from left to right (when viewed
                 // in the diagram); create the appropriate dummy nodes and assign them to the layer
-                LinkedList<LPort> portList = Lists.newLinkedList();
-                Iterables.addAll(portList, node.getPorts(PortSide.NORTH));
+                LinkedList<LPort> portList = new LinkedList<>();
+                node.getPorts(PortSide.NORTH).forEach(portList::add);
 
                 if (node.getGraph().getProperty(LayeredOptions.CONSIDER_MODEL_ORDER_STRATEGY) != OrderingStrategy.NONE) {                    
                     portList = modelOrderNorthSouthInputReversing(portList, node);
@@ -381,7 +379,7 @@ public final class NorthSouthPortPreprocessor implements ILayoutProcessor<LGraph
                 outgoing.add(port);
             }
         }
-        Lists.reverse(incoming).addAll(outgoing);
+        LGraphUtil.reversed(incoming).addAll(outgoing);
         return incoming;
     }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionMidprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionMidprocessor.java
@@ -24,8 +24,12 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Add constraint edges between partitions that force layering algorithms to adhere to the partitions.
@@ -58,12 +62,14 @@ public class PartitionMidprocessor implements ILayoutProcessor<LGraph> {
         monitor.begin("Partition midprocessing", 1);
         
         // Collect nodes which have a partition set
-        Multimap<Integer, LNode> partitionToNodesMap = HashMultimap.create();
+        Map<Integer, Set<LNode>> partitionToNodesMap = new HashMap<>();
         
         // Go through all layerless nodes and collect all partition IDs in use
         lGraph.getLayerlessNodes().stream()
             .filter(node -> node.hasProperty(LayeredOptions.PARTITIONING_PARTITION))
-            .forEach(node -> partitionToNodesMap.put(node.getProperty(LayeredOptions.PARTITIONING_PARTITION), node));
+            .forEach(node -> partitionToNodesMap
+                    .computeIfAbsent(node.getProperty(LayeredOptions.PARTITIONING_PARTITION), k -> new HashSet<>())
+                    .add(node));
         
         if (partitionToNodesMap.isEmpty()) {
             // This shouldn't happen, but if it does, there's nothing to do
@@ -82,7 +88,8 @@ public class PartitionMidprocessor implements ILayoutProcessor<LGraph> {
         Integer firstId = idIterator.next();
         while (idIterator.hasNext()) {
             Integer secondId = idIterator.next();
-            connectNodes(partitionToNodesMap.get(firstId), partitionToNodesMap.get(secondId));
+            connectNodes(partitionToNodesMap.getOrDefault(firstId, Collections.emptySet()),
+                    partitionToNodesMap.getOrDefault(secondId, Collections.emptySet()));
             firstId = secondId;
         }
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionPreprocessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/PartitionPreprocessor.java
@@ -23,7 +23,6 @@ import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Streams;
 
 /**
  * Reverses edges that connect higher-index to lower-index partitions. If all nodes have a partition set, the result is
@@ -71,7 +70,7 @@ public class PartitionPreprocessor implements ILayoutProcessor<LGraph> {
             .collect(Collectors.toList());
         List<LEdge> edgesToBeReversed = lGraph.getLayerlessNodes().stream()
             .filter(lNode -> lNode.hasProperty(LayeredOptions.PARTITIONING_PARTITION))
-            .flatMap(lNode -> Streams.stream(lNode.getOutgoingEdges()))
+            .flatMap(lNode -> java.util.stream.StreamSupport.stream(lNode.getOutgoingEdges().spliterator(), false))
             .filter(lEdge -> mustBeReversed(lEdge, partitionedNodes))
             .collect(Collectors.toList());
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/EdgeAwareScanlineConstraintCalculation.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/EdgeAwareScanlineConstraintCalculation.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.intermediate.compaction;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.common.compaction.oned.CGroup;
 import org.eclipse.elk.alg.common.compaction.oned.CNode;
@@ -23,7 +24,6 @@ import org.eclipse.elk.alg.layered.options.Spacings;
 import org.eclipse.elk.core.UnsupportedConfigurationException;
 import org.eclipse.elk.core.options.EdgeRouting;
 
-import com.google.common.collect.Lists;
 
 /**
  * An extended scanline procedure that is able to properly handle different spacing values between nodes and edges.
@@ -65,7 +65,7 @@ public class EdgeAwareScanlineConstraintCalculation extends ScanlineConstraintCa
     // -------------------------------------- SPLINES --------------------------------------
     
     private void calculateForSpline() {
-        final List<Runnable> schedule = Lists.newArrayList();
+        final List<Runnable> schedule = new ArrayList<>();
         
         /* -------------------- Vertical Segments -------------------- */
         // Note that some constraints between subsequent vertical segments of the same spline 
@@ -114,7 +114,7 @@ public class EdgeAwareScanlineConstraintCalculation extends ScanlineConstraintCa
     // -------------------------------------- ORTHOGONAL --------------------------------------
     private void calculateForOrthogonal() {
         
-        final List<Runnable> schedule = Lists.newArrayList();
+        final List<Runnable> schedule = new ArrayList<>();
         
         /* -------------------- Vertical Segments -------------------- */
         compactor.cGraph.cNodes.stream()

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/LGraphToCGraphTransformer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/LGraphToCGraphTransformer.java
@@ -19,6 +19,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 
 import org.eclipse.elk.alg.common.compaction.oned.CGraph;
 import org.eclipse.elk.alg.common.compaction.oned.CGroup;
@@ -41,11 +44,6 @@ import org.eclipse.elk.core.options.EdgeRouting;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
 /**
  * Manages the transformation of {@link LNode}s and {@link LEdge}s from an {@link LGraph} into
  * compactable {@link CNode}s and {@link CGroup}s.
@@ -59,12 +57,12 @@ public final class LGraphToCGraphTransformer {
     /** Current style of edge routing. */
     private EdgeRouting edgeRouting;
     /** remember comment boxes as we neglect them during compaction and offset them afterwards. */
-    private Map<LNode, Pair<LNode, KVector>> commentOffsets = Maps.newHashMap();
+    private Map<LNode, Pair<LNode, KVector>> commentOffsets = new HashMap<>();
     
     /* ------------------ Internal Mappings ------------------ */
-    private Map<LNode, CNode> nodesMap = Maps.newHashMap();
-    private Map<VerticalSegment, CNode> verticalSegmentsMap = Maps.newHashMap();
-    private Map<CNode, Quadruplet> lockMap = Maps.newHashMap();
+    private Map<LNode, CNode> nodesMap = new HashMap<>();
+    private Map<VerticalSegment, CNode> verticalSegmentsMap = new HashMap<>();
+    private Map<CNode, Quadruplet> lockMap = new HashMap<>();
     
     // for debugging
     private static final Function<CNode, String> NODE_TO_STRING_DELEGATE =
@@ -101,7 +99,7 @@ public final class LGraphToCGraphTransformer {
             l.id = index++;
             for (LNode n : l) {
                 // avoid calling Iterables.isEmpty unnecessarily
-                if (!hasEdges && !Iterables.isEmpty(n.getConnectedEdges())) {
+                if (!hasEdges && !!n.getConnectedEdges().iterator().hasNext()) {
                     hasEdges = true;
                 }
             }
@@ -129,8 +127,8 @@ public final class LGraphToCGraphTransformer {
                 // hence we can neglect them here without the risk
                 // of other nodes overlapping them after compaction
                 if (node.getProperty(LayeredOptions.COMMENT_BOX)) {
-                    if (!Iterables.isEmpty(node.getConnectedEdges())) {
-                        LEdge e = Iterables.get(node.getConnectedEdges(), 0);
+                    if (!!node.getConnectedEdges().iterator().hasNext()) {
+                        LEdge e = java.util.stream.StreamSupport.stream(node.getConnectedEdges().spliterator(), false).skip(0).findFirst().orElseThrow();
                         LNode other = e.getSource().getNode();
                         if (other == node) {
                             other = e.getTarget().getNode();
@@ -165,8 +163,8 @@ public final class LGraphToCGraphTransformer {
 
                 // locking the node for directions that fewer edges are connected in
                 // (only used if LEFT_RIGHT_CONNECTION_LOCKING is used)
-                int difference = Iterables.size(node.getIncomingEdges())
-                                 - Iterables.size(node.getOutgoingEdges());
+                int difference = ((int) java.util.stream.StreamSupport.stream(node.getIncomingEdges().spliterator(), false).count())
+                                 - ((int) java.util.stream.StreamSupport.stream(node.getOutgoingEdges().spliterator(), false).count());
                 if (difference < 0) {
                     nodeLock.set(true, Direction.LEFT);
                 } else if (difference > 0) {
@@ -212,7 +210,7 @@ public final class LGraphToCGraphTransformer {
     }
     
     private List<VerticalSegment> collectVerticalSegmentsOrthogonal() {
-        List<VerticalSegment> verticalSegments = Lists.newArrayList();
+        List<VerticalSegment> verticalSegments = new ArrayList<>();
         
         for (Layer layer : layeredGraph) {
             for (LNode node : layer) {
@@ -322,7 +320,7 @@ public final class LGraphToCGraphTransformer {
     }
     
     private List<VerticalSegment> collectVerticalSegmentsSplines() {
-        List<VerticalSegment> verticalSegments = Lists.newArrayList();
+        List<VerticalSegment> verticalSegments = new ArrayList<>();
         
         layeredGraph.getLayers().stream()
             .flatMap(l -> l.getNodes().stream())
@@ -405,8 +403,8 @@ public final class LGraphToCGraphTransformer {
         // segments belonging to multiple edges should be locked 
         // in the direction that fewer different ports are connected in
         // (only used if LEFT_RIGHT_CONNECTION_LOCKING is active)
-        Set<LPort> inc = Sets.newHashSet();
-        Set<LPort> out = Sets.newHashSet();
+        Set<LPort> inc = new HashSet<>();
+        Set<LPort> out = new HashSet<>();
         for (LEdge e : verticalSegment.representedLEdges) {
             inc.add(e.getSource());
             out.add(e.getTarget());

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/NetworkSimplexCompaction.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/NetworkSimplexCompaction.java
@@ -11,6 +11,8 @@ package org.eclipse.elk.alg.layered.intermediate.compaction;
 
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.common.compaction.oned.CGroup;
 import org.eclipse.elk.alg.common.compaction.oned.CNode;
@@ -26,10 +28,11 @@ import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.BasicProgressMonitor;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Compaction strategy for the {@link OneDimensionalCompactor} based on the network simplex
@@ -199,8 +202,8 @@ public class NetworkSimplexCompaction implements ICompactionAlgorithm {
     private void addEdgeConstraints() {
 
         // collect the original edges
-        Map<LNode, CNode> lNodeMap = Maps.newHashMap();
-        Multimap<LEdge, CNode> lEdgeMap = HashMultimap.create();
+        Map<LNode, CNode> lNodeMap = new HashMap<>();
+        Map<LEdge, Set<CNode>> lEdgeMap = new HashMap<>();
         for (CNode cNode : compactor.cGraph.cNodes) {
             LNode lNode = HorizontalGraphCompactor.getLNodeOrNull(cNode);
             if (lNode != null) {
@@ -209,7 +212,7 @@ public class NetworkSimplexCompaction implements ICompactionAlgorithm {
                 VerticalSegment vs = HorizontalGraphCompactor.getVerticalSegmentOrNull(cNode);
                 if (vs != null) {
                     for (LEdge e : vs.representedLEdges) {
-                        lEdgeMap.put(e, cNode);
+                        lEdgeMap.computeIfAbsent(e, k -> new HashSet<>()).add(cNode);
                     }
                 }
             } 
@@ -246,9 +249,9 @@ public class NetworkSimplexCompaction implements ICompactionAlgorithm {
                         .create();
                     
                     // keep vertical segments close to the node if they are inverted ports
-                    if (srcPort.getSide() == PortSide.WEST && LPort.OUTPUT_PREDICATE.apply(srcPort)) {
+                    if (srcPort.getSide() == PortSide.WEST && LPort.OUTPUT_PREDICATE.test(srcPort)) {
 
-                        for (CNode n : lEdgeMap.get(lEdge)) {
+                        for (CNode n : lEdgeMap.getOrDefault(lEdge, Collections.emptySet())) {
                             if (n.hitbox.x < cNode.hitbox.x) {
                                 NNode src = nNodes[n.cGroup.id];
                                 NNode tgt = nNodes[cNode.cGroup.id];
@@ -265,9 +268,9 @@ public class NetworkSimplexCompaction implements ICompactionAlgorithm {
                         }
                     }
 
-                    if (tgtPort.getSide() == PortSide.EAST && LPort.INPUT_PREDICATE.apply(tgtPort)) {
+                    if (tgtPort.getSide() == PortSide.EAST && LPort.INPUT_PREDICATE.test(tgtPort)) {
 
-                        for (CNode n : lEdgeMap.get(lEdge)) {
+                        for (CNode n : lEdgeMap.getOrDefault(lEdge, Collections.emptySet())) {
                             if (n.hitbox.x > cNode.hitbox.x) {
                                 NNode src = nNodes[cNode.cGroup.id];
                                 NNode tgt = nNodes[n.cGroup.id];
@@ -294,7 +297,7 @@ public class NetworkSimplexCompaction implements ICompactionAlgorithm {
      * node.
      */
     private void addArtificialSourceNode() {
-        List<NNode> sources = Lists.newLinkedList();
+        List<NNode> sources = new LinkedList<>();
         for (NNode n : networkSimplexGraph.nodes) {
             if (n.getIncomingEdges().isEmpty()) {
                 sources.add(n);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/VerticalSegment.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/compaction/VerticalSegment.java
@@ -10,9 +10,9 @@
 package org.eclipse.elk.alg.layered.intermediate.compaction;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.common.compaction.oned.CNode;
-import org.eclipse.elk.alg.common.compaction.oned.CompareFuzzy;
 import org.eclipse.elk.alg.common.compaction.oned.Quadruplet;
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LPort;
@@ -20,10 +20,8 @@ import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.math.ElkRectangle;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
+import org.eclipse.elk.alg.layered.compaction.oned.CompareFuzzy;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.math.DoubleMath;
 
 /**
  * Represents a vertical segment on a single {@link LEdge} that is merged with intersecting
@@ -40,15 +38,15 @@ public final class VerticalSegment implements Comparable<VerticalSegment> {
     // SUPPRESS CHECKSTYLE NEXT 34 VisibilityModifier
     
     /** Nodes that may become the parent of the {@link CNode} that will represent this segment. */
-    public List<CNode> potentialGroupParents = Lists.newArrayList();
+    public List<CNode> potentialGroupParents = new ArrayList<>();
     
     /** The edges that contribute at least partly to this vertical segment. */
-    public List<LEdge> representedLEdges = Lists.newArrayList();
+    public List<LEdge> representedLEdges = new ArrayList<>();
     /** The bendpoints that are located within the hitbox of this vertical segment.
      *  After compaction they should be adjusted. */
-    public List<KVector> affectedBends = Lists.newArrayList();
+    public List<KVector> affectedBends = new ArrayList<>();
     /** Bounding boxes, e.g. of splines, that are to be adjusted after compaction. */
-    public List<ElkRectangle> affectedBoundingBoxes = Lists.newArrayList();
+    public List<ElkRectangle> affectedBoundingBoxes = new ArrayList<>();
 
     /** The area occupied by this vertical segment. */
     public ElkRectangle hitbox = new ElkRectangle();
@@ -60,13 +58,13 @@ public final class VerticalSegment implements Comparable<VerticalSegment> {
     public Quadruplet ignoreSpacing = new Quadruplet();
     
     /** Pre-computed constraints that are to be added to the {@link CNode} which represents this segment. */
-    public List<VerticalSegment> constraints = Lists.newArrayList();
+    public List<VerticalSegment> constraints = new ArrayList<>();
 
     /** Orthogonal edges may have vertical segments that leave/enter a north/south port. Such a port is stored here. */
     public LPort aPort;
     
     /** Segments that have been joined with this one. */
-    public List<VerticalSegment> joined = Lists.newArrayList();
+    public List<VerticalSegment> joined = new ArrayList<>();
     
     /**
      * Creates a new instance setting all fields.
@@ -162,7 +160,7 @@ public final class VerticalSegment implements Comparable<VerticalSegment> {
 
     @Override
     public int compareTo(final VerticalSegment o) {
-        int d = DoubleMath.fuzzyCompare(hitbox.x, o.hitbox.x, CompareFuzzy.TOLERANCE);
+        int d = CompareFuzzy.fuzzyCompare(hitbox.x, o.hitbox.x, CompareFuzzy.TOLERANCE);
         if (d == 0) {
             return Double.compare(this.hitbox.y, o.hitbox.y);
         }
@@ -175,7 +173,7 @@ public final class VerticalSegment implements Comparable<VerticalSegment> {
         sb.append("VerticalSegment ");
         sb.append(hitbox);
         sb.append(" ");
-        sb.append(Joiner.on(", ").join(representedLEdges));
+        sb.append(representedLEdges.stream().map(String::valueOf).collect(java.util.stream.Collectors.joining(String.valueOf(", "))));
         return sb.toString();
     }
 }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/BetweenLayerEdgeTwoNodeCrossingsCounter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/greedyswitch/BetweenLayerEdgeTwoNodeCrossingsCounter.java
@@ -12,6 +12,8 @@ package org.eclipse.elk.alg.layered.intermediate.greedyswitch;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -19,8 +21,6 @@ import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.p3order.counting.CrossMinUtil;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * Calculates the number of crossings for edges incident to two nodes. In the case where there is
@@ -48,9 +48,9 @@ public final class BetweenLayerEdgeTwoNodeCrossingsCounter {
      *            Index of free layer.
      */
     public BetweenLayerEdgeTwoNodeCrossingsCounter(final LNode[][] currentNodeOrder, final int freeLayerIndex) {
-        portPositions = Maps.newHashMap();
-        easternAdjacencies = Maps.newHashMap();
-        westernAdjacencies = Maps.newHashMap();
+        portPositions = new HashMap<>();
+        easternAdjacencies = new HashMap<>();
+        westernAdjacencies = new HashMap<>();
         this.currentNodeOrder = currentNodeOrder;
         this.freeLayerIndex = freeLayerIndex;
         setPortPositionsForNeighbouringLayers();
@@ -241,7 +241,7 @@ public final class BetweenLayerEdgeTwoNodeCrossingsCounter {
         AdjacencyList(final LNode node, final PortSide side) {
             this.node = node;
             this.side = side;
-            adjacencyList = Lists.newArrayList();
+            adjacencyList = new ArrayList<>();
             getAdjacenciesSortedByPosition();
         }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/SelfHyperLoop.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/SelfHyperLoop.java
@@ -23,9 +23,9 @@ import org.eclipse.elk.alg.layered.intermediate.loops.ordering.PortRestorer;
 import org.eclipse.elk.alg.layered.intermediate.loops.routing.RoutingDirector;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multimap;
+import java.util.EnumMap;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A self loop hyperedge consisting of at least one self loop edge.
@@ -58,7 +58,7 @@ public class SelfHyperLoop {
     /** This self loop's loop type. Determined once port sides have been assigned. */
     private SelfLoopType selfLoopType;
     /** List of ports per port side. */
-    private ListMultimap<PortSide, SelfLoopPort> slPortsBySide;
+    private Map<PortSide, List<SelfLoopPort>> slPortsBySide;
     /** The hyper loop trunk's leftmost port. Computed after initialization. */
     private SelfLoopPort leftmostPort = null;
     /** The hyper loop trunk's rightmost port. Computed after initialization. */
@@ -86,12 +86,12 @@ public class SelfHyperLoop {
         assert slPortsBySide == null;
         
         // Remember ports for each side
-        slPortsBySide = ArrayListMultimap.create(PortSide.values().length, slPorts.size());
+        slPortsBySide = new EnumMap<>(PortSide.class);
         for (SelfLoopPort slPort : slPorts) {
             PortSide portSide = slPort.getLPort().getSide();
             assert portSide != PortSide.UNDEFINED;
             
-            slPortsBySide.put(portSide, slPort);
+            slPortsBySide.computeIfAbsent(portSide, k -> new ArrayList<>()).add(slPort);
         }
         
         // Determine this self loop's loop type
@@ -170,7 +170,7 @@ public class SelfHyperLoop {
     /**
      * Returns a map of port sides mapped to ports on that side.
      */
-    public Multimap<PortSide, SelfLoopPort> getSLPortsBySide() {
+    public Map<PortSide, List<SelfLoopPort>> getSLPortsBySide() {
         return slPortsBySide;
     }
     
@@ -178,7 +178,7 @@ public class SelfHyperLoop {
      * Returns the loop's ports on the given side.
      */
     public Collection<SelfLoopPort> getSLPortsBySide(final PortSide portSide) {
-        return slPortsBySide.get(portSide);
+        return slPortsBySide.getOrDefault(portSide, Collections.emptyList());
     }
     
     /**

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/ordering/PortRestorer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/ordering/PortRestorer.java
@@ -31,10 +31,9 @@ import org.eclipse.elk.alg.layered.options.SelfLoopOrderingStrategy;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ArrayTable;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Table;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Restores hidden ports assuming fixed side port constraints.
@@ -42,9 +41,9 @@ import com.google.common.collect.Table;
 public class PortRestorer {
     
     /** {@link SelfHyperLoop}s indexed by {@link SelfLoopType}. */
-    private ListMultimap<SelfLoopType, SelfHyperLoop> slLoopsByType;
+    private Map<SelfLoopType, List<SelfHyperLoop>> slLoopsByType;
     /** A table of all of the different areas around the node to place self loop ports. */
-    private Table<PortSide, PortSideArea, List<SelfLoopPort>> targetAreas;
+    private Map<PortSide, Map<PortSideArea, List<SelfLoopPort>>> targetAreas;
 
     /**
      * Restores all previously hidden ports at proper locations. This will also reset all hiding-related properties of
@@ -73,6 +72,7 @@ public class PortRestorer {
 
         // We're not hiding any ports anymore
         targetAreas.values().stream()
+            .flatMap(byArea -> byArea.values().stream())
             .flatMap(slPortList -> slPortList.stream())
             .forEach(slPort -> slPort.setHidden(false));
         slHolder.setPortsHidden(false);
@@ -86,14 +86,13 @@ public class PortRestorer {
      * of port side and port side area in {@link #targetAreas}.
      */
     private void initTargetAreas() {
-        // An array table is more efficient than other tables, but requires all row and column keys to be specified in
-        // advance
-        targetAreas = ArrayTable.create(Arrays.asList(PortSide.values()), Arrays.asList(PortSideArea.values()));
-        
+        targetAreas = new EnumMap<>(PortSide.class);
         for (PortSide side : PortSide.values()) {
+            Map<PortSideArea, List<SelfLoopPort>> areaMap = new EnumMap<>(PortSideArea.class);
             for (PortSideArea area : PortSideArea.values()) {
-                targetAreas.put(side, area, new ArrayList<>());
+                areaMap.put(area, new ArrayList<>());
             }
+            targetAreas.put(side, areaMap);
         }
     }
 
@@ -103,9 +102,11 @@ public class PortRestorer {
     /**
      * Gathers all of the self loops and distributes them by type.
      */
-    private ListMultimap<SelfLoopType, SelfHyperLoop> gatherSelfLoopsByType(final SelfLoopHolder slHolder) {
-        ListMultimap<SelfLoopType, SelfHyperLoop> loops = ArrayListMultimap.create();
-        slHolder.getSLHyperLoops().stream().forEach(slLoop -> loops.put(slLoop.getSelfLoopType(), slLoop));
+    private Map<SelfLoopType, List<SelfHyperLoop>> gatherSelfLoopsByType(final SelfLoopHolder slHolder) {
+        Map<SelfLoopType, List<SelfHyperLoop>> loops = new HashMap<>();
+        slHolder.getSLHyperLoops()
+                .forEach(slLoop -> loops.computeIfAbsent(slLoop.getSelfLoopType(), k -> new ArrayList<>())
+                        .add(slLoop));
         return loops;
     }
 
@@ -114,9 +115,9 @@ public class PortRestorer {
 
     private void processOneSideLoops(final SelfLoopOrderingStrategy ordering) {
         if (ordering == SelfLoopOrderingStrategy.REVERSE_STACKED) {
-            Collections.reverse(slLoopsByType.get(SelfLoopType.ONE_SIDE));
+            Collections.reverse(slLoopsByType.getOrDefault(SelfLoopType.ONE_SIDE, Collections.emptyList()));
         }
-        for (SelfHyperLoop slLoop : slLoopsByType.get(SelfLoopType.ONE_SIDE)) {
+        for (SelfHyperLoop slLoop : slLoopsByType.getOrDefault(SelfLoopType.ONE_SIDE, Collections.emptyList())) {
             // Obtain the port side
             PortSide side = slLoop.getSLPorts().get(0).getLPort().getSide();
             
@@ -188,7 +189,7 @@ public class PortRestorer {
     // Self Loop Placement (Two Sides)
 
     private void processTwoSideCornerLoops() {
-        for (SelfHyperLoop slLoop : slLoopsByType.get(SelfLoopType.TWO_SIDES_CORNER)) {
+        for (SelfHyperLoop slLoop : slLoopsByType.getOrDefault(SelfLoopType.TWO_SIDES_CORNER, Collections.emptyList())) {
             // Sort the port sides such that they follow a clockwise order
             PortSide[] sides = sortedTwoSideLoopPortSides(slLoop);
             
@@ -199,7 +200,7 @@ public class PortRestorer {
     }
 
     private void processTwoSideOpposingLoops() {
-        for (SelfHyperLoop slLoop : slLoopsByType.get(SelfLoopType.TWO_SIDES_OPPOSING)) {
+        for (SelfHyperLoop slLoop : slLoopsByType.getOrDefault(SelfLoopType.TWO_SIDES_OPPOSING, Collections.emptyList())) {
             // Sort the port sides such that they follow a clockwise order
             PortSide[] sides = sortedTwoSideLoopPortSides(slLoop);
             
@@ -238,7 +239,7 @@ public class PortRestorer {
     private static final PortSide[] WNE = { PortSide.WEST, PortSide.NORTH, PortSide.EAST };
 
     private void processThreeSideLoops() {
-        for (SelfHyperLoop slLoop : slLoopsByType.get(SelfLoopType.THREE_SIDES)) {
+        for (SelfHyperLoop slLoop : slLoopsByType.getOrDefault(SelfLoopType.THREE_SIDES, Collections.emptyList())) {
             // This array will yield the loop's start, middle, and end sides
             PortSide[] sides = determineLoopConstellation(slLoop);
             
@@ -270,7 +271,7 @@ public class PortRestorer {
     // Self Loop Placement (Four Sides)
 
     private void processFourSideLoops() {
-        for (SelfHyperLoop slLoop : slLoopsByType.get(SelfLoopType.FOUR_SIDES)) {
+        for (SelfHyperLoop slLoop : slLoopsByType.getOrDefault(SelfLoopType.FOUR_SIDES, Collections.emptyList())) {
             // Simply append to all port side's middle areas
             // Prepend to the start area, append to the other areas
             for (PortSide side : slLoop.getSLPortsBySide().keySet()) {
@@ -323,7 +324,7 @@ public class PortRestorer {
                 .collect(Collectors.toList());
 
         Collections.reverse(hiddenPorts);
-        List<SelfLoopPort> targetArea = targetAreas.get(portSide, area);
+        List<SelfLoopPort> targetArea = targetAreas.get(portSide).get(area);
         if (addMode == AddMode.PREPEND) {
             targetArea.addAll(0, hiddenPorts);
         } else {
@@ -347,51 +348,51 @@ public class PortRestorer {
         newPortList.clear();
         
         // Go over the target areas and add them in between the regular ports
-        addAll(targetAreas.get(PortSide.NORTH, PortSideArea.START), lNode);
+        addAll(targetAreas.get(PortSide.NORTH).get(PortSideArea.START), lNode);
         nextOldPortIndex = addAllThat(
                 oldPortList,
                 nextOldPortIndex,
                 (lPort) -> lPort.getSide() == PortSide.NORTH && isNorthSouthPortWithWestOrWestEastConnections(lPort),
                 newPortList);
-        addAll(targetAreas.get(PortSide.NORTH, PortSideArea.MIDDLE), lNode);
+        addAll(targetAreas.get(PortSide.NORTH).get(PortSideArea.MIDDLE), lNode);
         nextOldPortIndex = addAllThat(
                 oldPortList,
                 nextOldPortIndex,
                 (lPort) -> lPort.getSide() == PortSide.NORTH,
                 newPortList);
-        addAll(targetAreas.get(PortSide.NORTH, PortSideArea.END), lNode);
+        addAll(targetAreas.get(PortSide.NORTH).get(PortSideArea.END), lNode);
         
-        addAll(targetAreas.get(PortSide.EAST, PortSideArea.START), lNode);
-        addAll(targetAreas.get(PortSide.EAST, PortSideArea.MIDDLE), lNode);
+        addAll(targetAreas.get(PortSide.EAST).get(PortSideArea.START), lNode);
+        addAll(targetAreas.get(PortSide.EAST).get(PortSideArea.MIDDLE), lNode);
         nextOldPortIndex = addAllThat(
                 oldPortList,
                 nextOldPortIndex,
                 (lPort) -> lPort.getSide() == PortSide.EAST,
                 newPortList);
-        addAll(targetAreas.get(PortSide.EAST, PortSideArea.END), lNode);
+        addAll(targetAreas.get(PortSide.EAST).get(PortSideArea.END), lNode);
         
-        addAll(targetAreas.get(PortSide.SOUTH, PortSideArea.START), lNode);
+        addAll(targetAreas.get(PortSide.SOUTH).get(PortSideArea.START), lNode);
         nextOldPortIndex = addAllThat(
                 oldPortList,
                 nextOldPortIndex,
                 (lPort) -> lPort.getSide() == PortSide.SOUTH && isNorthSouthPortWithEastConnections(lPort),
                 newPortList);
-        addAll(targetAreas.get(PortSide.SOUTH, PortSideArea.MIDDLE), lNode);
+        addAll(targetAreas.get(PortSide.SOUTH).get(PortSideArea.MIDDLE), lNode);
         nextOldPortIndex = addAllThat(
                 oldPortList,
                 nextOldPortIndex,
                 (lPort) -> lPort.getSide() == PortSide.SOUTH,
                 newPortList);
-        addAll(targetAreas.get(PortSide.SOUTH, PortSideArea.END), lNode);
+        addAll(targetAreas.get(PortSide.SOUTH).get(PortSideArea.END), lNode);
         
-        addAll(targetAreas.get(PortSide.WEST, PortSideArea.START), lNode);
+        addAll(targetAreas.get(PortSide.WEST).get(PortSideArea.START), lNode);
         nextOldPortIndex = addAllThat(
                 oldPortList,
                 nextOldPortIndex,
                 (lPort) -> lPort.getSide() == PortSide.WEST,
                 newPortList);
-        addAll(targetAreas.get(PortSide.WEST, PortSideArea.MIDDLE), lNode);
-        addAll(targetAreas.get(PortSide.WEST, PortSideArea.END), lNode);
+        addAll(targetAreas.get(PortSide.WEST).get(PortSideArea.MIDDLE), lNode);
+        addAll(targetAreas.get(PortSide.WEST).get(PortSideArea.END), lNode);
         
         assert newPortList.size() >= oldPortList.size() && newPortList.size() >= slHolder.getSLPortMap().size();
         assert !slHolder.arePortsHidden() || newPortList.size() > oldPortList.size();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/routing/PolylineSelfLoopRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/loops/routing/PolylineSelfLoopRouter.java
@@ -15,8 +15,8 @@ import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.intermediate.loops.SelfLoopEdge;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
+import org.eclipse.elk.alg.layered.compaction.oned.CompareFuzzy;
 
-import com.google.common.math.DoubleMath;
 
 /**
  * Routes self loops with polylines. This is basically the same routing as computed by the
@@ -105,10 +105,10 @@ public class PolylineSelfLoopRouter extends OrthogonalSelfLoopRouter {
      * Determines whether the three vectors constitute an orthogonal routing, minus double tolerances.
      */
     private boolean areOrthogonallyRouted(final KVector previous, final KVector corner, final KVector next) {
-        boolean verticalHorizontal = DoubleMath.fuzzyEquals(previous.x, corner.x, TOLERANCE)
-                && DoubleMath.fuzzyEquals(corner.y, next.y, TOLERANCE);
-        boolean horizontalVertical = DoubleMath.fuzzyEquals(previous.y, corner.y, TOLERANCE)
-                && DoubleMath.fuzzyEquals(corner.x, next.x, TOLERANCE);
+        boolean verticalHorizontal = CompareFuzzy.fuzzyEquals(previous.x, corner.x, TOLERANCE)
+                && CompareFuzzy.fuzzyEquals(corner.y, next.y, TOLERANCE);
+        boolean horizontalVertical = CompareFuzzy.fuzzyEquals(previous.y, corner.y, TOLERANCE)
+                && CompareFuzzy.fuzzyEquals(corner.x, next.x, TOLERANCE);
         
         return verticalHorizontal || horizontalVertical;
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/unzipping/AlternatingLayerUnzipper.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/unzipping/AlternatingLayerUnzipper.java
@@ -25,8 +25,8 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * Divides nodes up between layers to create a more compact final layout.
@@ -220,7 +220,9 @@ public class AlternatingLayerUnzipper implements ILayoutProcessor<LGraph> {
         int edgeCount = 0;
         // If there are no incoming edges, the nodeindex will have to be decreased by one
         boolean noIncomingEdges = true; 
-        List<LEdge> reversedIncomingEdges = Lists.reverse(Lists.newArrayList(node.getIncomingEdges()));
+        List<LEdge> incomingEdges = new ArrayList<>();
+        node.getIncomingEdges().forEach(incomingEdges::add);
+        List<LEdge> reversedIncomingEdges = LGraphUtil.reversed(incomingEdges);
         for (LEdge incomingEdge : reversedIncomingEdges) {
             noIncomingEdges = false;
             LEdge nextEdgeToSplit = incomingEdge;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/ARDCutIndexHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/ARDCutIndexHeuristic.java
@@ -10,10 +10,10 @@
 package org.eclipse.elk.alg.layered.intermediate.wrapping;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 
-import com.google.common.collect.Lists;
 
 /**
  * Calculates cut indexes based on a desired aspect ratio. Given a layering and estimations on the width and height of
@@ -26,7 +26,7 @@ public class ARDCutIndexHeuristic implements ICutIndexCalculator {
         int rows = getChunkCount(gs);
 
         // the number of cuts is one less than the number of rows
-        List<Integer> cuts = Lists.newArrayList();
+        List<Integer> cuts = new ArrayList<>();
         double step = gs.longestPath / (double) rows;
         for (int idx = 1; idx < rows; ++idx) {
             cuts.add((int) Math.round(idx * step));

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointInserter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointInserter.java
@@ -14,6 +14,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -29,8 +32,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Calculates cut points and inserts breaking points into the calculated layering. 
@@ -126,10 +127,10 @@ public class BreakingPointInserter implements ILayoutProcessor<LGraph> {
         int cut = cutIt.next();
         int noSplitEdges = 0;
         
-        Set<LEdge> alreadySplit = Sets.newHashSet();
+        Set<LEdge> alreadySplit = new HashSet<>();
         
         // keep track of edges that have to be split upon cut insertion
-        Set<LEdge> openEdges = Sets.newLinkedHashSet();
+        Set<LEdge> openEdges = new LinkedHashSet<>();
         // run
         while (layerIt.hasNext()) {
             
@@ -242,10 +243,10 @@ public class BreakingPointInserter implements ILayoutProcessor<LGraph> {
     @SuppressWarnings("unused")
     private List<Integer> improveCuts(final LGraph graph, final List<Integer> cuts) {
         
-        List<Integer> improvedCuts = Lists.newArrayList();
+        List<Integer> improvedCuts = new ArrayList<>();
        
         // convert to cut object
-        List<Cut> ccuts = Lists.newArrayList();
+        List<Cut> ccuts = new ArrayList<>();
         Cut lastCut = null;
         for (Integer cutIdx : cuts) {
             Cut cut = new Cut(cutIdx);
@@ -333,7 +334,7 @@ public class BreakingPointInserter implements ILayoutProcessor<LGraph> {
     private int[] computeEdgeSpans(final LGraph graph) {
         int[] spans = new int[graph.getLayers().size() + 1];
         
-        Set<LEdge> open = Sets.newHashSet();
+        Set<LEdge> open = new HashSet<>();
         int i = 0;
         for (Layer l : graph.getLayers()) {
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointProcessor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointProcessor.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.intermediate.wrapping;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.function.Predicate;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -25,8 +26,8 @@ import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * The second of the triumvirate of breaking point processors. While the other two
@@ -108,7 +109,7 @@ public class BreakingPointProcessor implements ILayoutProcessor<LGraph> {
             
             Layer layer = layerIt.next();
             Layer newLayer = layers.get(idx);
-            List<LNode> nodesToMove = Lists.newArrayList(layer.getNodes());
+            List<LNode> nodesToMove = new ArrayList<>(layer.getNodes());
            
             // remember an offset used for adding in-layer dummies later
             int offset = nodesToMove.size();
@@ -120,9 +121,11 @@ public class BreakingPointProcessor implements ILayoutProcessor<LGraph> {
             
             if (reverse) {
                 // important to introduce the chains of long edge dummies in reversed order
-                for (LNode n : Lists.reverse(nodesToMove)) {
+                for (LNode n : LGraphUtil.reversed(nodesToMove)) {
                     
-                    for (LEdge e : Lists.newArrayList(n.getIncomingEdges())) {
+                    List<LEdge> incEdges = new ArrayList<>();
+                    n.getIncomingEdges().forEach(incEdges::add);
+                    for (LEdge e : incEdges) {
                         
                         // reverse the edge
                         e.reverse(graph, true);
@@ -174,7 +177,7 @@ public class BreakingPointProcessor implements ILayoutProcessor<LGraph> {
     private void improveMultiCutIndexEdges(final LGraph graph) {
 
         for (Layer l : graph.getLayers()) {
-            for (LNode n : Lists.newArrayList(l.getNodes())) {
+            for (LNode n : new ArrayList<>(l.getNodes())) {
                 if (BPInfo.isStart(n)) {
                     BPInfo info = n.getProperty(InternalProperties.BREAKING_POINT_INFO);
 
@@ -239,12 +242,12 @@ public class BreakingPointProcessor implements ILayoutProcessor<LGraph> {
         do {
             didsome = false;
 
-            List<Layer> layers = forwards ? Lists.reverse(graph.getLayers()) : graph.getLayers();
+            List<Layer> layers = forwards ? LGraphUtil.reversed(graph.getLayers()) : graph.getLayers();
             for (Layer layer : layers) {
 
-                List<LNode> nodes = Lists.newArrayList(layer.getNodes());
+                List<LNode> nodes = new ArrayList<>(layer.getNodes());
                 if (!forwards) {
-                    Lists.reverse(nodes);
+                    LGraphUtil.reversed(nodes);
                 }
 
                 for (LNode n : nodes) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointRemover.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/BreakingPointRemover.java
@@ -11,6 +11,7 @@ package org.eclipse.elk.alg.layered.intermediate.wrapping;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -27,8 +28,8 @@ import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.EdgeRouting;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * The processor locates any {@link NodeType#BREAKING_POINT} end dummies 
@@ -69,7 +70,7 @@ public class BreakingPointRemover implements ILayoutProcessor<LGraph> {
         
         edgeRouting = graph.getProperty(LayeredOptions.EDGE_ROUTING);
         for (Layer l : graph.getLayers()) {
-            for (LNode node : Lists.newArrayList(l.getNodes())) {
+            for (LNode node : new ArrayList<>(l.getNodes())) {
                 
                 if (BPInfo.isEnd(node)) {
                     BPInfo bpi = node.getProperty(InternalProperties.BREAKING_POINT_INFO);
@@ -107,15 +108,15 @@ public class BreakingPointRemover implements ILayoutProcessor<LGraph> {
                 List<LEdge> e3 = bpi.originalEdge.getProperty(InternalProperties.SPLINE_EDGE_CHAIN);
 
                 // join them (... and remember to reverse some of the segments)
-                List<SplineSegment> joinedSegments = Lists.newArrayList();
+                List<SplineSegment> joinedSegments = new ArrayList<>();
                 joinedSegments.addAll(s1);
                 s2.forEach(s -> s.inverseOrder = true);
-                joinedSegments.addAll(Lists.reverse(s2));
+                joinedSegments.addAll(LGraphUtil.reversed(s2));
                 joinedSegments.addAll(s3);
                 
-                List<LEdge> joinedEdges = Lists.newArrayList();
+                List<LEdge> joinedEdges = new ArrayList<>();
                 joinedEdges.addAll(e1);
-                joinedEdges.addAll(Lists.reverse(e2));
+                joinedEdges.addAll(LGraphUtil.reversed(e2));
                 joinedEdges.addAll(e3);
 
                 // transfer the information to the original edge
@@ -135,7 +136,7 @@ public class BreakingPointRemover implements ILayoutProcessor<LGraph> {
             case POLYLINE:
                 newBends.addAll(bpi.nodeStartEdge.getBendPoints());
                 newBends.add(bpi.start.getPosition());
-                newBends.addAll(Lists.reverse(bpi.startEndEdge.getBendPoints()));
+                newBends.addAll(LGraphUtil.reversed(bpi.startEndEdge.getBendPoints()));
                 newBends.add(bpi.end.getPosition());
                 newBends.addAll(bpi.originalEdge.getBendPoints());
                 break;
@@ -145,7 +146,7 @@ public class BreakingPointRemover implements ILayoutProcessor<LGraph> {
             // of bpi.start and bpi.end can be dropped since they lie on a straight line
             default: // ORTHOGONAL
                 newBends.addAll(bpi.nodeStartEdge.getBendPoints());
-                newBends.addAll(Lists.reverse(bpi.startEndEdge.getBendPoints()));
+                newBends.addAll(LGraphUtil.reversed(bpi.startEndEdge.getBendPoints()));
                 newBends.addAll(bpi.originalEdge.getBendPoints());
         }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/CuttingUtils.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/CuttingUtils.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.intermediate.wrapping;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -24,7 +25,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IndividualSpacings;
 
-import com.google.common.collect.Lists;
 
 /**
  * Utility methods for cut index calculations used by more than one heuristic.
@@ -75,7 +75,7 @@ public final class CuttingUtils {
         int srcIndex = src.getLayer().getIndex();
         int tgtIndex = tgt.getLayer().getIndex();
         
-        List<LEdge> createdEdges = Lists.newArrayList();
+        List<LEdge> createdEdges = new ArrayList<>();
         
         for (int i = srcIndex; i <= tgtIndex; i++) {
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/MSDCutIndexHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/MSDCutIndexHeuristic.java
@@ -10,11 +10,11 @@
 package org.eclipse.elk.alg.layered.intermediate.wrapping;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 
-import com.google.common.collect.Lists;
 
 /**
  * As opposed to the simple {@link ARDCutIndexHeuristic}, this heuristic tries to directly optimize the max scale value
@@ -52,7 +52,7 @@ public class MSDCutIndexHeuristic implements ICutIndexCalculator {
         int freedom = graph.getProperty(LayeredOptions.WRAPPING_CUTTING_MSD_FREEDOM);
 
         double bestMaxScale = Double.NEGATIVE_INFINITY;
-        List<Integer> bestCuts = Lists.newArrayList();
+        List<Integer> bestCuts = new ArrayList<>();
         
         // now find the best set of cut indexes
         for (int m = Math.max(0, cutCnt - freedom); 
@@ -63,7 +63,7 @@ public class MSDCutIndexHeuristic implements ICutIndexCalculator {
             double rowSum = total / (m + 1);
             double sumSoFar = 0;
             int index = 1;
-            List<Integer> cuts = Lists.newArrayList();
+            List<Integer> cuts = new ArrayList<>();
             
             // maximum of any row width
             double width = Double.NEGATIVE_INFINITY;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/SingleEdgeGraphWrapper.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/intermediate/wrapping/SingleEdgeGraphWrapper.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -24,7 +25,6 @@ import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.alg.ILayoutProcessor;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * Intermediate processor that splits path-like graphs into 
@@ -119,7 +119,7 @@ public class SingleEdgeGraphWrapper implements ILayoutProcessor<LGraph> {
      * Validify {@code desiredCuts} by increasing every forbidden index (and its successors) until they are valid.
      */
     public static List<Integer> validifyIndexesGreedily(final GraphStats gs, final List<Integer> cuts) {
-        List<Integer> validCuts = Lists.newArrayList();
+        List<Integer> validCuts = new ArrayList<>();
         int offset = 0;
 
         Iterator<Integer> cutIt = cuts.iterator();
@@ -148,7 +148,7 @@ public class SingleEdgeGraphWrapper implements ILayoutProcessor<LGraph> {
         }
         
         // initialize array with valid cuts
-        List<Integer> validCuts = Lists.newArrayList();
+        List<Integer> validCuts = new ArrayList<>();
         validCuts.add(Integer.MIN_VALUE); // -inf
         for (int i = 1; i < gs.longestPath; ++i) {
             if (gs.isCutAllowed(i)) {
@@ -173,7 +173,7 @@ public class SingleEdgeGraphWrapper implements ILayoutProcessor<LGraph> {
         assert validCuts.get(validCuts.size() - 1) == Integer.MAX_VALUE;
 
         // turn cuts into valid cuts
-        List<Integer> finalCuts = Lists.newArrayList();
+        List<Integer> finalCuts = new ArrayList<>();
         int iIdx = 0;
         int cIdx = 0;
         int offset = 0;
@@ -248,7 +248,7 @@ public class SingleEdgeGraphWrapper implements ILayoutProcessor<LGraph> {
                 Layer oldLayer = graph.getLayers().get(index);
                 Layer newLayer = graph.getLayers().get(newIndex);
 
-                List<LNode> nodesToMove = Lists.newArrayList(oldLayer.getNodes()); 
+                List<LNode> nodesToMove = new ArrayList<>(oldLayer.getNodes()); 
                 for (LNode n : nodesToMove) {
                     
                     // first move the original node 
@@ -257,7 +257,8 @@ public class SingleEdgeGraphWrapper implements ILayoutProcessor<LGraph> {
 
                     // at the cut points the edges have to be re-routed
                     if (newIndex == 0) {
-                        List<LEdge> incEdges = Lists.newArrayList(n.getIncomingEdges());
+                        List<LEdge> incEdges = new ArrayList<>();
+                        n.getIncomingEdges().forEach(incEdges::add);
                         for (LEdge e : incEdges) {
                             e.reverse(graph, true);
                             graph.setProperty(InternalProperties.CYCLIC, true);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/InternalProperties.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/InternalProperties.java
@@ -39,8 +39,6 @@ import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.Property;
 
-import com.google.common.collect.Multimap;
-
 /**
  * Container for property definitions for internal use of the algorithm. These properties should
  * not be accessed from outside. Some properties here are redefinitions of layout options in
@@ -334,8 +332,8 @@ public final class InternalProperties {
      * Map of original hierarchy crossing edges to a set of dummy edges by which the original edge
      * has been replaced.
      */
-    public static final IProperty<Multimap<LEdge, CrossHierarchyEdge>> CROSS_HIERARCHY_MAP =
-            new Property<Multimap<LEdge, CrossHierarchyEdge>>("crossHierarchyMap");
+    public static final IProperty<Map<LEdge, Set<CrossHierarchyEdge>>> CROSS_HIERARCHY_MAP =
+            new Property<Map<LEdge, Set<CrossHierarchyEdge>>>("crossHierarchyMap");
 
     /**
      * Offset to be added to the target anchor point of an edge when the layout is applied back to

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeredSpacings.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/options/LayeredSpacings.java
@@ -27,8 +27,7 @@ import org.eclipse.elk.core.util.ElkSpacings.ElkCoreSpacingsBuilder;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
 
-import com.google.common.collect.Lists;
-import com.google.common.math.DoubleMath;
+import org.eclipse.elk.alg.layered.compaction.oned.CompareFuzzy;
 
 /**
  * Utility class to conveniently configure core spacing values ({@link LayeredOptions#SPACING_*}) for a graph element or
@@ -56,7 +55,7 @@ public final class LayeredSpacings {
         public static final IProperty<Double> BASE_SPACING_OPTION = LayeredOptions.SPACING_NODE_NODE;
         
         // @formatter:off
-        private static final List<IProperty<Double>> DEPENDENT_SPACING_OPTIONS = Lists.newArrayList(
+        private static final List<IProperty<Double>> DEPENDENT_SPACING_OPTIONS = java.util.Arrays.asList(
             // Sorted alphabetically
             // First the ones inherited from CoreOptions (with possibly overridden default value)
             LayeredOptions.SPACING_COMPONENT_COMPONENT,
@@ -79,7 +78,7 @@ public final class LayeredSpacings {
         static {
             assert BASE_SPACING_OPTION.getDefault() != null : "Base spacing default value must be non-null.";
             // Avoid division by zero.
-            assert !DoubleMath.fuzzyEquals(0.0d, BASE_SPACING_OPTION.getDefault(),
+            assert !CompareFuzzy.fuzzyEquals(0.0d, BASE_SPACING_OPTION.getDefault(),
                     DOUBLE_EQ_EPSILON) : "Base spacing default value must be different from 0.0d.";
         }
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/BFSNodeOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/BFSNodeOrderCycleBreaker.java
@@ -30,7 +30,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Iterables;
 
 /**
  * Uses the Breadth-First-Search to traverse the graph and reverses edges if the node is already explored.
@@ -102,10 +101,10 @@ public class BFSNodeOrderCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
         for (LNode node : nodes) {
             // The node id is used as index into our arrays
             node.id = index;
-            if (Iterables.isEmpty(node.getIncomingEdges())) {
+            if (!node.getIncomingEdges().iterator().hasNext()) {
                 sources.add(node);
             }
-            if (Iterables.isEmpty(node.getOutgoingEdges())) {
+            if (!node.getOutgoingEdges().iterator().hasNext()) {
                 sinks.add(node);
             }
             index++;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/DFSNodeOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/DFSNodeOrderCycleBreaker.java
@@ -28,7 +28,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Iterables;
 
 /**
  * Cycle breaker implementation that uses a depth-first traversal of the graph. Described in
@@ -101,7 +100,7 @@ public class DFSNodeOrderCycleBreaker implements ILayoutPhase<LayeredPhases, LGr
         for (LNode node : nodes) {
             // The node id is used as index into our arrays
             node.id = index;
-            if (Iterables.isEmpty(node.getIncomingEdges())) {
+            if (!node.getIncomingEdges().iterator().hasNext()) {
                 sources.add(node);
             }
             index++;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/DepthFirstCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/DepthFirstCycleBreaker.java
@@ -23,7 +23,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Iterables;
 
 /**
  * Cycle breaker implementation that uses a depth-first traversal of the graph. Described in
@@ -89,7 +88,7 @@ public class DepthFirstCycleBreaker implements ILayoutPhase<LayeredPhases, LGrap
         for (LNode node : nodes) {
             // The node id is used as index into our arrays
             node.id = index;
-            if (Iterables.isEmpty(node.getIncomingEdges())) {
+            if (!node.getIncomingEdges().iterator().hasNext()) {
                 sources.add(node);
             }
             index++;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/GreedyCycleBreaker.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.p1cycles;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -26,7 +27,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * Cycle breaker implementation that uses a greedy algorithm. Inspired by
@@ -68,9 +68,9 @@ public class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGraph> {
     /** mark for the nodes, inducing an ordering of the nodes. */
     private int[] mark;
     /** list of source nodes. */
-    private final LinkedList<LNode> sources = Lists.newLinkedList();
+    private final LinkedList<LNode> sources = new LinkedList<>();
     /** list of sink nodes. */
-    private final LinkedList<LNode> sinks = Lists.newLinkedList();
+    private final LinkedList<LNode> sinks = new LinkedList<>();
     
     /**
      * The graph
@@ -140,7 +140,7 @@ public class GreedyCycleBreaker implements ILayoutPhase<LayeredPhases, LGraph> {
         int nextRight = -1, nextLeft = 1;
 
         // assign marks to all nodes
-        List<LNode> maxNodes = Lists.newArrayList();
+        List<LNode> maxNodes = new ArrayList<>();
         random = layeredGraph.getProperty(InternalProperties.RANDOM);
         
         while (unprocessedNodeCount > 0) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/InteractiveCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/InteractiveCycleBreaker.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.p1cycles;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -22,7 +23,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * A cycle breaker that responds to user interaction by respecting the direction of
@@ -54,7 +54,7 @@ public final class InteractiveCycleBreaker implements ILayoutPhase<LayeredPhases
         monitor.begin("Interactive cycle breaking", 1);
         
         // gather edges that point to the wrong direction
-        List<LEdge> revEdges = Lists.newArrayList();
+        List<LEdge> revEdges = new ArrayList<>();
         for (LNode source : layeredGraph.getLayerlessNodes()) {
             source.id = 1;
             double sourcex = source.getInteractiveReferencePoint().x;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/ModelOrderCycleBreaker.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.p1cycles;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -25,7 +26,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * A cycle breaker that reverses all edges that go against the model order or group model order,
@@ -55,7 +55,7 @@ public final class ModelOrderCycleBreaker implements ILayoutPhase<LayeredPhases,
         monitor.begin("Model order cycle breaking", 1);
         
         // gather edges that point to the wrong direction
-        List<LEdge> revEdges = Lists.newArrayList();
+        List<LEdge> revEdges = new ArrayList<>();
         
         // One needs an offset to make sure that the model order of nodes with port constraints is
         // always lower/higher than that of other nodes.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/SCCModelOrderCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/SCCModelOrderCycleBreaker.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -27,7 +28,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * This Cycle Breaking Strategy relies on Tarjan's algorithm to find strongly connected components.
@@ -57,7 +57,7 @@ public abstract class SCCModelOrderCycleBreaker implements ILayoutPhase<LayeredP
     /**
      * The edges to reverse.
      */
-    protected List<LEdge> revEdges = Lists.newArrayList();
+    protected List<LEdge> revEdges = new ArrayList<>();
     
     /**
      * The graph.
@@ -82,7 +82,7 @@ public abstract class SCCModelOrderCycleBreaker implements ILayoutPhase<LayeredP
         this.graph = layeredGraph;
 
         // gather edges that point to the wrong direction
-        revEdges = Lists.newArrayList();
+        revEdges = new ArrayList<>();
 
         // One needs an offset to make sure that the model order of nodes with port constraints is
         // always lower/higher than that of other nodes.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/SCCNodeTypeCycleBreaker.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/SCCNodeTypeCycleBreaker.java
@@ -14,7 +14,6 @@ import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.options.GroupOrderStrategy;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 
-import com.google.common.collect.Iterables;
 
 /**
  * This cycle breaking strategy extends the {@link org.eclipse.elk.alg.layered.p1cycles.SCCModelOrderCycleBreaker}.
@@ -90,7 +89,7 @@ public class SCCNodeTypeCycleBreaker extends SCCModelOrderCycleBreaker {
                 }
             } else {
                 // Use connectivity to decide.
-                if (Iterables.size(min.getIncomingEdges()) > Iterables.size(max.getOutgoingEdges())) {
+                if (((int) java.util.stream.StreamSupport.stream(min.getIncomingEdges().spliterator(), false).count()) > ((int) java.util.stream.StreamSupport.stream(max.getOutgoingEdges().spliterator(), false).count())) {
                     for (LEdge edge : min.getIncomingEdges()) {
                         if (stronglyConnectedComponents.get(i).contains(edge.getSource().getNode())) {
                             revEdges.add(edge);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/SCConnectivity.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p1cycles/SCConnectivity.java
@@ -14,7 +14,6 @@ import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.options.GroupOrderStrategy;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 
-import com.google.common.collect.Iterables;
 
 /**
  * Based on the SCCModelOrderCycleBreaker. This finds the nodes with minimum and maximum model order and reverses the 
@@ -78,7 +77,7 @@ public class SCConnectivity extends SCCModelOrderCycleBreaker {
             // If the minimum node has more incoming edges than the maximum node has outgoing edges,
             // reverse all edges to the minimum node and remove it from the strongly connected component.
             // If it is the other way around, reverse all outgoing edges of the maximum node.
-            if (Iterables.size(min.getIncomingEdges()) > Iterables.size(max.getOutgoingEdges())) {
+            if (((int) java.util.stream.StreamSupport.stream(min.getIncomingEdges().spliterator(), false).count()) > ((int) java.util.stream.StreamSupport.stream(max.getOutgoingEdges().spliterator(), false).count())) {
                 for (LEdge edge : min.getIncomingEdges()) {
                     if (stronglyConnectedComponents.get(i).contains(edge.getSource().getNode())) {
                         revEdges.add(edge);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/CoffmanGrahamLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/CoffmanGrahamLayerer.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.PriorityQueue;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -25,9 +26,9 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Lists;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A layering algorithm that places nodes in layers subject to a bound on the maximum number of (original) nodes per 
@@ -64,7 +65,7 @@ public class CoffmanGrahamLayerer implements ILayoutPhase<LayeredPhases, LGraph>
     /** For each node, stores the positions of incoming nodes in the topological ordering. 
      *  Due to the way the positions are added to the lists, one can assume that the 
      *  lists are sorted. */
-    private ListMultimap<LNode, Integer> inTopo = ArrayListMultimap.create(); 
+    private Map<LNode, List<Integer>> inTopo = new HashMap<>();
     
     @Override
     public void process(final LGraph layeredGraph, final IElkProgressMonitor progressMonitor) {
@@ -130,7 +131,7 @@ public class CoffmanGrahamLayerer implements ILayoutPhase<LayeredPhases, LGraph>
                 }
                 LNode tgt = e.getTarget().getNode();
                 inDeg[tgt.id]--;
-                inTopo.put(tgt, topoOrd[v.id]);
+                inTopo.computeIfAbsent(tgt, k -> new ArrayList<>()).add(topoOrd[v.id]);
                 if (inDeg[tgt.id] == 0) {
                     sources.add(tgt); // 'tgt' is added according to its priority
                 }
@@ -158,7 +159,7 @@ public class CoffmanGrahamLayerer implements ILayoutPhase<LayeredPhases, LGraph>
         }
 
         // assign the layers
-        List<Layer> layers = Lists.newArrayList();
+        List<Layer> layers = new ArrayList<>();
         Layer currentLayer = createLayer(layeredGraph, layers);
         while (!sinks.isEmpty()) {
             // select a node for which all outgoing nodes have been placed,
@@ -226,8 +227,8 @@ public class CoffmanGrahamLayerer implements ILayoutPhase<LayeredPhases, LGraph>
     }
     
     private int compareNodesInTopo(final LNode u, final LNode v) {
-        List<Integer> inListU = inTopo.get(u);
-        List<Integer> inListV = inTopo.get(v);
+        List<Integer> inListU = inTopo.getOrDefault(u, Collections.emptyList());
+        List<Integer> inListV = inTopo.getOrDefault(v, Collections.emptyList());
         ListIterator<Integer> itU = inListU.listIterator(inListU.size());
         ListIterator<Integer> itV = inListV.listIterator(inListV.size());
         

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/InteractiveLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/InteractiveLayerer.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.p2layers;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.ArrayList;
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -24,7 +25,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
 
 /**
  * A node layerer that allows user interaction by respecting previous node positions.
@@ -54,7 +54,7 @@ public final class InteractiveLayerer implements ILayoutPhase<LayeredPhases, LGr
     private static class LayerSpan {
         private double start;
         private double end;
-        private List<LNode> nodes = Lists.newArrayList();
+        private List<LNode> nodes = new ArrayList<>();
     }
 
     @Override
@@ -62,7 +62,7 @@ public final class InteractiveLayerer implements ILayoutPhase<LayeredPhases, LGr
         monitor.begin("Interactive node layering", 1);
 
         // create layers with a start and an end position, merging when they overlap with others
-        List<LayerSpan> currentSpans = Lists.newArrayList();
+        List<LayerSpan> currentSpans = new ArrayList<>();
         for (LNode node : layeredGraph.getLayerlessNodes()) {
             double minx = node.getPosition().x;
             double maxx = minx + node.getSize().x;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/MinWidthLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/MinWidthLayerer.java
@@ -28,10 +28,10 @@ import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Range;
-import com.google.common.collect.Sets;
+import java.util.function.Predicate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 /**
  * Implementation of the heuristic MinWidth for solving the NP-hard minimum-width layering problem
@@ -99,8 +99,10 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
      * http://dx.doi.org/10.1007/978-3-540-24838-5_42.</li>
      * </ul>
      */
-    private static final Range<Integer> UPPERBOUND_ON_WIDTH_RANGE = Range.closed(1, 4);
-    private static final Range<Integer> COMPENSATOR_RANGE = Range.closed(1, 2);
+    private static final int UPPERBOUND_ON_WIDTH_LOWER = 1;
+    private static final int UPPERBOUND_ON_WIDTH_UPPER = 4;
+    private static final int COMPENSATOR_LOWER = 1;
+    private static final int COMPENSATOR_UPPER = 2;
 
     // Some variables used for considering real node sizes, see below.
     private double dummySize;
@@ -214,12 +216,12 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
         // ... then check, whether any special values (i.e. negative values, which aren't valid) have
         // been used for the properties. In that case use the recommended ranges described above …
         if (upperBoundOnWidth < 0) {
-            ubwStart = UPPERBOUND_ON_WIDTH_RANGE.lowerEndpoint();
-            ubwEnd = UPPERBOUND_ON_WIDTH_RANGE.upperEndpoint();
+            ubwStart = UPPERBOUND_ON_WIDTH_LOWER;
+            ubwEnd = UPPERBOUND_ON_WIDTH_UPPER;
         }
         if (compensator < 0) {
-            cStart = COMPENSATOR_RANGE.lowerEndpoint();
-            cEnd = COMPENSATOR_RANGE.upperEndpoint();
+            cStart = COMPENSATOR_LOWER;
+            cEnd = COMPENSATOR_UPPER;
         }
 
         // … Depending on the start- and end-values, this nested for-loop will last for up to 8
@@ -272,15 +274,15 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
      * @return List of Set of successor {@link LNode}s in order of the given nodes
      */
     private List<Set<LNode>> precalcSuccessors(final Collection<LNode> nodes) {
-        List<Set<LNode>> successors = Lists.newArrayListWithCapacity(nodes.size());
+        List<Set<LNode>> successors = new ArrayList<>(nodes.size());
 
         for (LNode node : nodes) {
 
-            Set<LNode> outNodes = Sets.newHashSet();
+            Set<LNode> outNodes = new HashSet<>();
             Iterable<LEdge> outEdges = node.getOutgoingEdges();
 
             for (LEdge edge : outEdges) {
-                if (!isSelfLoopTest.apply(edge)) {
+                if (!isSelfLoopTest.test(edge)) {
                     outNodes.add(edge.getTarget().getNode());
                 }
             }
@@ -321,8 +323,9 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
             final int compensator, final Iterable<LNode> nodes,
             final List<Set<LNode>> nodeSuccessors) {
 
-        List<List<LNode>> layers = Lists.newArrayList();
-        Set<LNode> unplacedNodes = Sets.newLinkedHashSet(nodes);
+        List<List<LNode>> layers = new ArrayList<>();
+        Set<LNode> unplacedNodes = new LinkedHashSet<>();
+        nodes.forEach(unplacedNodes::add);
 
         // One of the deviations from the paper is, that our upper bound is taking node sizes into
         // account:
@@ -337,12 +340,12 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
         // version we consider only the nodes already placed in the current layer), and the
         // second contains all nodes already placed in layers which have been determined before the
         // currentLayer.
-        Set<LNode> alreadyPlacedInCurrentLayer = Sets.newHashSet();
-        Set<LNode> alreadyPlacedInOtherLayers = Sets.newHashSet();
+        Set<LNode> alreadyPlacedInCurrentLayer = new HashSet<>();
+        Set<LNode> alreadyPlacedInOtherLayers = new HashSet<>();
 
         // Set up the first layer (algorithm is bottom up, so the List layer is going to be reversed
         // at the end.
-        List<LNode> currentLayer = Lists.newArrayList();
+        List<LNode> currentLayer = new ArrayList<>();
 
         // Initial values for the width of the current layer and the estimated width of the coming
         // layers
@@ -400,7 +403,7 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
                     || (widthCurrent >= ubwConsiderSize && normSize[currentNode.id] > outDeg * dummySize)
                     || widthUp >= compensator * ubwConsiderSize) {
                 layers.add(currentLayer);
-                currentLayer = Lists.newArrayList();
+                currentLayer = new ArrayList<>();
                 alreadyPlacedInOtherLayers.addAll(alreadyPlacedInCurrentLayer);
                 alreadyPlacedInCurrentLayer.clear();
 
@@ -458,7 +461,7 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
     private int countEdgesExceptSelfLoops(final Iterable<LEdge> edges) {
         int i = 0;
         for (LEdge edge : edges) {
-            if (!isSelfLoopTest.apply(edge)) {
+            if (!isSelfLoopTest.test(edge)) {
                 i++;
             }
         }
@@ -471,7 +474,7 @@ public final class MinWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph
     private class SelfLoopPredicate implements Predicate<LEdge> {
 
         @Override
-        public boolean apply(final LEdge input) {
+        public boolean test(final LEdge input) {
             return input.getSource().getNode().equals(input.getTarget().getNode());
         }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/NetworkSimplexLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/NetworkSimplexLayerer.java
@@ -13,6 +13,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import org.eclipse.elk.alg.common.networksimplex.NEdge;
 import org.eclipse.elk.alg.common.networksimplex.NGraph;
@@ -30,8 +32,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * The main class of the network simplex layerer component. It offers an algorithm to determine an
@@ -107,7 +107,7 @@ public final class NetworkSimplexLayerer implements ILayoutPhase<LayeredPhases, 
         } else {
             Arrays.fill(nodeVisited, false);
         }
-        componentNodes = Lists.newArrayList();
+        componentNodes = new ArrayList<>();
 
         // re-index nodes
         int counter = 0;
@@ -115,7 +115,7 @@ public final class NetworkSimplexLayerer implements ILayoutPhase<LayeredPhases, 
             node.id = counter++;
         }
         // determine connected components
-        LinkedList<List<LNode>> components = Lists.newLinkedList();
+        LinkedList<List<LNode>> components = new LinkedList<>();
         for (LNode node : theNodes) {
             if (!nodeVisited[node.id]) {
                 connectedComponentsDFS(node);
@@ -126,7 +126,7 @@ public final class NetworkSimplexLayerer implements ILayoutPhase<LayeredPhases, 
                 } else {
                     components.addLast(componentNodes);
                 }
-                componentNodes = Lists.newArrayList();
+                componentNodes = new ArrayList<>();
             }
         }
         return components;
@@ -176,7 +176,7 @@ public final class NetworkSimplexLayerer implements ILayoutPhase<LayeredPhases, 
      */
     private NGraph initialize(final List<LNode> theNodes) {
 
-        final Map<LNode, NNode> nodeMap = Maps.newHashMap();
+        final Map<LNode, NNode> nodeMap = new HashMap<>();
         
         // transform nodes
         NGraph graph = new NGraph();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/StretchWidthLayerer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p2layers/StretchWidthLayerer.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashSet;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -27,9 +29,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * This class implements the StretchWidth layering algorithm described in In Search for Efficient
@@ -58,9 +57,9 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
     /** Sorted list of layerless nodes. */
     private List<LNode> sortedLayerlessNodes;
     /** Set of nodes placed in the current layer. */
-    private Set<LNode> alreadyPlacedNodes = Sets.newHashSet();
+    private Set<LNode> alreadyPlacedNodes = new HashSet<>();
     /** Set of nodes in all layers except the current. */
-    private Set<LNode> alreadyPlacedInOtherLayers = Sets.newHashSet();
+    private Set<LNode> alreadyPlacedInOtherLayers = new HashSet<>();
     /**
      * List of layerless nodes to be used in one layering approach, will be sorted after
      * initialization.
@@ -158,7 +157,7 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
         // add first layer to the graph
         currentGraph.getLayers().add(currentLayer);
         // Copy the sorted layerless nodes so we don't overwrite it in the reset case
-        tempLayerlessNodes = Lists.newArrayList(sortedLayerlessNodes);
+        tempLayerlessNodes = new ArrayList<>(sortedLayerlessNodes);
         // Copy the outDegree Array
         remainingOutGoing = Arrays.copyOf(outDegree, outDegree.length);
 
@@ -198,7 +197,7 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
                     // increase maxWidth
                     maxWidth++;
                     // reset layerless nodes
-                    tempLayerlessNodes = Lists.newArrayList(sortedLayerlessNodes);
+                    tempLayerlessNodes = new ArrayList<>(sortedLayerlessNodes);
                     // reset successors
                     remainingOutGoing = Arrays.copyOf(outDegree, outDegree.length);
 
@@ -261,7 +260,7 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
      */
     private void computeSortedNodes() {
         List<LNode> unsortedNodes = currentGraph.getLayerlessNodes();
-        sortedLayerlessNodes = Lists.newArrayList(unsortedNodes);
+        sortedLayerlessNodes = new ArrayList<>(unsortedNodes);
         // the id-field is reused later on, be careful
         for (LNode node : unsortedNodes) {
             node.id = getRank(node);
@@ -290,14 +289,14 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
      * @return rank of the node
      */
     private Integer getRank(final LNode node) {
-        int max = Iterables.size(node.getOutgoingEdges());
+        int max = ((int) java.util.stream.StreamSupport.stream(node.getOutgoingEdges().spliterator(), false).count());
         int temp;
         LNode pre;
 
         // compute max of predecessors out-degree and out-degree of the current node
         for (LEdge preEdge : node.getIncomingEdges()) {
             pre = preEdge.getSource().getNode();
-            temp = Iterables.size(pre.getOutgoingEdges());
+            temp = ((int) java.util.stream.StreamSupport.stream(pre.getOutgoingEdges().spliterator(), false).count());
             max = Math.max(max, temp);
         }
 
@@ -310,8 +309,8 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
      */
     private void computeSuccessors() {
         int i = 0;
-        successors = Lists.newArrayList();
-        Set<LNode> currSucc = Sets.newHashSet();
+        successors = new ArrayList<>();
+        Set<LNode> currSucc = new HashSet<>();
 
         for (LNode node : sortedLayerlessNodes) {
             node.id = i;
@@ -320,7 +319,7 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
             }
             // remove current node from accSucc to deal with self-loops
             currSucc.remove(node);
-            successors.add(Sets.newHashSet(currSucc));
+            successors.add(new HashSet<>(currSucc));
             currSucc.clear();
             i++;
         }
@@ -335,8 +334,8 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
         outDegree = new int[sortedLayerlessNodes.size()];
 
         for (LNode node : sortedLayerlessNodes) {
-            inDegree[node.id] = Iterables.size(node.getIncomingEdges());
-            outDegree[node.id] = Iterables.size(node.getOutgoingEdges());
+            inDegree[node.id] = ((int) java.util.stream.StreamSupport.stream(node.getIncomingEdges().spliterator(), false).count());
+            outDegree[node.id] = ((int) java.util.stream.StreamSupport.stream(node.getOutgoingEdges().spliterator(), false).count());
         }
     }
 
@@ -394,7 +393,7 @@ public class StretchWidthLayerer implements ILayoutPhase<LayeredPhases, LGraph> 
     private float getAverageOutDegree() {
         float allOut = 0;
         for (LNode node : currentGraph.getLayerlessNodes()) {
-            allOut += Iterables.size(node.getOutgoingEdges());
+            allOut += ((int) java.util.stream.StreamSupport.stream(node.getOutgoingEdges().spliterator(), false).count());
         }
         return allOut / currentGraph.getLayerlessNodes().size();
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/AbstractBarycenterPortDistributor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/AbstractBarycenterPortDistributor.java
@@ -11,6 +11,7 @@ package org.eclipse.elk.alg.layered.p3order;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -21,7 +22,6 @@ import org.eclipse.elk.alg.layered.p3order.counting.IInitializable;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Lists;
 
 /**
  * Calculates port ranks and distributes ports.
@@ -57,7 +57,7 @@ public abstract class AbstractBarycenterPortDistributor implements ISweepPortDis
      *            the number of layers in the graph.
      */
     public AbstractBarycenterPortDistributor(final int numLayers) {
-        inLayerPorts = Lists.newArrayList();
+        inLayerPorts = new ArrayList<>();
         nodePositions = new int[numLayers][];
     }
 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/BarycenterHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/BarycenterHeuristic.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Random;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
@@ -22,7 +23,6 @@ import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.alg.layered.options.PortType;
 
-import com.google.common.collect.Lists;
 
 /**
  * Determines the node order of a given free layer. Uses heuristic methods to find an ordering that
@@ -338,7 +338,7 @@ public class BarycenterHeuristic implements ICrossingMinimizationHeuristic {
         LNode firstNodeInLayer = order[freeLayerIndex][0];
         boolean preOrdered = !isFirstSweep || isExternalPortDummy(firstNodeInLayer);
 
-        List<LNode> nodes = Lists.newArrayList(order[freeLayerIndex]);
+        List<LNode> nodes = new ArrayList<>(java.util.Arrays.asList(order[freeLayerIndex]));
         minimizeCrossings(nodes, preOrdered, false, forwardSweep);
         // apply the new ordering
         int index = 0;
@@ -354,8 +354,8 @@ public class BarycenterHeuristic implements ICrossingMinimizationHeuristic {
         // if sweeping forward, startIndex = 0, else the last existing element of order
         int startIndex = startIndex(isForwardSweep, order.length);
         // extract first layer into List<LNode>
-        List<LNode> nodes = Lists.newArrayList(
-                order[startIndex]);
+        List<LNode> nodes = new ArrayList<>(
+                java.util.Arrays.asList(order[startIndex]));
         // randomize nodes' barycenters
         minimizeCrossings(nodes, false, true, isForwardSweep);
         // fill first layer with nodes

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/ForsterConstraintResolver.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/ForsterConstraintResolver.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.p3order;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
@@ -20,9 +21,11 @@ import org.eclipse.elk.alg.layered.p3order.BarycenterHeuristic.BarycenterState;
 import org.eclipse.elk.alg.layered.p3order.counting.IInitializable;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Detects and resolves violated constraints. Inspired by
@@ -42,7 +45,7 @@ public class ForsterConstraintResolver implements IInitializable {
     /** Whether there are successor constraints between non-dummies. */
     private boolean constraintsBetweenNonDummies = false;
     /** the layout units for handling dummy nodes for north / south ports. */
-    private Multimap<LNode, LNode> layoutUnits;
+    private Map<LNode, Set<LNode>> layoutUnits;
     /** the barycenter values of every node in the graph, indexed by layer.id and node.id. */
     private BarycenterState[][] barycenterStates;
     /** the constraint groups, indexed by layer.id and node.id. */
@@ -64,7 +67,7 @@ public class ForsterConstraintResolver implements IInitializable {
         }
         barycenterStates = new BarycenterState[currentNodeOrder.length][];
         constraintGroups = new ConstraintGroup[currentNodeOrder.length][];
-        layoutUnits = LinkedHashMultimap.create();
+        layoutUnits = new LinkedHashMap<>();
     }
 
     @Override
@@ -99,7 +102,7 @@ public class ForsterConstraintResolver implements IInitializable {
             
             LNode layoutUnit = node.getProperty(InternalProperties.IN_LAYER_LAYOUT_UNIT);
             if (layoutUnit != null) {
-                layoutUnits.put(layoutUnit, node);
+                layoutUnits.computeIfAbsent(layoutUnit, k -> new LinkedHashSet<>()).add(node);
             }
         }
     }
@@ -202,8 +205,8 @@ public class ForsterConstraintResolver implements IInitializable {
                 // constraints from all of that other node's layout unit's vertices to this
                 // node's layout unit's vertices
                 if (lastNonDummyNode != null) {
-                    for (LNode lastUnitNode : layoutUnits.get(lastNonDummyNode)) {
-                        for (LNode currentUnitNode : layoutUnits.get(node)) {
+                    for (LNode lastUnitNode : layoutUnits.getOrDefault(lastNonDummyNode, Collections.emptySet())) {
+                        for (LNode currentUnitNode : layoutUnits.getOrDefault(node, Collections.emptySet())) {
                             groupOf(lastUnitNode).getOutgoingConstraints().add(groupOf(currentUnitNode));
                             groupOf(currentUnitNode).incomingConstraintsCount++;
                         }
@@ -238,7 +241,7 @@ public class ForsterConstraintResolver implements IInitializable {
             // Find sources of the constraint graph to start the constraints check
             if (group.hasOutgoingConstraints() && group.incomingConstraintsCount == 0) {
                 if (activeGroups == null) {
-                    activeGroups = Lists.newArrayList();
+                    activeGroups = new ArrayList<>();
                 }
                 activeGroups.add(group);
             }
@@ -415,7 +418,7 @@ public class ForsterConstraintResolver implements IInitializable {
             // Add constraints, taking care not to add any constraints to vertex1 or vertex2
             // and to decrement the incoming constraints count of those that are successors to both
             if (nodeGroup1.outgoingConstraints != null) {
-                this.outgoingConstraints = Lists.newLinkedList(nodeGroup1.outgoingConstraints);
+                this.outgoingConstraints = new LinkedList<>(nodeGroup1.outgoingConstraints);
                 this.outgoingConstraints.remove(nodeGroup2);
                 if (nodeGroup2.outgoingConstraints != null) {
                     for (ConstraintGroup candidate : nodeGroup2.outgoingConstraints) {
@@ -430,7 +433,7 @@ public class ForsterConstraintResolver implements IInitializable {
                     }
                 }
             } else if (nodeGroup2.outgoingConstraints != null) {
-                this.outgoingConstraints = Lists.newLinkedList(nodeGroup2.outgoingConstraints);
+                this.outgoingConstraints = new LinkedList<>(nodeGroup2.outgoingConstraints);
                 this.outgoingConstraints.remove(nodeGroup1);
             }
 
@@ -475,7 +478,7 @@ public class ForsterConstraintResolver implements IInitializable {
          */
         public List<ConstraintGroup> getOutgoingConstraints() {
             if (outgoingConstraints == null) {
-                outgoingConstraints = Lists.newArrayList();
+                outgoingConstraints = new ArrayList<>();
             }
             return outgoingConstraints;
         }
@@ -503,7 +506,7 @@ public class ForsterConstraintResolver implements IInitializable {
          */
         public List<ConstraintGroup> getIncomingConstraints() {
             if (incomingConstraints == null) {
-                incomingConstraints = Lists.newArrayList();
+                incomingConstraints = new ArrayList<>();
             }
             return incomingConstraints;
         }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GraphInfoHolder.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GraphInfoHolder.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -25,7 +26,6 @@ import org.eclipse.elk.alg.layered.p3order.LayerSweepCrossingMinimizer.CrossMinT
 import org.eclipse.elk.alg.layered.p3order.counting.AllCrossingsCounter;
 import org.eclipse.elk.alg.layered.p3order.counting.IInitializable;
 
-import com.google.common.collect.Lists;
 
 /**
  * Collects data needed for cross minimization and port distribution.
@@ -82,15 +82,15 @@ public class GraphInfoHolder implements IInitializable {
         parentGraphData = hasParent ? graphs.get(parent.getGraph().id) : null;
         Set<GraphProperties> graphProperties = graph.getProperty(InternalProperties.GRAPH_PROPERTIES);
         hasExternalPorts = graphProperties.contains(GraphProperties.EXTERNAL_PORTS);
-        childGraphs = Lists.newArrayList();
+        childGraphs = new ArrayList<>();
 
         // Init all objects needing initialization by graph traversal.
         crossingsCounter = new AllCrossingsCounter(currentNodeOrder);
         Random random = lGraph.getProperty(InternalProperties.RANDOM);
         portDistributor = ISweepPortDistributor.create(crossMinType, random, currentNodeOrder);
         layerSweepTypeDecider = new LayerSweepTypeDecider(this);
-        List<IInitializable> initializables =
-                Lists.newArrayList(this, crossingsCounter, layerSweepTypeDecider, portDistributor);
+        List<IInitializable> initializables = new ArrayList<>(java.util.Arrays.asList(
+                this, crossingsCounter, layerSweepTypeDecider, portDistributor));
 
         if (crossMinType == CrossMinType.BARYCENTER
                 && !graph.getProperty(LayeredOptions.CROSSING_MINIMIZATION_FORCE_NODE_MODEL_ORDER)) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GreedyPortDistributor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/GreedyPortDistributor.java
@@ -21,8 +21,8 @@ import org.eclipse.elk.alg.layered.p3order.counting.IInitializable;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * Distribute ports greedily on a single node.
@@ -72,7 +72,7 @@ public class GreedyPortDistributor implements ISweepPortDistributor, IInitializa
 
         List<LPort> ports = node.getPortSideView(side);
         if (side == PortSide.SOUTH || side == PortSide.WEST) {
-            ports = Lists.reverse(ports);
+            ports = LGraphUtil.reversed(ports);
         }
         boolean improved = false;
         boolean continueSwitching;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -16,6 +16,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.layered.IHierarchyAwareLayoutProcessor;
 import org.eclipse.elk.alg.layered.LayeredPhases;
@@ -40,8 +43,6 @@ import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * This class minimizes crossings by sweeping through a graph, holding the order of nodes in one layer fixed and
@@ -602,11 +603,11 @@ public class LayerSweepCrossingMinimizer
      * Traverses inclusion breadth-first and initializes each Graph.
      */
     private List<GraphInfoHolder> initialize(final LGraph rootGraph) {
-        graphInfoHolders = Lists.newArrayList();
+        graphInfoHolders = new ArrayList<>();
         random = rootGraph.getProperty(InternalProperties.RANDOM);
         randomSeed = random.nextLong();
-        List<GraphInfoHolder> graphsToSweepOn = Lists.newLinkedList();
-        List<LGraph> graphs = Lists.<LGraph>newArrayList(rootGraph);
+        List<GraphInfoHolder> graphsToSweepOn = new LinkedList<>();
+        List<LGraph> graphs = new ArrayList<>(java.util.Arrays.asList(rootGraph));
         int i = 0;
         while (i < graphs.size()) {
             LGraph graph = graphs.get(i);
@@ -619,7 +620,7 @@ public class LayerSweepCrossingMinimizer
             }
         }
     
-        graphsWhoseNodeOrderChanged = Sets.newHashSet();
+        graphsWhoseNodeOrderChanged = new HashSet<>();
     
         return graphsToSweepOn;
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepTypeDecider.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepTypeDecider.java
@@ -21,7 +21,7 @@ import org.eclipse.elk.alg.layered.p3order.counting.IInitializable;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Iterables;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
 /**
  * In order to decide whether to sweep into the graph or not, we compare the number of paths to nodes whose position is
@@ -104,7 +104,7 @@ public class LayerSweepTypeDecider implements IInitializable {
                 // Do the same for north/south dummies: Increase counts of paths by the number outgoing edges times the
                 // influence and transfer information to dummies.
                 Iterable<LPort> northSouthPorts =
-                        Iterables.concat(node.getPortSideView(PortSide.NORTH), node.getPortSideView(PortSide.SOUTH));
+                        LGraphUtil.concat(node.getPortSideView(PortSide.NORTH), node.getPortSideView(PortSide.SOUTH));
                 for (LPort port : northSouthPorts) {
                     LNode nsDummy = port.getProperty(InternalProperties.PORT_DUMMY);
                     if (nsDummy != null) {
@@ -188,12 +188,12 @@ public class LayerSweepTypeDecider implements IInitializable {
 
     private boolean hasNoEasternPorts(final LNode node) {
         List<LPort> eastPorts = node.getPortSideView(PortSide.EAST);
-        return eastPorts.isEmpty() || !Iterables.any(eastPorts, p -> p.getConnectedEdges().iterator().hasNext());
+        return eastPorts.isEmpty() || !java.util.stream.StreamSupport.stream(eastPorts.spliterator(), false).anyMatch(p -> p.getConnectedEdges().iterator().hasNext());
     }
 
     private boolean hasNoWesternPorts(final LNode node) {
         List<LPort> westPorts = node.getPortSideView(PortSide.WEST);
-        return westPorts.isEmpty() || !Iterables.any(westPorts, p -> p.getConnectedEdges().iterator().hasNext());
+        return westPorts.isEmpty() || !java.util.stream.StreamSupport.stream(westPorts.spliterator(), false).anyMatch(p -> p.getConnectedEdges().iterator().hasNext());
     }
 
     private boolean isExternalPortDummy(final LNode node) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/MedianHeuristic.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/MedianHeuristic.java
@@ -18,7 +18,6 @@ import java.util.Random;
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.options.InternalProperties;
-import com.google.common.collect.Lists;
 
 /**
  * A Heuristic for minimizing crossings using weights and propagated medians. After assigning random weights to the
@@ -57,7 +56,7 @@ public class MedianHeuristic implements ICrossingMinimizationHeuristic {
         // determine first index (
         int firstIndex = forwardSweep ? 0 : Math.max(0, order.length - 1);
         // extract firstLayer from 2D-array
-        List<LNode> firstLayer = Lists.newArrayList(order[firstIndex]);
+        List<LNode> firstLayer = new ArrayList<>(java.util.Arrays.asList(order[firstIndex]));
         // set random weights for nodes in firstLayer
         for (LNode node : firstLayer) {
             node.setProperty(InternalProperties.WEIGHT, random.nextDouble());
@@ -86,7 +85,7 @@ public class MedianHeuristic implements ICrossingMinimizationHeuristic {
      */
     @Override
     public boolean minimizeCrossings(LNode[][] order, int freeLayerIndex, boolean forwardSweep, boolean isFirstSweep) {
-        List<LNode> freeLayer = Lists.newArrayList(order[freeLayerIndex]);
+        List<LNode> freeLayer = new ArrayList<>(java.util.Arrays.asList(order[freeLayerIndex]));
         // calculate Medians for the free Layer (does not sort the free layer)
         calculateMedians(freeLayer, forwardSweep ? freeLayerIndex - 1 : freeLayerIndex + 1);
         // sort the free Layer

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/SweepCopy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/SweepCopy.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.HashSet;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -26,8 +27,6 @@ import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Stores node and port order for a sweep.
@@ -90,8 +89,8 @@ class SweepCopy {
         // the {@link LayeredOptions.ALLOW_NON_FLOW_PORTS_TO_SWITCH_SIDES} option allows the crossing minimizer 
         // to decide the side a corresponding dummy node is placed on in order to reduce the number of crossings
         // as a consequence the configured port side may not be valid anymore and has to be corrected
-        List<LNode> northSouthPortDummies = Lists.newArrayList();
-        Set<LNode> updatePortOrder = Sets.newHashSet();
+        List<LNode> northSouthPortDummies = new ArrayList<>();
+        Set<LNode> updatePortOrder = new HashSet<>();
         
         // iterate the layers
         List<Layer> layers = lGraph.getLayers();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/CrossMinUtil.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/CrossMinUtil.java
@@ -14,8 +14,8 @@ import java.util.Collections;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.core.options.PortSide;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * Utility class for iterating over ports in any direction.
@@ -43,7 +43,7 @@ public final class CrossMinUtil {
             return node.getPortSideView(side);
         case SOUTH:
         case WEST:
-            return Lists.reverse(node.getPortSideView(side));
+            return LGraphUtil.reversed(node.getPortSideView(side));
         }
         return Collections.emptyList();
     }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/CrossingsCounter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/CrossingsCounter.java
@@ -26,8 +26,7 @@ import org.eclipse.elk.alg.layered.options.InternalProperties;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
 /**
  * In ELK Layered we distinguish three types of edge crossings that can occur:
@@ -342,7 +341,7 @@ public final class CrossingsCounter {
                 }
             }
         }
-        return Lists.newArrayList(ports);
+        return new ArrayList<>(ports);
     }
 
     private List<LPort> connectedPortsSortedByPosition(final LPort upperPort, final LPort lowerPort) {
@@ -355,7 +354,7 @@ public final class CrossingsCounter {
                 }
             }
         }
-        return Lists.newArrayList(ports);
+        return new ArrayList<>(ports);
     }
 
     private int countCrossingsOnPorts(final Iterable<LPort> ports) {
@@ -407,7 +406,7 @@ public final class CrossingsCounter {
    
     private int countNorthSouthCrossingsOnPorts(final Iterable<LPort> ports) {
         int crossings = 0;
-        final List<Pair<LPort, Integer>> targetsAndDegrees = Lists.newArrayList();
+        final List<Pair<LPort, Integer>> targetsAndDegrees = new ArrayList<>();
         
         for (LPort port : ports) {
             indexTree.removeAll(positionOf(port));
@@ -483,7 +482,7 @@ public final class CrossingsCounter {
     private static final PortSide STACK_SIDE = PortSide.EAST;
     
     private List<LPort> initPositionsForNorthSouthCounting(final LNode[] nodes) {
-        final List<LPort> ports = Lists.newArrayList();
+        final List<LPort> ports = new ArrayList<>();
         final Deque<LNode> stack = new ArrayDeque<>();
         
         LNode lastLayoutUnit = null;
@@ -574,17 +573,17 @@ public final class CrossingsCounter {
             if (topDown) {
                 return node.getPortSideView(side);
             } else {
-                return Lists.reverse(node.getPortSideView(side));
+                return LGraphUtil.reversed(node.getPortSideView(side));
             }
         } else if (topDown) {
-            return Lists.reverse(node.getPortSideView(side));
+            return LGraphUtil.reversed(node.getPortSideView(side));
         } else {
             return node.getPortSideView(side);
         }
     }
 
     private Iterable<LPort> getNorthSouthPortsWithIncidentEdges(final LNode node, final PortSide side) {
-        return Iterables.filter(node.getPortSideView(side), p -> p.hasProperty(InternalProperties.PORT_DUMMY));
+        return LGraphUtil.filter(node.getPortSideView(side), p -> p.hasProperty(InternalProperties.PORT_DUMMY));
     }
     
     private int start(final LNode[] nodes, final boolean topDown) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/HyperedgeCrossingsCounter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/counting/HyperedgeCrossingsCounter.java
@@ -14,6 +14,9 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -21,9 +24,6 @@ import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.graph.Layer;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * Crossings counter implementation specialized for hyperedges. It also works for normal edges,
@@ -66,8 +66,8 @@ public class HyperedgeCrossingsCounter {
      * Hyperedge representation.
      */
     private static class Hyperedge implements Comparable<Hyperedge> {
-        private List<LEdge> edges = Lists.newArrayList();
-        private List<LPort> ports = Lists.newArrayList();
+        private List<LEdge> edges = new ArrayList<>();
+        private List<LPort> ports = new ArrayList<>();
         private int upperLeft;
         private int lowerLeft;
         private int upperRight;
@@ -208,8 +208,8 @@ public class HyperedgeCrossingsCounter {
         }
         
         // Gather hyperedges
-        Map<LPort, Hyperedge> port2HyperedgeMap = Maps.newHashMap();
-        Set<Hyperedge> hyperedgeSet = Sets.newLinkedHashSet();
+        Map<LPort, Hyperedge> port2HyperedgeMap = new HashMap<>();
+        Set<Hyperedge> hyperedgeSet = new LinkedHashSet<>();
         for (LNode node : leftLayer) {
             for (LPort sourcePort : node.getPorts()) {
                 for (LEdge edge : sourcePort.getOutgoingEdges()) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/LinearSegmentsNodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/LinearSegmentsNodePlacer.java
@@ -32,7 +32,6 @@ import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.graph.properties.Property;
 
-import com.google.common.collect.Lists;
 
 /**
  * Node placement implementation that aligns long edges using linear segments. Inspired by Section 4 of
@@ -62,7 +61,7 @@ public final class LinearSegmentsNodePlacer implements ILayoutPhase<LayeredPhase
      */
     public static class LinearSegment implements Comparable<LinearSegment> {
         /** Nodes of the linear segment. */
-        private List<LNode> nodes = Lists.newArrayList();
+        private List<LNode> nodes = new ArrayList<>();
         /** Identifier value, used as index in the segments array. */
         private int id;
         /** Index in the previous layer. Used for cycle avoidance. */
@@ -215,7 +214,7 @@ public final class LinearSegmentsNodePlacer implements ILayoutPhase<LayeredPhase
      */
     private LinearSegment[] sortLinearSegments(final LGraph layeredGraph, final IElkProgressMonitor monitor) {
         // set the identifier and input / output priority for all nodes
-        List<LinearSegment> segmentList = Lists.newArrayList();
+        List<LinearSegment> segmentList = new ArrayList<>();
         for (Layer layer : layeredGraph) {
             for (LNode node : layer) {
                 node.id = -1;
@@ -251,8 +250,8 @@ public final class LinearSegmentsNodePlacer implements ILayoutPhase<LayeredPhase
         }
 
         // create and initialize segment ordering graph
-        List<List<LinearSegment>> outgoingList = Lists.newArrayListWithCapacity(segmentList.size());
-        List<Integer> incomingCountList = Lists.newArrayListWithCapacity(segmentList.size());
+        List<List<LinearSegment>> outgoingList = new ArrayList<>(segmentList.size());
+        List<Integer> incomingCountList = new ArrayList<>(segmentList.size());
         for (int i = 0; i < segmentList.size(); i++) {
             outgoingList.add(new ArrayList<LinearSegment>());
             incomingCountList.add(0);
@@ -274,7 +273,7 @@ public final class LinearSegmentsNodePlacer implements ILayoutPhase<LayeredPhase
 
         // gather the sources of the segment ordering graph
         int nextRank = 0;
-        List<LinearSegment> noIncoming = Lists.newArrayList();
+        List<LinearSegment> noIncoming = new ArrayList<>();
         for (int i = 0; i < segments.length; i++) {
             if (incomingCount[i] == 0) {
                 noIncoming.add(segments[i]);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/NetworkSimplexPlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/NetworkSimplexPlacer.java
@@ -22,6 +22,9 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.common.networksimplex.NEdge;
 import org.eclipse.elk.alg.common.networksimplex.NGraph;
@@ -51,12 +54,9 @@ import org.eclipse.elk.core.options.NodeLabelPlacement;
 import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
+import org.eclipse.elk.alg.layered.compaction.oned.CompareFuzzy;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.math.DoubleMath;
 /**
  * Implements the node placement strategy as described by Gansner et al. in the following paper. It
  * is based on the idea to convert the problem into an auxiliary graph which is layered using the
@@ -167,7 +167,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
     /** Mapping of the internal representations of edges, indexed by {@link LEdge#id}. */
     private EdgeRep[] edgeReps;
     /** Mapping of network simplex nodes to the graph elements they represent. */
-    private Map<LGraphElement, NNode> portMap = Maps.newHashMap();
+    private Map<LGraphElement, NNode> portMap = new HashMap<>();
     
     /** Node count of {@link #lGraph}. The field is uninitialized until {@link #buildInitialAuxiliaryGraph()} 
      *  has been executed. */
@@ -182,7 +182,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
     private boolean[] crossing;
 
     // used for a special version of node flexibility
-    private Set<NEdge> flexibleWhereSpacePermitsEdges = Sets.newHashSet();
+    private Set<NEdge> flexibleWhereSpacePermitsEdges = new HashSet<>();
     
     // - - - - - - edge weights used in the auxiliary network simplex graph - - - - - -  
     /** Basis for the weight of edges. */
@@ -488,7 +488,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
         // -----------------------------------
         // convert the ports to NNodes, note that the list of westward ports 
         // must be reversed since their original order is from bottom to top
-        transformPorts(Lists.reverse(lNode.getPortSideView(PortSide.WEST)), corners);
+        transformPorts(LGraphUtil.reversed(lNode.getPortSideView(PortSide.WEST)), corners);
         transformPorts(lNode.getPortSideView(PortSide.EAST), corners);
 
         // return the corners for further processing
@@ -497,7 +497,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
     
     private void transformPorts(final Iterable<LPort> ports, final NodeRep corners) {
         
-        if (Iterables.isEmpty(ports)) {
+        if (!ports.iterator().hasNext()) {
             // nothing to do ...
             // the top and bottom border of the node are already safely spaced apart
             return;
@@ -584,7 +584,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
         if (!tgtRep.isFlexible) {
             tgtOffset += tgtPort.getPosition().y;
         } 
-        assert DoubleMath.fuzzyEquals(srcOffset - tgtOffset, Math.round(srcOffset - tgtOffset),
+        assert CompareFuzzy.fuzzyEquals(srcOffset - tgtOffset, Math.round(srcOffset - tgtOffset),
                 EPSILON) : "Port positions must be integral";
         
         int tgtDelta = (int) Math.max(0, srcOffset - tgtOffset);
@@ -1013,7 +1013,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
 
         // the nodes were counted and indexed during #prepare
         nodeState = new int[nodeCount];
-        twoPaths = Lists.newArrayList();
+        twoPaths = new ArrayList<>();
         
         // record node states
         lGraph.getLayers().stream()
@@ -1077,7 +1077,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
      * Iteratively post processes 'two paths' until no further bends can be removed. 
      */
     private void postProcessTwoPaths() {
-        Queue<Path> q = Lists.newLinkedList();
+        Queue<Path> q = new LinkedList<>();
         q.addAll(twoPaths);
         
         Stack<Path> s = new Stack<>();
@@ -1150,7 +1150,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
         }
         
         // same space on both sides, check again later 
-        if (probe && DoubleMath.fuzzyEquals(aboveDist, belowDist, EPSILON)) {
+        if (probe && CompareFuzzy.fuzzyEquals(aboveDist, belowDist, EPSILON)) {
             return true; 
         }
         
@@ -1222,7 +1222,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
     // ------------------------------------------------------------------------------------------------
     
     private List<Path> identifyPaths() {
-        final List<Path> paths = Lists.newArrayList();
+        final List<Path> paths = new ArrayList<>();
         lGraph.getLayers().stream()
             .flatMap(l -> l.getNodes().stream()) 
             .filter(n -> nodeState[n.id] == JUNCTION)
@@ -1307,7 +1307,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
      */
     private void markCrossingEdges(final Layer left, final Layer right) {
         
-        final List<LEdge> openEdges = Lists.newArrayList();
+        final List<LEdge> openEdges = new ArrayList<>();
 
         // add all edges in the order they occur in the left layer
         for (LNode node : left) {
@@ -1323,7 +1323,7 @@ public class NetworkSimplexPlacer implements ILayoutPhase<LayeredPhases, LGraph>
         }
         
         // close the edges one after another, recording edge crossings
-        for (LNode node : Lists.reverse(right.getNodes())) {
+        for (LNode node : LGraphUtil.reversed(right.getNodes())) {
             for (LPort port : node.getPortSideView(PortSide.WEST)) { // don't reverse, bottom up is correct
                 for (LEdge edge : port.getIncomingEdges()) {
                     if (edge.isInLayerEdge() || edge.isSelfLoop() 

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKAligner.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKAligner.java
@@ -24,8 +24,8 @@ import org.eclipse.elk.alg.layered.graph.LNode.NodeType;
 import org.eclipse.elk.alg.layered.p4nodes.bk.BKAlignedLayout.HDirection;
 import org.eclipse.elk.alg.layered.p4nodes.bk.BKAlignedLayout.VDirection;
 import org.eclipse.elk.core.util.Pair;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
 
 /**
  * For documentation see {@link BKNodePlacer}.
@@ -77,7 +77,7 @@ public class BKAligner {
         // If the horizontal direction is LEFT, the layers are traversed from
         // right to left, thus a reverse iterator is needed
         if (bal.hdir == HDirection.LEFT) {
-            layers = Lists.reverse(layers);
+            layers = LGraphUtil.reversed(layers);
         }
 
         for (Layer layer : layers) {
@@ -90,7 +90,7 @@ public class BKAligner {
                 // If the alignment direction is UP, the nodes in a layer are traversed
                 // reversely, thus we start at INT_MAX and with the reversed list of nodes.
                 r = Integer.MAX_VALUE;
-                nodes = Lists.reverse(nodes);
+                nodes = LGraphUtil.reversed(nodes);
             }
             
             // Variable names here are again taken from the paper mentioned above.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKCompactor.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKCompactor.java
@@ -13,6 +13,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.layered.graph.LGraph;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -25,9 +28,8 @@ import org.eclipse.elk.alg.layered.p4nodes.bk.BKAlignedLayout.VDirection;
 import org.eclipse.elk.alg.layered.p4nodes.bk.ThresholdStrategy.NullThresholdStrategy;
 import org.eclipse.elk.alg.layered.p4nodes.bk.ThresholdStrategy.SimpleThresholdStrategy;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.layered.graph.LGraphUtil;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * For documentation see {@link BKNodePlacer}.
@@ -47,7 +49,7 @@ public class BKCompactor implements ICompactor {
     /** Spacings. */
     private Spacings spacings;
     /** Representation of the class graph. */
-    private Map<LNode, ClassNode> sinkNodes = Maps.newHashMap();
+    private Map<LNode, ClassNode> sinkNodes = new HashMap<>();
     
     /**
      * @param layeredGraph the graph to handle.
@@ -96,7 +98,7 @@ public class BKCompactor implements ICompactor {
         // a reverse iterator is needed (note that this does not change the original list of layers)
         List<Layer> layers = layeredGraph.getLayers();
         if (bal.hdir == HDirection.LEFT) {
-            layers = Lists.reverse(layers);
+            layers = LGraphUtil.reversed(layers);
         }
 
         // init threshold strategy
@@ -108,7 +110,7 @@ public class BKCompactor implements ICompactor {
             // As with layers, we need a reversed iterator for blocks for different directions
             List<LNode> nodes = layer.getNodes();
             if (bal.vdir == VDirection.UP) {
-                nodes = Lists.reverse(nodes);
+                nodes = LGraphUtil.reversed(nodes);
             }
             
             // Do an initial placement for all blocks
@@ -332,7 +334,7 @@ public class BKCompactor implements ICompactor {
     private void placeClasses(final BKAlignedLayout bal) {
         
         // collect sinks of the class graph
-        Queue<ClassNode> sinks = Lists.newLinkedList();
+        Queue<ClassNode> sinks = new LinkedList<>();
         for (ClassNode n : sinkNodes.values()) {
             if (n.indegree == 0) {
                 sinks.add(n);
@@ -392,7 +394,7 @@ public class BKCompactor implements ICompactor {
         // SUPPRESS CHECKSTYLE NEXT 5 VisibilityModifier
         Double classShift = null;
         LNode node;
-        List<ClassEdge> outgoing = Lists.newArrayList();
+        List<ClassEdge> outgoing = new ArrayList<>();
         int indegree = 0;
         
         private void addEdge(final ClassNode target, final double separation) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKNodePlacer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/BKNodePlacer.java
@@ -14,6 +14,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -33,9 +37,6 @@ import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * This algorithm is an implementation for solving the node placement problem
@@ -132,7 +133,7 @@ public final class BKNodePlacer implements ILayoutPhase<LayeredPhases, LGraph> {
     
     private LGraph lGraph;
     /** List of edges involved in type 1 conflicts (see above). */
-    private final Set<LEdge> markedEdges = Sets.newHashSet();
+    private final Set<LEdge> markedEdges = new HashSet<>();
     /**  Precalculated information on nodes' neighborhoods etc. */
     private NeighborhoodInformation ni;
 
@@ -165,7 +166,7 @@ public final class BKNodePlacer implements ILayoutPhase<LayeredPhases, LGraph> {
         // Initialize four layouts which result from the two possible directions respectively.
         BKAlignedLayout rightdown = null, rightup = null, leftdown = null, leftup = null;
         // SUPPRESS CHECKSTYLE NEXT MagicNumber
-        List<BKAlignedLayout> layouts = Lists.newArrayListWithCapacity(4);
+        List<BKAlignedLayout> layouts = new ArrayList<>(4);
         switch (layeredGraph.getProperty(LayeredOptions.NODE_PLACEMENT_BK_FIXED_ALIGNMENT)) {
             case LEFTDOWN:
                 leftdown =
@@ -510,7 +511,7 @@ public final class BKNodePlacer implements ILayoutPhase<LayeredPhases, LGraph> {
      * @return The blocks of the given layout
      */
     static Map<LNode, List<LNode>> getBlocks(final BKAlignedLayout bal) {
-        Map<LNode, List<LNode>> blocks = Maps.newLinkedHashMap();
+        Map<LNode, List<LNode>> blocks = new LinkedHashMap<>();
         
         for (Layer layer : bal.layeredGraph.getLayers()) {
             for (LNode node : layer.getNodes()) {
@@ -518,7 +519,7 @@ public final class BKNodePlacer implements ILayoutPhase<LayeredPhases, LGraph> {
                 List<LNode> blockContents = blocks.get(root);
                 
                 if (blockContents == null) {
-                    blockContents = Lists.newArrayList();
+                    blockContents = new ArrayList<>();
                     blocks.put(root, blockContents);
                 }
                 
@@ -537,10 +538,10 @@ public final class BKNodePlacer implements ILayoutPhase<LayeredPhases, LGraph> {
      * @return The classes of the given layout
      */
     static Map<LNode, List<LNode>> getClasses(final BKAlignedLayout bal, final IElkProgressMonitor monitor) {
-        Map<LNode, List<LNode>> classes = Maps.newLinkedHashMap();
+        Map<LNode, List<LNode>> classes = new LinkedHashMap<>();
         
         // We need to enumerate all block roots
-        Set<LNode> roots = Sets.newLinkedHashSet(Arrays.asList(bal.root));
+        Set<LNode> roots = new LinkedHashSet<>(Arrays.asList(bal.root));
         for (LNode root : roots) {
             if (root == null) {
                 monitor.log("There are no classes in a balanced layout.");
@@ -550,7 +551,7 @@ public final class BKNodePlacer implements ILayoutPhase<LayeredPhases, LGraph> {
             List<LNode> classContents = classes.get(sink);
             
             if (classContents == null) {
-                classContents = Lists.newArrayList();
+                classContents = new ArrayList<>();
                 classes.put(sink, classContents);
             }
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/NeighborhoodInformation.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/NeighborhoodInformation.java
@@ -12,6 +12,7 @@ package org.eclipse.elk.alg.layered.p4nodes.bk;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -20,7 +21,6 @@ import org.eclipse.elk.alg.layered.graph.Layer;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Lists;
 
 /**
  * Class holds neighborhood information for a layered graph that is used during bk node placing.
@@ -110,9 +110,9 @@ public final class NeighborhoodInformation {
         ni.neighborComparator = ni.new NeighborComparator();
         
         // determine all left and right neighbors of the graph's nodes
-        ni.leftNeighbors = Lists.newArrayListWithCapacity(ni.nodeCount);
+        ni.leftNeighbors = new ArrayList<>(ni.nodeCount);
         determineAllLeftNeighbors(ni, graph);
-        ni.rightNeighbors = Lists.newArrayListWithCapacity(ni.nodeCount);
+        ni.rightNeighbors = new ArrayList<>(ni.nodeCount);
         determineAllRightNeighbors(ni, graph);
         
         return ni;
@@ -127,7 +127,7 @@ public final class NeighborhoodInformation {
         for (Layer l : graph) {
             for (LNode n : l) {
 
-                List<Pair<LNode, LEdge>> result = Lists.newArrayList();
+                List<Pair<LNode, LEdge>> result = new ArrayList<>();
                 int maxPriority = 0;
                 
                 for (LEdge edge : n.getOutgoingEdges()) {
@@ -160,7 +160,7 @@ public final class NeighborhoodInformation {
         for (Layer l : graph) {
             for (LNode n : l) {
                 
-                List<Pair<LNode, LEdge>> result = Lists.newArrayList();
+                List<Pair<LNode, LEdge>> result = new ArrayList<>();
                 int maxPriority = 0;
                 
                 for (LEdge edge : n.getIncomingEdges()) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/ThresholdStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p4nodes/bk/ThresholdStrategy.java
@@ -12,16 +12,16 @@ package org.eclipse.elk.alg.layered.p4nodes.bk;
 import java.util.Queue;
 import java.util.Set;
 import java.util.Stack;
+import java.util.HashSet;
+import java.util.LinkedList;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.p4nodes.bk.BKAlignedLayout.HDirection;
 import org.eclipse.elk.alg.layered.p4nodes.bk.BKAlignedLayout.VDirection;
+import org.eclipse.elk.alg.layered.compaction.oned.CompareFuzzy;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.common.math.DoubleMath;
 
 /**
  * 
@@ -47,12 +47,12 @@ public abstract class ThresholdStrategy {
     /**
      * We keep track of which blocks have been completely finished.
      */
-    protected Set<LNode> blockFinished = Sets.newHashSet();
+    protected Set<LNode> blockFinished = new HashSet<>();
 
     /**
      * A queue with blocks that are postponed during compaction.
      */
-    protected Queue<Postprocessable> postProcessablesQueue = Lists.newLinkedList();
+    protected Queue<Postprocessable> postProcessablesQueue = new LinkedList<>();
     
     /** 
      * A stack that is used to treat postponed nodes in reversed order.
@@ -387,7 +387,7 @@ public abstract class ThresholdStrategy {
             if (delta > 0 && delta < THRESHOLD) {
                 // target y larger than source y --> shift upwards?
                 double availableSpace = bal.checkSpaceAbove(block.getNode(), delta, ni);
-                assert DoubleMath.fuzzyEquals(availableSpace, 0, EPSILON) || availableSpace >= 0;
+                assert CompareFuzzy.fuzzyEquals(availableSpace, 0, EPSILON) || availableSpace >= 0;
                 bal.shiftBlock(block.getNode(), -availableSpace);
                 return availableSpace > 0;
             } else if (delta < 0 && -delta < THRESHOLD) {
@@ -395,7 +395,7 @@ public abstract class ThresholdStrategy {
                 // direction is up, we possibly shifted some blocks too far upward 
                 // for an edge to be straight, so check if we can shift down again
                 double availableSpace = bal.checkSpaceBelow(block.getNode(), -delta, ni);
-                assert DoubleMath.fuzzyEquals(availableSpace, 0, EPSILON) || availableSpace >= 0;
+                assert CompareFuzzy.fuzzyEquals(availableSpace, 0, EPSILON) || availableSpace >= 0;
                 bal.shiftBlock(block.getNode(), availableSpace);
                 return availableSpace > 0;
             }

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/OrthogonalEdgeRouter.java
@@ -28,7 +28,6 @@ import org.eclipse.elk.core.alg.ILayoutPhase;
 import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Iterables;
 
 /**
  * Edge routing implementation that creates orthogonal bend points. Inspired by
@@ -252,10 +251,8 @@ public final class OrthogonalEdgeRouter implements ILayoutPhase<LayeredPhases, L
             slotsCount = routingGenerator.routeEdges(monitor, layeredGraph, leftLayerNodes, leftLayerIndex,
                     rightLayerNodes, startPos);
             
-            boolean isLeftLayerExternal = leftLayer == null || Iterables.all(leftLayerNodes,
-                    PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
-            boolean isRightLayerExternal = rightLayer == null || Iterables.all(rightLayerNodes,
-                    PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
+            boolean isLeftLayerExternal = leftLayer == null || java.util.stream.StreamSupport.stream(leftLayerNodes.spliterator(), false).allMatch(PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
+            boolean isRightLayerExternal = rightLayer == null || java.util.stream.StreamSupport.stream(rightLayerNodes.spliterator(), false).allMatch(PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
             
             if (slotsCount > 0) {
                 // Compute routing area's width

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/PolylineEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/PolylineEdgeRouter.java
@@ -31,9 +31,8 @@ import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
+import java.util.function.Predicate;
+import java.util.HashSet;
 
 /**
  * Edge router module that draws edges with non-orthogonal line segments.
@@ -57,12 +56,10 @@ public final class PolylineEdgeRouter implements ILayoutPhase<LayeredPhases, LGr
     /**
      * Predicate that checks whether nodes represent external ports.
      */
-    public static final Predicate<LNode> PRED_EXTERNAL_WEST_OR_EAST_PORT = new Predicate<LNode>() {
-        public boolean apply(final LNode node) {
-            PortSide extPortSide = node.getProperty(InternalProperties.EXT_PORT_SIDE);
-            return node.getType() == NodeType.EXTERNAL_PORT
-                    && (extPortSide == PortSide.WEST || extPortSide == PortSide.EAST);
-        }
+    public static final Predicate<LNode> PRED_EXTERNAL_WEST_OR_EAST_PORT = node -> {
+        PortSide extPortSide = node.getProperty(InternalProperties.EXT_PORT_SIDE);
+        return node.getType() == NodeType.EXTERNAL_PORT
+                && (extPortSide == PortSide.WEST || extPortSide == PortSide.EAST);
     };
     
     /* The basic processing strategy for this phase is empty. Depending on the graph features,
@@ -180,7 +177,7 @@ public final class PolylineEdgeRouter implements ILayoutPhase<LayeredPhases, LGr
     private static final double LAYER_SPACE_FAC = 0.4;
 
     /** Set of already created junction points, to avoid multiple points at the same position. */
-    private final Set<KVector> createdJunctionPoints = Sets.newHashSet();
+    private final Set<KVector> createdJunctionPoints = new HashSet<>();
     
     
     /* Implementation Note:
@@ -216,7 +213,7 @@ public final class PolylineEdgeRouter implements ILayoutPhase<LayeredPhases, LGr
         ListIterator<Layer> layerIter = layeredGraph.getLayers().listIterator();
         while (layerIter.hasNext()) {
             Layer layer = layerIter.next();
-            boolean externalLayer = Iterables.all(layer, PRED_EXTERNAL_WEST_OR_EAST_PORT);
+            boolean externalLayer = java.util.stream.StreamSupport.stream(layer.spliterator(), false).allMatch(PRED_EXTERNAL_WEST_OR_EAST_PORT);
             
             // The rightmost layer is not given any node spacing if it's an external port layer
             if (externalLayer && xpos > 0) {

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/HyperEdgeCycleDetector.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/HyperEdgeCycleDetector.java
@@ -14,11 +14,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.eclipse.elk.alg.layered.p5edges.orthogonal.HyperEdgeSegmentDependency.DependencyType;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Finds a set of dependencies to remove or reverse to break cycles in the conflict graph of {@link HyperEdgeSegment}s
@@ -59,8 +58,8 @@ public final class HyperEdgeCycleDetector {
         
         List<HyperEdgeSegmentDependency> result = new ArrayList<>();
         
-        LinkedList<HyperEdgeSegment> sources = Lists.newLinkedList();
-        LinkedList<HyperEdgeSegment> sinks = Lists.newLinkedList();
+        LinkedList<HyperEdgeSegment> sources = new LinkedList<>();
+        LinkedList<HyperEdgeSegment> sinks = new LinkedList<>();
 
         // initialize values for the algorithm
         initialize(segments, sources, sinks, criticalOnly);
@@ -144,7 +143,7 @@ public final class HyperEdgeCycleDetector {
             final LinkedList<HyperEdgeSegment> sources, final LinkedList<HyperEdgeSegment> sinks,
             final boolean criticalOnly, final Random random) {
         
-        Set<HyperEdgeSegment> unprocessed = Sets.newTreeSet(segments);
+        Set<HyperEdgeSegment> unprocessed = new TreeSet<>(segments);
         List<HyperEdgeSegment> maxSegments = new ArrayList<HyperEdgeSegment>();
         
         // We'll mark sinks with marks < markBase and sources with marks > markBase. Sink marks will later be offset to

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/HyperEdgeSegment.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/HyperEdgeSegment.java
@@ -14,12 +14,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.ArrayList;
 
 import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.alg.layered.p5edges.orthogonal.direction.BaseRoutingDirectionStrategy;
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Lists;
 
 /**
  * Instances of this class represent the "trunk" of a hyper edge. In left-to-right layouts, this will be the vertical
@@ -56,7 +56,7 @@ public class HyperEdgeSegment implements Comparable<HyperEdgeSegment> {
     /** routing strategy which will ultimately decide how edges will be routed. */
     private final BaseRoutingDirectionStrategy routingStrategy;
     /** ports represented by this hypernode. */
-    private final List<LPort> ports = Lists.newArrayList();
+    private final List<LPort> ports = new ArrayList<>();
     
     /** mark value used for cycle breaking (to be accessed directly). */
     // SUPPRESS CHECKSTYLE NEXT Visibility 
@@ -71,18 +71,18 @@ public class HyperEdgeSegment implements Comparable<HyperEdgeSegment> {
     private double endPosition = Double.NaN;
     
     /** sorted list of coordinates where incoming connections enter this segment. */
-    private final LinkedList<Double> incomingConnectionCoordinates = Lists.newLinkedList();
+    private final LinkedList<Double> incomingConnectionCoordinates = new LinkedList<>();
     /** sorted list of coordinates where outgoing connections leave this segment. */
-    private final LinkedList<Double> outgoingConnectionCoordinates = Lists.newLinkedList();
+    private final LinkedList<Double> outgoingConnectionCoordinates = new LinkedList<>();
     
     /** list of outgoing dependencies to other edge segments. */
-    private final List<HyperEdgeSegmentDependency> outgoingSegmentDependencies = Lists.newArrayList();
+    private final List<HyperEdgeSegmentDependency> outgoingSegmentDependencies = new ArrayList<>();
     /** combined weight of all outgoing dependencies. */
     private int outDepWeight;
     /** combined weight of critical outgoing dependencies. */
     private int criticalOutDepWeight;
     /** list of incoming dependencies from other edge segments. */
-    private final List<HyperEdgeSegmentDependency> incomingSegmentDependencies = Lists.newArrayList();
+    private final List<HyperEdgeSegmentDependency> incomingSegmentDependencies = new ArrayList<>();
     /** combined weight of all incoming dependencies. */
     private int inDepWeight;
     /** combined weight of critical incoming dependencies. */

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/HyperEdgeSegmentSplitter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/HyperEdgeSegmentSplitter.java
@@ -17,7 +17,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.elk.core.util.Pair;
 
-import com.google.common.collect.Streams;
 
 /**
  * Responsible for splitting {@link HyperEdgeSegment}s in order to avoid overlaps. This class assumes that critical
@@ -83,7 +82,7 @@ public final class HyperEdgeSegmentSplitter {
         Stream<Double> inCoordinates = segments.stream().flatMap(s -> s.getIncomingConnectionCoordinates().stream());
         Stream<Double> outCoordinates = segments.stream().flatMap(s -> s.getOutgoingConnectionCoordinates().stream());
         
-        double[] sortedCoordinates = Streams.concat(inCoordinates, outCoordinates)
+        double[] sortedCoordinates = Stream.concat(inCoordinates, outCoordinates)
             .mapToDouble(coordinate -> coordinate.doubleValue())
             .sorted()
             .toArray();

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/OrthogonalRoutingGenerator.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/OrthogonalRoutingGenerator.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import org.eclipse.elk.alg.layered.DebugUtil;
 import org.eclipse.elk.alg.layered.graph.LGraph;
@@ -27,8 +29,6 @@ import org.eclipse.elk.alg.layered.p5edges.orthogonal.direction.RoutingDirection
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * Edge routing implementation that creates orthogonal bend points. Inspired by:
@@ -156,8 +156,8 @@ public final class OrthogonalRoutingGenerator {
             final double startPos) {
 
         // Keep track of our hyperedge segements, and which ports they were created for
-        Map<LPort, HyperEdgeSegment> portToEdgeSegmentMap = Maps.newHashMap();
-        List<HyperEdgeSegment> edgeSegments = Lists.newArrayList();
+        Map<LPort, HyperEdgeSegment> portToEdgeSegmentMap = new HashMap<>();
+        List<HyperEdgeSegment> edgeSegments = new ArrayList<>();
 
         // create hyperedge segments for eastern output ports of the left layer and for western output ports of the
         // right layer
@@ -489,8 +489,8 @@ public final class OrthogonalRoutingGenerator {
         // determine sources, targets, incoming count and outgoing count; targets are only
         // added to the list if they only connect westward ports (that is, if all their
         // horizontal segments point to the right)
-        List<HyperEdgeSegment> sources = Lists.newArrayList();
-        List<HyperEdgeSegment> rightwardTargets = Lists.newArrayList();
+        List<HyperEdgeSegment> sources = new ArrayList<>();
+        List<HyperEdgeSegment> rightwardTargets = new ArrayList<>();
         for (HyperEdgeSegment node : segments) {
             node.setInWeight(node.getIncomingSegmentDependencies().size());
             node.setOutWeight(node.getOutgoingSegmentDependencies().size());

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/direction/BaseRoutingDirectionStrategy.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/orthogonal/direction/BaseRoutingDirectionStrategy.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.alg.layered.p5edges.orthogonal.direction;
 
 import java.util.Set;
+import java.util.HashSet;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LPort;
@@ -20,7 +21,6 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Sets;
 
 /**
  * A routing direction strategy adapts the {@link OrthogonalRoutingGenerator} to different routing directions. Commonly,
@@ -36,7 +36,7 @@ public abstract class BaseRoutingDirectionStrategy {
     // Properties
 
     /** set of already created junction points, to avoid multiple points at the same position. */
-    private final Set<KVector> createdJunctionPoints = Sets.newHashSet();
+    private final Set<KVector> createdJunctionPoints = new HashSet<>();
     
     
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/NubSpline.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/NubSpline.java
@@ -13,12 +13,12 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.ArrayList;
+import java.util.LinkedList;
 
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.KVectorChain;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Represents a Non Uniform B-Spline. This spline is not rational, thus there is no weight for the
@@ -44,9 +44,9 @@ public class NubSpline {
 
     /** The knotVector of this NubSpline. (The traditionally added 0 at the beginning and 1 at the end
      *  of the knot vector is not added, as these elements are not relevant for the calculation) */
-    private List<Double> knotVector = Lists.newArrayList();
+    private List<Double> knotVector = new ArrayList<>();
     /** The control points of this NubSpline. */
-    private List<PolarCP> controlPoints = Lists.newArrayList();
+    private List<PolarCP> controlPoints = new ArrayList<>();
 
     /** The dimension of this NubSpline. All contained and constructible vectors have the same dim. */
     private int dimNUBS;
@@ -82,10 +82,10 @@ public class NubSpline {
         isClamped = nubSpline.isClamped;
         outerBox = nubSpline.outerBox;
         isBezier = nubSpline.isBezier;
-        knotVector = Lists.newLinkedList(nubSpline.knotVector);
+        knotVector = new LinkedList<>(nubSpline.knotVector);
         minKnot = nubSpline.minKnot;
         maxKnot = nubSpline.maxKnot;
-        controlPoints = Lists.newLinkedList(nubSpline.controlPoints);
+        controlPoints = new LinkedList<>(nubSpline.controlPoints);
     }
 
     /**
@@ -117,7 +117,7 @@ public class NubSpline {
             // create the knot vector
             createUniformKnotVector(clamped, kVectors.size() + dimNUBS - 1);
 
-            final List<Double> polarCoordinate = Lists.newArrayList();
+            final List<Double> polarCoordinate = new ArrayList<>();
             final Iterator<Double> knotIter = knotVector.iterator();
 
             // the first (dimNUBS - 1) elements of the knotVector for the "sliding window" that
@@ -145,7 +145,7 @@ public class NubSpline {
      * @param kVectors The control points of this NubSpline.
      */
     public NubSpline(final boolean clamped, final int dimension, final KVector... kVectors) {
-        this(clamped, dimension, Lists.newArrayList(kVectors));
+        this(clamped, dimension, new ArrayList<>(java.util.Arrays.asList(kVectors)));
     }
 
     /**
@@ -169,7 +169,7 @@ public class NubSpline {
         knotVector = knotVec;
         controlPoints = polarVectors;
         minKnot = knotVec.iterator().next();
-        maxKnot = Iterables.getLast(knotVec);
+        maxKnot = java.util.stream.StreamSupport.stream(knotVec.spliterator(), false).reduce((first, second) -> second).orElseThrow();
     }
 
     // ########################################################################################
@@ -188,9 +188,8 @@ public class NubSpline {
         final int oldDim = nubSpline.dimNUBS;
         final int newDim = oldDim - 1;
         final List<Double> oldKnotVector = nubSpline.knotVector;
-        final List<Double> newKnotVector = Lists.newLinkedList(
-                nubSpline.knotVector.subList(1, nubSpline.knotVector.size() - 1));
-        final List<KVector> newControlPoints = Lists.newArrayList();
+        final List<Double> newKnotVector = new LinkedList<>(nubSpline.knotVector.subList(1, nubSpline.knotVector.size() - 1));
+        final List<KVector> newControlPoints = new ArrayList<>();
 
         // Calculate the new control points.
         for (int i = 0; i < nubSpline.controlPoints.size() - 1; i++) {
@@ -202,9 +201,9 @@ public class NubSpline {
         }
 
         // Create the PolarCPs
-        final List<Double> polarCoordinate = Lists.newArrayList();
+        final List<Double> polarCoordinate = new ArrayList<>();
         final Iterator<Double> knotIter = newKnotVector.iterator();
-        final List<PolarCP> newPolarVectors = Lists.newArrayList();
+        final List<PolarCP> newPolarVectors = new ArrayList<>();
 
         // the first (dimNUBS - 1) elements of the knotVector for the "sliding window" that
         // determines the polarCoordinates of the PolarCP.
@@ -233,7 +232,7 @@ public class NubSpline {
      * @return The inverted NubSpline.
      */
     public static NubSpline generateInvertedNUBS(final NubSpline nubSpline) {
-        final List<Double> newKnotVector = Lists.newArrayList();
+        final List<Double> newKnotVector = new ArrayList<>();
         final double maxVector =  nubSpline.knotVector.get(nubSpline.knotVector.size() - 1); 
         for (final Double vector : nubSpline.knotVector) {
             newKnotVector.add(0, maxVector - vector);
@@ -241,9 +240,9 @@ public class NubSpline {
         final List<KVector> newControlPoints = KVectorChain.reverse(nubSpline.getControlPoints());
 
         // Create the PolarCPs
-        final List<Double> polarCoordinate = Lists.newArrayList();
+        final List<Double> polarCoordinate = new ArrayList<>();
         final Iterator<Double> knotIter = newKnotVector.iterator();
-        final List<PolarCP> newPolarVectors = Lists.newArrayList();
+        final List<PolarCP> newPolarVectors = new ArrayList<>();
 
         // the first (dimNUBS - 1) elements of the knotVector for the "sliding window" that
         // determines the polarCoordinates of the PolarCP.
@@ -342,7 +341,7 @@ public class NubSpline {
      * @return A copy of the knotVector.
      */
     public List<Double> getKnotVector() {
-        return Lists.newLinkedList(knotVector);
+        return new LinkedList<>(knotVector);
     }
 
 
@@ -516,7 +515,7 @@ public class NubSpline {
             iterKnot.add(knotToInsert);
 
             // We will first construct the new CPs and than add them.
-            final List<PolarCP> newCPs = Lists.newArrayList();
+            final List<PolarCP> newCPs = new ArrayList<>();
             // The first CP we need for the calculation.
             PolarCP secondCP = iterCP.next();
 
@@ -1024,7 +1023,7 @@ public class NubSpline {
          */
         PolarCP(final KVector controlPoint, final List<Double> polarCoordinate) {
             setCp(controlPoint.clone());
-            setPolarCoordinate(Lists.newLinkedList(polarCoordinate));
+            setPolarCoordinate(new LinkedList<>(polarCoordinate));
         }
 
         /**
@@ -1034,7 +1033,7 @@ public class NubSpline {
          */
         PolarCP(final PolarCP polarCP) {
             setCp(polarCP.getCp().clone());
-            setPolarCoordinate(Lists.newLinkedList(polarCP.getPolarCoordinate()));
+            setPolarCoordinate(new LinkedList<>(polarCP.getPolarCoordinate()));
         }
 
         /**
@@ -1054,7 +1053,7 @@ public class NubSpline {
          */
         PolarCP(final PolarCP firstCP, final PolarCP secondCP, final double newKnot) {
             final double firstFactor = firstCP.polarCoordinate.iterator().next();
-            final double secondFactor = Iterables.getLast(secondCP.polarCoordinate);
+            final double secondFactor = java.util.stream.StreamSupport.stream(secondCP.polarCoordinate.spliterator(), false).reduce((first, second) -> second).orElseThrow();
 
             // vectorC = ((b-c) * vectorA + (c-a) * vectorB) / (b-a)
             final KVector aScaled = firstCP.cp.clone().scale(secondFactor - newKnot);
@@ -1063,7 +1062,7 @@ public class NubSpline {
             total.scale(1.0 / (secondFactor - firstFactor));
 
             cp = total;
-            polarCoordinate = Lists.newArrayList();
+            polarCoordinate = new ArrayList<>();
 
             // Specifies, if the newKnot still needs to be added.
             boolean needsToBeAdded = true;

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/Rectangle.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/Rectangle.java
@@ -19,7 +19,6 @@ import org.eclipse.elk.core.math.ElkMargin;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Iterables;
 
 /**
  * This class is representing a rectangle and provides some comfort methods to work with the
@@ -105,7 +104,7 @@ public final class Rectangle {
      * @param vectors The coordinates to span the rectangle around.
      */
     public Rectangle(final Iterable<KVector> vectors) {
-        if (Iterables.isEmpty(vectors)) {
+        if (!vectors.iterator().hasNext()) {
             throw new IllegalArgumentException("The list of vectors may not be empty.");
         }
             

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineEdgeRouter.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineEdgeRouter.java
@@ -16,6 +16,10 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 import org.eclipse.elk.alg.layered.LayeredPhases;
 import org.eclipse.elk.alg.layered.graph.LEdge;
@@ -37,11 +41,6 @@ import org.eclipse.elk.core.alg.LayoutProcessorConfiguration;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.IElkProgressMonitor;
 import org.eclipse.elk.core.util.Pair;
-
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * Implements a way of routing the edges with splines. Uses the dummy nodes as reference points for
@@ -150,27 +149,27 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
     
     // some variables valid during one iteration (a pair of layers)
     /** current edges of the layers in a current iteration. */
-    private final List<LEdge> edgesRemainingLayer = Lists.newArrayList();
+    private final List<LEdge> edgesRemainingLayer = new ArrayList<>();
     /** current spline segments of the layers in a current iteration. */
-    private final List<SplineSegment> splineSegmentsLayer = Lists.newArrayList();
+    private final List<SplineSegment> splineSegmentsLayer = new ArrayList<>();
     /** current ports on the left layer involved in a current iteration. */
-    private final Set<LPort> leftPortsLayer = Sets.newLinkedHashSet();
+    private final Set<LPort> leftPortsLayer = new LinkedHashSet<>();
     /** current ports on the right layer involved in a current iteration. */
-    private final Set<LPort> rightPortsLayer = Sets.newLinkedHashSet();
+    private final Set<LPort> rightPortsLayer = new LinkedHashSet<>();
     /** current self loops of the layers in a current iteration. */
-    private final Set<LEdge> selfLoopsLayer = Sets.newLinkedHashSet();
+    private final Set<LEdge> selfLoopsLayer = new LinkedHashSet<>();
     
     // variables for the whole edge routing process
     private LGraph lGraph;
     /** a collection of all edges that have a normal node as their source. */
-    private final List<LEdge> startEdges = Lists.newArrayList();
+    private final List<LEdge> startEdges = new ArrayList<>();
     /** all created spline segments. */
-    private final List<SplineSegment> allSplineSegments = Lists.newArrayList();
+    private final List<SplineSegment> allSplineSegments = new ArrayList<>();
     /** Maps {@link LEdge} to their representing segments. */
-    private final Map<LEdge, SplineSegment> edgeToSegmentMap = Maps.newHashMap();
+    private final Map<LEdge, SplineSegment> edgeToSegmentMap = new HashMap<>();
     /** A mapping pointing from an edge to it's succeeding edge, together with their connected 
        friends, they form a long-edge. */
-    private final Map<LEdge, LEdge> successingEdge = Maps.newHashMap();
+    private final Map<LEdge, LEdge> successingEdge = new HashMap<>();
     
     //////////////////////////////////////////////////
 
@@ -203,10 +202,10 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
         // check if the first and/or last layer are populated with external port dummies
         final Layer firstLayer = layeredGraph.getLayers().get(0);
         final boolean isLeftLayerExternal =
-                Iterables.all(firstLayer.getNodes(), PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
+                java.util.stream.StreamSupport.stream(firstLayer.getNodes().spliterator(), false).allMatch(PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
         final Layer lastLayer = layeredGraph.getLayers().get(layeredGraph.getLayers().size() - 1);
         final boolean isRightLayerExternal =
-                Iterables.all(lastLayer.getNodes(), PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
+                java.util.stream.StreamSupport.stream(lastLayer.getNodes().spliterator(), false).allMatch(PolylineEdgeRouter.PRED_EXTERNAL_WEST_OR_EAST_PORT);
 
         final Iterator<Layer> layerIterator = layeredGraph.iterator();
         Layer leftLayer = null;
@@ -580,8 +579,8 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
         // Iterate through all ports on the side to process.
         for (final LPort singlePort : portsToProcess) {
             final double singlePortPosition = singlePort.getAbsoluteAnchor().y;
-            final Set<Pair<SideToProcess, LEdge>> upEdges = Sets.newHashSet();
-            final Set<Pair<SideToProcess, LEdge>> downEdges = Sets.newHashSet();
+            final Set<Pair<SideToProcess, LEdge>> upEdges = new HashSet<>();
+            final Set<Pair<SideToProcess, LEdge>> downEdges = new HashSet<>();
             
             // Find edges we could construct a hyper-edge from. If the edge is in the 
             // edgesRemaining set, there is no hyper-edge that represents this edge. 
@@ -705,8 +704,8 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
      * @param edges list of hypernodes
      */
     private static void breakCycles(final List<SplineSegment> edges, final Random random) {
-        final LinkedList<SplineSegment> sources = Lists.newLinkedList();
-        final LinkedList<SplineSegment> sinks = Lists.newLinkedList();
+        final LinkedList<SplineSegment> sources = new LinkedList<>();
+        final LinkedList<SplineSegment> sinks = new LinkedList<>();
         
         // initialize values for the algorithm
         int nextMark = -1;
@@ -734,11 +733,11 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
         }
     
         // assign marks to all nodes, ignore dependencies of weight zero
-        final Set<SplineSegment> unprocessed = Sets.newLinkedHashSet(edges);
+        final Set<SplineSegment> unprocessed = new LinkedHashSet<>(edges);
         final int markBase = edges.size();
         int nextLeft = markBase + 1;
         int nextRight = markBase - 1;
-        final List<SplineSegment> maxEdges = Lists.newArrayList();
+        final List<SplineSegment> maxEdges = new ArrayList<>();
 
         while (!unprocessed.isEmpty()) {
             while (!sinks.isEmpty()) {
@@ -852,8 +851,8 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
         // determine sources, targets, incoming count and outgoing count; targets are only
         // added to the list if they only connect westward ports (that is, if all their
         // horizontal segments point to the right)
-        final List<SplineSegment> sources = Lists.newLinkedList();
-        final List<SplineSegment> rightwardTargets = Lists.newLinkedList();
+        final List<SplineSegment> sources = new LinkedList<>();
+        final List<SplineSegment> rightwardTargets = new LinkedList<>();
         for (final SplineSegment edge : edges) {
             edge.rank = 0;
             edge.inweight = edge.incoming.size();
@@ -934,7 +933,7 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
     }
     
     private List<LEdge> getEdgeChain(final LEdge start) {
-        List<LEdge> edgeChain = Lists.newArrayList();
+        List<LEdge> edgeChain = new ArrayList<>();
         LEdge current = start;
         do {
             edgeChain.add(current);
@@ -944,7 +943,7 @@ public final class SplineEdgeRouter implements ILayoutPhase<LayeredPhases, LGrap
     }
     
     private List<SplineSegment> getSplinePath(final LEdge start) {
-        List<SplineSegment> segmentChain = Lists.newArrayList();
+        List<SplineSegment> segmentChain = new ArrayList<>();
         LEdge current = start;
         do {
             SplineSegment segment = edgeToSegmentMap.get(current);

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineSegment.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplineSegment.java
@@ -12,6 +12,9 @@ package org.eclipse.elk.alg.layered.p5edges.splines;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 
 import org.eclipse.elk.alg.layered.graph.LEdge;
 import org.eclipse.elk.alg.layered.graph.LNode;
@@ -24,10 +27,6 @@ import org.eclipse.elk.alg.layered.p5edges.splines.SplineEdgeRouter.SideToProces
 import org.eclipse.elk.core.math.ElkRectangle;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.util.Pair;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * Represents a segment of a spline that is to be created. A segment represents one or more {@link LEdge}s between
@@ -56,13 +55,13 @@ public final class SplineSegment implements Comparable<SplineSegment> {
     
     // the following variables are used during cycle breaking and topological sorting
     /** A sets of ports, determining the ports left of the hyper-edge. */  
-    public final Set<LPort> leftPorts = Sets.newHashSet();
+    public final Set<LPort> leftPorts = new HashSet<>();
     /** A sets of ports, determining the ports right of the hyper-edge. */  
-    public final Set<LPort> rightPorts = Sets.newHashSet();
+    public final Set<LPort> rightPorts = new HashSet<>();
     /** Outgoing dependencies are pointing to hyper-edges that must lay right of this hyper edge. */
-    public final List<Dependency> outgoing = Lists.newArrayList();
+    public final List<Dependency> outgoing = new ArrayList<>();
     /** Incoming dependencies are pointing to hyper-edges that must lay left of this hyper edge. */
-    public final List<Dependency> incoming = Lists.newArrayList();
+    public final List<Dependency> incoming = new ArrayList<>();
     /** Used to mark nodes in the cycle breaker. */
     public int mark;
     /** Determines how many elements are depending on this. */
@@ -74,7 +73,7 @@ public final class SplineSegment implements Comparable<SplineSegment> {
     
     // variables representing the characteristics of the segment 
     /** A set of all LEdges that are combined in this hyper-edge. */
-    public final Set<LEdge> edges = Sets.newHashSet();
+    public final Set<LEdge> edges = new HashSet<>();
     /** If true, the spline segment has no vertical segment, connecting two ports by a horizontal edge path. */
     public final boolean isStraight;
     /** An imaginary bounding box in which this spline segment should reside. */
@@ -134,7 +133,7 @@ public final class SplineSegment implements Comparable<SplineSegment> {
     }
     
     /** Map holding for each {@link LEdge} information that was valid during the edge routing phase. */
-    public Map<LEdge, EdgeInformation> edgeInformation = Maps.newHashMap();
+    public Map<LEdge, EdgeInformation> edgeInformation = new HashMap<>();
     
     /**
      * Constructor for a 1:n hyper-edge.

--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplinesMath.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p5edges/splines/SplinesMath.java
@@ -16,7 +16,6 @@ import org.eclipse.elk.alg.layered.graph.LPort;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.PortSide;
 
-import com.google.common.collect.Iterables;
 
 /**
  * Mathematics utility class used in the splines routing.
@@ -167,7 +166,7 @@ public final class SplinesMath {
      * @return The readable string.
      */
     public static String convertKVectorToString(final Iterable<KVector> list) {
-        if (list == null || Iterables.size(list) == 0) {
+        if (list == null || !list.iterator().hasNext()) {
             return NULL_STRING;
         }
         final StringBuilder retVal = new StringBuilder();

--- a/plugins/org.eclipse.elk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.core/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-Name: ELK Core Components
 Bundle-SymbolicName: org.eclipse.elk.core;singleton:=true
 Bundle-Version: 0.12.0.qualifier
 Eclipse-BuddyPolicy: registered
-Require-Bundle: com.google.guava,
- org.eclipse.emf.ecore,
+Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi,
  org.eclipse.elk.graph
 Export-Package: org.eclipse.elk.core,

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/LayoutConfigurator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/LayoutConfigurator.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package org.eclipse.elk.core;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,9 +30,6 @@ import org.eclipse.elk.graph.properties.IPropertyHolder;
 import org.eclipse.elk.graph.properties.MapPropertyHolder;
 import org.eclipse.elk.graph.properties.Property;
 import org.eclipse.elk.graph.util.ElkReflect;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * A layout configurator is a graph element visitor that applies layout option values. It can be
@@ -52,10 +51,10 @@ public class LayoutConfigurator implements IGraphElementVisitor {
     public static final IProperty<LayoutConfigurator> ADD_LAYOUT_CONFIG =
             new Property<LayoutConfigurator>("org.eclipse.elk.addLayoutConfig");
     
-    private final Map<ElkGraphElement, MapPropertyHolder> elementOptionMap = Maps.newHashMap();
-    private final Map<Class<? extends ElkGraphElement>, MapPropertyHolder> classOptionMap = Maps.newHashMap();
+    private final Map<ElkGraphElement, MapPropertyHolder> elementOptionMap = new HashMap<>();
+    private final Map<Class<? extends ElkGraphElement>, MapPropertyHolder> classOptionMap = new HashMap<>();
     private boolean clearLayout = false;
-    private final List<IOptionFilter> optionFilters = Lists.newArrayList();
+    private final List<IOptionFilter> optionFilters = new ArrayList<>();
     
     /**
      * Functional interface that allows to specify whether a certain property should be set for a certain graph element.

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/RecursiveGraphLayoutEngine.java
@@ -9,7 +9,9 @@
  *******************************************************************************/
 package org.eclipse.elk.core;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -37,8 +39,6 @@ import org.eclipse.elk.graph.ElkLabel;
 import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.properties.GraphFeature;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
-
-import com.google.common.collect.Lists;
 
 /**
  * Performs layout on a graph with hierarchy by executing a layout algorithm on each level of the
@@ -162,7 +162,7 @@ public class RecursiveGraphLayoutEngine implements IGraphLayoutEngine {
             }
             
             // We collect inside self loops of children and post-process them later
-            List<ElkEdge> childrenInsideSelfLoops = Lists.newArrayList();
+            List<ElkEdge> childrenInsideSelfLoops = new ArrayList<>();
             
             // If the layout provider supports hierarchy, it is expected to layout the node's compound
             // node children as well
@@ -180,7 +180,7 @@ public class RecursiveGraphLayoutEngine implements IGraphLayoutEngine {
                 nodeCount = countNodesWithHierarchy(layoutNode);
                 
                 // Look for nodes that stop the hierarchy handling, evaluating the inheritance on the way
-                final Queue<ElkNode> nodeQueue = Lists.newLinkedList();
+                final Queue<ElkNode> nodeQueue = new LinkedList<>();
                 nodeQueue.addAll(layoutNode.getChildren());
                 
                 while (!nodeQueue.isEmpty()) {
@@ -564,7 +564,7 @@ public class RecursiveGraphLayoutEngine implements IGraphLayoutEngine {
      */
     protected List<ElkEdge> gatherInsideSelfLoops(final ElkNode node) {
         if (node.getProperty(CoreOptions.INSIDE_SELF_LOOPS_ACTIVATE)) {
-            List<ElkEdge> insideSelfLoops = Lists.newArrayList();
+            List<ElkEdge> insideSelfLoops = new ArrayList<>();
             
             for (ElkEdge edge : ElkGraphUtil.allOutgoingEdges(node)) {
                 // MIGRATE Adapt to hyperedges and make error-safe

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/alg/AlgorithmAssembler.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/alg/AlgorithmAssembler.java
@@ -9,16 +9,15 @@
  *******************************************************************************/
 package org.eclipse.elk.core.alg;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.elk.core.util.AbstractRandomListAccessor;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * A builder class for algorithms which are structured into phases and intermediate processing slots. The assembler
@@ -145,7 +144,7 @@ public final class AlgorithmAssembler<P extends Enum<P>, G>
 
         configuredPhases = EnumSet.noneOf(phasesEnumClass);
         additionalProcessors = LayoutProcessorConfiguration.create();
-        cache = Maps.newHashMap();
+        cache = new HashMap<>();
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -268,7 +267,7 @@ public final class AlgorithmAssembler<P extends Enum<P>, G>
         P[] phaseEnumConstants = phasesEnumClass.getEnumConstants();
 
         // Instantiate all configured phases
-        List<ILayoutPhase<P, G>> phaseImplementations = Lists.newArrayListWithCapacity(numberOfPhases);
+        List<ILayoutPhase<P, G>> phaseImplementations = new ArrayList<>(numberOfPhases);
         for (P phase : phaseEnumConstants) {
             ILayoutPhaseFactory<P, G> phaseFactory = getListItem(phase.ordinal());
             if (phaseFactory != null) {
@@ -288,7 +287,7 @@ public final class AlgorithmAssembler<P extends Enum<P>, G>
         processorConfiguration.addAll(additionalProcessors);
 
         // The list of processors the algorithm will be made up of
-        List<ILayoutProcessor<G>> algorithm = Lists.newArrayList();
+        List<ILayoutProcessor<G>> algorithm = new ArrayList<>();
 
         // Add processors and phases to the algorithm
         for (P phase : phaseEnumConstants) {
@@ -331,7 +330,7 @@ public final class AlgorithmAssembler<P extends Enum<P>, G>
      * @return the sorted list of instantiated processors.
      */
     private List<ILayoutProcessor<G>> retrieveProcessors(final Set<ILayoutProcessorFactory<G>> factories) {
-        List<ILayoutProcessor<G>> processors = Lists.newArrayListWithCapacity(factories.size());
+        List<ILayoutProcessor<G>> processors = new ArrayList<>(factories.size());
         factories.stream()
             .sorted(processorComparator)
             .forEach(factory -> processors.add(retrieveProcessor(factory)));

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/alg/LayoutProcessorConfiguration.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/alg/LayoutProcessorConfiguration.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import org.eclipse.elk.core.util.AbstractRandomListAccessor;
 
-import com.google.common.collect.Sets;
+import java.util.HashSet;
 
 /**
  * Instances of this class specify {@link ILayoutProcessor layout processors} that should be executed in the different
@@ -236,7 +236,7 @@ public final class LayoutProcessorConfiguration<P extends Enum<P>, G>
      * @return set of processors.
      */
     private Set<ILayoutProcessorFactory<G>> processors(final int index) {
-        return Sets.newHashSet(getListItem(index));
+        return new HashSet<>(getListItem(index));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -249,7 +249,7 @@ public final class LayoutProcessorConfiguration<P extends Enum<P>, G>
      */
     @Override
     protected Set<ILayoutProcessorFactory<G>> provideDefault() {
-        return Sets.newHashSet();
+        return new HashSet<>();
     }
 
 }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/CommentAttacher.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/CommentAttacher.java
@@ -9,16 +9,16 @@
  *******************************************************************************/
 package org.eclipse.elk.core.comments;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 
 import org.eclipse.elk.core.util.Pair;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * Main class of the comment attachment framework. Comment attachment infers the relation between comments and the
@@ -109,9 +109,9 @@ public final class CommentAttacher<C, T> {
     /** The bounds provider to be used. */
     private IBoundsProvider<C, T> boundsProvider = null;
     /** List of filters. */
-    private List<IFilter<C>> filters = Lists.newArrayList();
+    private List<IFilter<C>> filters = new ArrayList<>();
     /** List of matchers. */
-    private List<IMatcher<C, T>> matchers = Lists.newArrayList();
+    private List<IMatcher<C, T>> matchers = new ArrayList<>();
     /** The attachment decider. */
     private IDecider<T> decider = new AggregatedMatchDecider<>();
     
@@ -277,11 +277,11 @@ public final class CommentAttacher<C, T> {
         
         // We keep track of all comment->target pairs we find (we may want to store the data provider that was used
         // to obtain the comment and the attachment target at some point)
-        Collection<Pair<C, T>> explicitAttachments = Lists.newArrayList();
-        Collection<Pair<C, T>> heuristicAttachments = Lists.newArrayList();
+        Collection<Pair<C, T>> explicitAttachments = new ArrayList<>();
+        Collection<Pair<C, T>> heuristicAttachments = new ArrayList<>();
         
         // Iterate over all comments we should iterate over
-        Queue<IDataProvider<C, T>> processingQueue = Lists.newLinkedList();
+        Queue<IDataProvider<C, T>> processingQueue = new LinkedList<>();
         processingQueue.add(dataProvider);
         
         while (!processingQueue.isEmpty()) {
@@ -371,10 +371,10 @@ public final class CommentAttacher<C, T> {
         }
         
         // Collect the matcher results in this map, indexed by attachment target, then indexed by the matcher
-        Map<T, Map<Class<? extends IMatcher<?, T>>, Double>> results = Maps.newHashMap();
+        Map<T, Map<Class<? extends IMatcher<?, T>>, Double>> results = new HashMap<>();
         
         for (T candidate : candidates) {
-            Map<Class<? extends IMatcher<?, T>>, Double> candidateResults = Maps.newHashMap();
+            Map<Class<? extends IMatcher<?, T>>, Double> candidateResults = new HashMap<>();
             results.put(candidate, candidateResults);
             
             // Run the normalized heuristics and collect their results in an array

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/IBoundsProvider.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/IBoundsProvider.java
@@ -11,9 +11,8 @@ package org.eclipse.elk.core.comments;
 
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.Rectangle2D.Double;
+import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.collect.Maps;
 
 /**
  * Knows how to retrieve the position and size of comments and attachment targets.
@@ -90,9 +89,9 @@ public interface IBoundsProvider<C, T> {
         return new IBoundsProvider<C, T>() {
 
             /** Cache for comment bounds. */
-            private final Map<C, Rectangle2D.Double> commentBoundsCache = Maps.newHashMap();
+            private final Map<C, Rectangle2D.Double> commentBoundsCache = new HashMap<>();
             /** Cache for target bounds. */
-            private final Map<T, Rectangle2D.Double> targetBoundsCache = Maps.newHashMap();
+            private final Map<T, Rectangle2D.Double> targetBoundsCache = new HashMap<>();
             
             @Override
             public Double boundsForComment(final C comment) {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/IDataProvider.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/IDataProvider.java
@@ -9,12 +9,13 @@
  *******************************************************************************/
 package org.eclipse.elk.core.comments;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Provides access to the objects that represent comments and the objects that represent possible attachment targets.
@@ -95,14 +96,14 @@ public interface IDataProvider<C, T> {
             /** Cache for targets. */
             private List<T> targetsCache = null;
             /** Cache for comment-specific targets. */
-            private final Multimap<C, T> commentTargetsCache = HashMultimap.create();
+            private final Map<C, Set<T>> commentTargetsCache = new HashMap<>();
             /** Cache for sub-level data providers. */
             private List<IDataProvider<C, T>> subProviderCache = null;
 
             @Override
             public Collection<C> provideComments() {
                 if (commentsCache == null) {
-                    commentsCache = Lists.newArrayList();
+                    commentsCache = new ArrayList<>();
                     commentsCache.addAll(IDataProvider.this.provideComments());
                 }
                 
@@ -112,7 +113,7 @@ public interface IDataProvider<C, T> {
             @Override
             public Collection<T> provideTargets() {
                 if (targetsCache == null) {
-                    targetsCache = Lists.newArrayList();
+                    targetsCache = new ArrayList<>();
                     targetsCache.addAll(IDataProvider.this.provideTargets());
                 }
                 
@@ -125,7 +126,9 @@ public interface IDataProvider<C, T> {
                     return commentTargetsCache.get(comment);
                 } else {
                     Collection<T> targets = IDataProvider.this.provideTargetsFor(comment);
-                    commentTargetsCache.putAll(comment, targets);
+                    if (!targets.isEmpty()) {
+                        commentTargetsCache.put(comment, new HashSet<>(targets));
+                    }
                     return targets;
                 }
             }
@@ -133,7 +136,7 @@ public interface IDataProvider<C, T> {
             @Override
             public Collection<IDataProvider<C, T>> provideSubHierarchies() {
                 if (subProviderCache == null) {
-                    subProviderCache = Lists.newArrayList();
+                    subProviderCache = new ArrayList<>();
                     
                     // Add cached versions of the providers
                     IDataProvider.this.provideSubHierarchies().stream()

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/NodeReferenceMatcher.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/NodeReferenceMatcher.java
@@ -10,6 +10,8 @@
 package org.eclipse.elk.core.comments;
 
 import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -19,10 +21,6 @@ import java.util.regex.Pattern;
 
 import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.graph.ElkNode;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * A binary matcher that checks if target names are referenced in comment texts. This can either be the case or not,
@@ -75,7 +73,7 @@ public class NodeReferenceMatcher<C, T> implements IMatcher<C, T> {
     /** Whether to use fuzzy mode when looking for occurrences of a target's name in a comment's text. */
     private boolean fuzzy = false;
     /** The comment-target attachments we've found during preprocessing. */
-    private Map<C, T> foundAttachments = Maps.newHashMap();
+    private Map<C, T> foundAttachments = new HashMap<>();
     
     
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -198,22 +196,22 @@ public class NodeReferenceMatcher<C, T> implements IMatcher<C, T> {
         checkConfiguration();
         
         // Build up maps of comment texts
-        List<Pair<C, String>> commentTexts = Lists.newArrayList();
+        List<Pair<C, String>> commentTexts = new ArrayList<>();
         
         for (C comment : dataProvider.provideComments()) {
             String commentText = commentTextFunction.apply(comment);
             
-            if (!Strings.isNullOrEmpty(commentText)) {
+            if (commentText != null && !commentText.isEmpty()) {
                 commentTexts.add(Pair.of(comment, commentText));
             }
         }
 
         // Build up maps of target names
-        List<Pair<T, String>> targetNames = Lists.newArrayList();
+        List<Pair<T, String>> targetNames = new ArrayList<>();
         for (T target : dataProvider.provideTargets()) {
             String targetName = targetNameFunction.apply(target);
             
-            if (!Strings.isNullOrEmpty(targetName)) {
+            if (targetName != null && !targetName.isEmpty()) {
                 targetNames.add(Pair.of(target, targetName));
             }
         }
@@ -266,7 +264,7 @@ public class NodeReferenceMatcher<C, T> implements IMatcher<C, T> {
      */
     private void goFindMatches(final List<Pair<C, String>> commentTexts, final List<Pair<T, String>> targetNames) {
         // Produce regular expression patterns for all target names
-        List<Pair<T, Pattern>> targetRegexps = Lists.newArrayListWithCapacity(targetNames.size());
+        List<Pair<T, Pattern>> targetRegexps = new ArrayList<>(targetNames.size());
         for (Pair<T, String> targetNamePair : targetNames) {
             Pattern regexp = fuzzy
                     ? fuzzyRegexpFor(targetNamePair.getSecond())

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/TextPrefixFilter.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/comments/TextPrefixFilter.java
@@ -9,12 +9,10 @@
  *******************************************************************************/
 package org.eclipse.elk.core.comments;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 
 /**
  * Determines if a comment is eligible for attachment based on its size. Use the methods named
@@ -28,7 +26,7 @@ public class TextPrefixFilter<C> implements IFilter<C> {
     /** Function that provides the text for comments. */
     private Function<C, String> commentTextProvider = null;
     /** List of prefixes. */
-    private List<String> prefixes = Lists.newArrayList();
+    private List<String> prefixes = new ArrayList<>();
     /**
      * If {@code true}, a comment that starts with one of the prefixes is not eligible for attachment. If {@code false},
      * a comment must start with one of the prefixes to be eligible.
@@ -100,7 +98,7 @@ public class TextPrefixFilter<C> implements IFilter<C> {
      *             if the prefix is {@code null} or the empty string.
      */
     public TextPrefixFilter<C> addPrefix(final String prefix) {
-        if (Strings.isNullOrEmpty(prefix)) {
+        if (prefix == null || prefix.isEmpty()) {
             throw new IllegalArgumentException("Prefix cannot be null or empty. Wouldn't make sense.");
         }
         
@@ -138,7 +136,7 @@ public class TextPrefixFilter<C> implements IFilter<C> {
     public boolean eligibleForAttachment(final C comment) {
         String commentText = commentTextProvider.apply(comment);
 
-        if (!Strings.isNullOrEmpty(commentText)) {
+        if (commentText != null && !commentText.isEmpty()) {
             for (String prefix : prefixes) {
                 // We can only have a match if the comment is as least as long as the prefix
                 if (commentText.length() >= prefix.length()) {

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacer.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/DeprecatedLayoutOptionReplacer.java
@@ -19,8 +19,6 @@ import org.eclipse.elk.core.util.IGraphElementVisitor;
 import org.eclipse.elk.graph.ElkGraphElement;
 import org.eclipse.elk.graph.properties.IProperty;
 
-import com.google.common.collect.ImmutableMap;
-
 /**
  * Replaces (and removes) any deprecated layout options from {@link CoreOptions} with a corresponding new layout option
  * (or whatever is required to reconstruct the old behavior).
@@ -53,7 +51,7 @@ public class DeprecatedLayoutOptionReplacer implements IGraphElementVisitor {
      */
     @SuppressWarnings("deprecation")
     public static final Map<IProperty<?>, Consumer<ElkGraphElement>> RULES =
-            ImmutableMap.of(
+            Map.of(
                 CoreOptions.PORT_LABELS_NEXT_TO_PORT_IF_POSSIBLE, NEXT_TO_PORT_IF_POSSIBLE,
                 CoreOptions.NODE_SIZE_OPTIONS, SPACE_EFFICIENT
             );

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutAlgorithmData.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutAlgorithmData.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.core.data;
 
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -19,8 +20,6 @@ import org.eclipse.elk.core.util.InstancePool;
 import org.eclipse.elk.core.validation.IValidatingGraphElementVisitor;
 import org.eclipse.elk.graph.properties.GraphFeature;
 import org.eclipse.elk.graph.properties.IProperty;
-
-import com.google.common.collect.Maps;
 
 /**
  * Data type used to store information for a layout algorithm.
@@ -51,7 +50,7 @@ public final class LayoutAlgorithmData implements ILayoutMetaData {
     private final Class<? extends IValidatingGraphElementVisitor> validatorClass;
     
     /** Map of known layout options. Keys are option IDs, values are the default values. */
-    private final Map<String, Object> knownOptions = Maps.newHashMap();
+    private final Map<String, Object> knownOptions = new HashMap<>();
     
     /**
      * Create a layout algorithm data entry.

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutDataContentAssist.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutDataContentAssist.java
@@ -9,8 +9,10 @@
  *******************************************************************************/
 package org.eclipse.elk.core.data;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -26,12 +28,6 @@ import org.eclipse.elk.graph.ElkLabel;
 import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
-
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Utility class providing basic mechanisms for layout option content assist.
@@ -82,8 +78,8 @@ public final class LayoutDataContentAssist {
 
         LayoutAlgorithmData responsibleAlgorithm = getAlgorithm(element);
         if (element instanceof ElkNode) {
-            Set<Target> targets = ((ElkNode) element).getChildren().isEmpty() ? ImmutableSet.of(Target.NODES)
-                    : ImmutableSet.of(Target.NODES, Target.PARENTS);
+            Set<Target> targets = ((ElkNode) element).getChildren().isEmpty() ? Set.of(Target.NODES)
+                    : Set.of(Target.NODES, Target.PARENTS);
             return getLayoutOptionProposals(element, responsibleAlgorithm, targets, prefix);
         } else if (element instanceof ElkEdge) {
             return getLayoutOptionProposals(element, responsibleAlgorithm, Target.EDGES, prefix);
@@ -112,7 +108,7 @@ public final class LayoutDataContentAssist {
      */
     public static List<Proposal<Object>> getLayoutOptionValueProposal(final LayoutOptionData option,
             final String prefix) {
-        List<Proposal<Object>> proposals = Lists.newArrayList();
+        List<Proposal<Object>> proposals = new ArrayList<>();
 
         switch (option.getType()) {
         case BOOLEAN:
@@ -156,7 +152,7 @@ public final class LayoutDataContentAssist {
     private static List<Proposal<LayoutOptionData>> getLayoutOptionProposals(final ElkGraphElement element,
             final LayoutAlgorithmData algorithmData, final LayoutOptionData.Target targetType, final String prefix) {
         return getLayoutOptionProposals(element, algorithmData,
-                targetType != null ? Sets.newHashSet(targetType) : Collections.emptySet(), prefix);
+                targetType != null ? new HashSet<>(Arrays.asList(targetType)) : Collections.emptySet(), prefix);
     }
 
     private static List<Proposal<LayoutOptionData>> getLayoutOptionProposals(final ElkGraphElement element,
@@ -193,7 +189,7 @@ public final class LayoutDataContentAssist {
 
         // Case 3)
         final boolean matchesName =
-                !Strings.isNullOrEmpty(prefix) && data.getName().toLowerCase().contains(prefix.toLowerCase());
+                !(prefix == null || prefix.isEmpty()) && data.getName().toLowerCase().contains(prefix.toLowerCase());
 
         List<String> idSplit = Arrays.asList(data.getId().split("\\."));
         List<String> prefixSplit = matchesName ? null : Arrays.asList(prefix.split("\\."));
@@ -202,16 +198,17 @@ public final class LayoutDataContentAssist {
         int start = idSplit.size() - 1;
         if (data instanceof LayoutOptionData) {
             LayoutOptionData layoutOption = (LayoutOptionData) data;
-            if (!Strings.isNullOrEmpty(layoutOption.getGroup())) {
+            String group = layoutOption.getGroup();
+            if (group != null && !group.isEmpty()) {
                 --start;
             }
-            long numberOfGroups = layoutOption.getGroup().chars().filter(c -> c == '.').count();
+            long numberOfGroups = group.chars().filter(c -> c == '.').count();
             start -= numberOfGroups;
         }
 
         for (int i = start; i >= 0; i--) {
             List<String> suffixElements = idSplit.subList(i, idSplit.size());
-            String suffix = Joiner.on('.').join(suffixElements);
+            String suffix = String.join(".", suffixElements);
             // Case 2) (note that Case 1 is included here)
             if (checker.apply(suffix) != null && (matchesName || startsWith(suffixElements, prefixSplit))) {
                 return Optional.of(Proposal.of(suffix, data));
@@ -252,7 +249,7 @@ public final class LayoutDataContentAssist {
         ElkNode relevantNode = getRelevantNode(element);
         if (relevantNode != null) {
             String algorithmId = relevantNode.getProperty(CoreOptions.ALGORITHM);
-            if (!Strings.isNullOrEmpty(algorithmId)) {
+            if (algorithmId != null && !algorithmId.isEmpty()) {
                 return LayoutMetaDataService.getInstance().getAlgorithmDataBySuffix(algorithmId);
             }
         }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
@@ -12,7 +12,9 @@ package org.eclipse.elk.core.data;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,10 +29,6 @@ import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.util.IndividualSpacings;
 import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.graph.util.ElkReflect;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * Singleton class for access to the ELK layout meta data. This class is used globally to retrieve meta data for
@@ -139,44 +137,44 @@ public final class LayoutMetaDataService {
                 (al) -> ((ArrayList) al).clone());
         ElkReflect.register(LinkedList.class, 
                 () -> new LinkedList(),
-                (ll) -> Lists.newLinkedList((LinkedList) ll));
+                (ll) -> new LinkedList((LinkedList) ll));
         ElkReflect.register(HashSet.class, 
                 () -> new HashSet(),
-                (hs) -> Sets.newHashSet((HashSet) hs));
+                (hs) -> new HashSet((HashSet) hs));
         ElkReflect.register(LinkedHashSet.class, 
                 () -> new LinkedHashSet(),
-                (hs) -> Sets.newLinkedHashSet((HashSet) hs));
+                (hs) -> new LinkedHashSet((HashSet) hs));
         ElkReflect.register(TreeSet.class, 
                 () -> new TreeSet(),
-                (ts) -> Sets.newTreeSet((TreeSet) ts));
+                (ts) -> new TreeSet((TreeSet) ts));
     }
 
     /**
      * Mapping of layout provider identifiers to their data instances.
      */
-    private final Map<String, LayoutAlgorithmData> layoutAlgorithmMap = Maps.newLinkedHashMap();
+    private final Map<String, LayoutAlgorithmData> layoutAlgorithmMap = new LinkedHashMap<>();
     /**
      * Mapping of layout option identifiers to their data instances.
      */
-    private final Map<String, LayoutOptionData> layoutOptionMap = Maps.newLinkedHashMap();
+    private final Map<String, LayoutOptionData> layoutOptionMap = new LinkedHashMap<>();
     /**
      * Mapping of legacy layout option identifiers to their data instances. Note that the actual layout option data
      * contain the new identifiers.
      */
-    private final Map<String, LayoutOptionData> legacyLayoutOptionMap = Maps.newLinkedHashMap();
+    private final Map<String, LayoutOptionData> legacyLayoutOptionMap = new LinkedHashMap<>();
     /**
      * Mapping of layout category identifiers to their data instances.
      */
-    private final Map<String, LayoutCategoryData> layoutCategoryMap = Maps.newLinkedHashMap();
+    private final Map<String, LayoutCategoryData> layoutCategoryMap = new LinkedHashMap<>();
     /**
      * Additional map of layout algorithm suffixes to data instances.
      */
-    private final Map<String, LayoutAlgorithmData> algorithmSuffixMap = Maps.newHashMap();
+    private final Map<String, LayoutAlgorithmData> algorithmSuffixMap = new HashMap<>();
     /**
      * Additional map of layout option suffixes to data instances. For layout options this include the layout option's
      * group.
      */
-    private final Map<String, LayoutOptionData> optionSuffixMap = Maps.newHashMap();
+    private final Map<String, LayoutOptionData> optionSuffixMap = new HashMap<>();
 
     /**
      * Registers the data provided by the given meta data providers with the meta data service.

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutOptionData.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutOptionData.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.core.data;
 
 import java.util.EnumSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -18,8 +19,6 @@ import org.eclipse.elk.core.util.Pair;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.Property;
 import org.eclipse.elk.graph.util.ElkReflect;
-
-import com.google.common.collect.Lists;
 
 /**
  * Data type used to store information for a layout option.
@@ -92,7 +91,7 @@ public final class LayoutOptionData implements ILayoutMetaData, IProperty<Object
     /** configured targets. */
     private final Set<Target> targets;
     /** dependencies to other layout options. */
-    private final List<Pair<LayoutOptionData, Object>> dependencies = Lists.newLinkedList();
+    private final List<Pair<LayoutOptionData, Object>> dependencies = new LinkedList<>();
     /** cached value of the available choices. */
     private String[] choices;
     /** visibility in the UI. */

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkMath.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/math/ElkMath.java
@@ -12,8 +12,6 @@ package org.eclipse.elk.core.math;
 import java.util.Iterator;
 import java.util.ListIterator;
 
-import com.google.common.math.DoubleMath;
-
 /**
  * Mathematics utility class for the Eclipse Layout Kernel.
  * 
@@ -25,6 +23,22 @@ public final class ElkMath {
      * Hidden constructor to avoid instantiation.
      */
     private ElkMath() {
+    }
+
+    private static boolean fuzzyEquals(final double a, final double b, final double tolerance) {
+        return Math.abs(a - b) <= tolerance
+                || Double.valueOf(a).equals(Double.valueOf(b));
+    }
+
+    private static int fuzzyCompare(final double a, final double b, final double tolerance) {
+        if (fuzzyEquals(a, b, tolerance)) {
+            return 0;
+        } else if (a < b) {
+            return -1;
+        } else if (a > b) {
+            return 1;
+        }
+        return Boolean.compare(Double.isNaN(a), Double.isNaN(b));
     }
 
     /** table of precomputed factorial values. */
@@ -1012,7 +1026,7 @@ public final class ElkMath {
         double x11 = v1.x, y11 = v1.y;
         
         double d = x11 * y01 - x01 * y11;
-        if (DoubleMath.fuzzyEquals(0, d, DOUBLE_EQ_EPSILON)) {
+        if (fuzzyEquals(0, d, DOUBLE_EQ_EPSILON)) {
             return false;
         }
         double s = (1 / d) * ((x00 - x10) * y01 - (y00 - y10) * x01);
@@ -1022,13 +1036,13 @@ public final class ElkMath {
         // use < instead of <= to not recognize "touching" as intersection
         final boolean intersects =
                 // 0 < s
-                DoubleMath.fuzzyCompare(0, s, DOUBLE_EQ_EPSILON) < 0
+                fuzzyCompare(0, s, DOUBLE_EQ_EPSILON) < 0
                 // s < 1
-                && DoubleMath.fuzzyCompare(s, 1, DOUBLE_EQ_EPSILON) < 0
+                && fuzzyCompare(s, 1, DOUBLE_EQ_EPSILON) < 0
                 // 0 < t
-                && DoubleMath.fuzzyCompare(0, t, DOUBLE_EQ_EPSILON) < 0
+                && fuzzyCompare(0, t, DOUBLE_EQ_EPSILON) < 0
                 // t < 1
-                && DoubleMath.fuzzyCompare(t, 1, DOUBLE_EQ_EPSILON) < 0;
+                && fuzzyCompare(t, 1, DOUBLE_EQ_EPSILON) < 0;
         return intersects;
     }
     
@@ -1254,11 +1268,11 @@ public final class ElkMath {
         double bottomDist = r2.y - (r1.y + r1.height);
         double horzDist = Math.max(leftDist, rightDist);
         double vertDist = Math.max(topDist, bottomDist);
-        if (DoubleMath.fuzzyCompare(horzDist, 0, DOUBLE_EQ_EPSILON) >= 0 
-                ^ DoubleMath.fuzzyCompare(vertDist, 0, DOUBLE_EQ_EPSILON) >= 0) { // case 1
+        if (fuzzyCompare(horzDist, 0, DOUBLE_EQ_EPSILON) >= 0
+                ^ fuzzyCompare(vertDist, 0, DOUBLE_EQ_EPSILON) >= 0) { // case 1
             return Math.max(vertDist, horzDist);
         }
-        if (DoubleMath.fuzzyCompare(horzDist, 0, DOUBLE_EQ_EPSILON) > 0) { // case 2
+        if (fuzzyCompare(horzDist, 0, DOUBLE_EQ_EPSILON) > 0) { // case 2
             return Math.sqrt(vertDist * vertDist + horzDist * horzDist);
         }
         // case 3

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/NodeLabelPlacement.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/NodeLabelPlacement.java
@@ -12,8 +12,6 @@ package org.eclipse.elk.core.options;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
-
 /**
  * Options for controlling how node labels are placed by layout algorithms. The corresponding layout
  * option will usually accept an {@link EnumSet} over this enumeration, theoretically allowing
@@ -252,19 +250,19 @@ public enum NodeLabelPlacement {
     public static boolean isValid(final Set<NodeLabelPlacement> placement) {
         final Set<NodeLabelPlacement> validInsideOutside =
                 EnumSet.of(NodeLabelPlacement.INSIDE, NodeLabelPlacement.OUTSIDE);
-        if (Sets.intersection(validInsideOutside, placement).size() > 1) {
+        if (validInsideOutside.stream().filter(placement::contains).count() > 1) {
             return false;
         }
 
         final Set<NodeLabelPlacement> validHorizontal =
                 EnumSet.of(NodeLabelPlacement.H_LEFT, NodeLabelPlacement.H_CENTER, NodeLabelPlacement.H_RIGHT);
-        if (Sets.intersection(validHorizontal, placement).size() > 1) {
+        if (validHorizontal.stream().filter(placement::contains).count() > 1) {
             return false;
         }
 
         final Set<NodeLabelPlacement> validVertical =
                 EnumSet.of(NodeLabelPlacement.V_TOP, NodeLabelPlacement.V_CENTER, NodeLabelPlacement.V_BOTTOM);
-        if (Sets.intersection(validVertical, placement).size() > 1) {
+        if (validVertical.stream().filter(placement::contains).count() > 1) {
             return false;
         }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortLabelPlacement.java
@@ -12,8 +12,6 @@ package org.eclipse.elk.core.options;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
-
 /**
  * Options for controlling how port labels are placed by layout algorithms. The corresponding layout
  * option will usually accept an {@link EnumSet} over this enumeration, theoretically allowing
@@ -125,7 +123,7 @@ public enum PortLabelPlacement {
     public static boolean isValid(final Set<PortLabelPlacement> placement) {
         final Set<PortLabelPlacement> validInsideOutside =
                 EnumSet.of(PortLabelPlacement.INSIDE, PortLabelPlacement.OUTSIDE);
-        if (Sets.intersection(validInsideOutside, placement).size() > 1) {
+        if (validInsideOutside.stream().filter(placement::contains).count() > 1) {
             return false;
         }
 
@@ -133,7 +131,7 @@ public enum PortLabelPlacement {
                 EnumSet.of(PortLabelPlacement.ALWAYS_SAME_SIDE,
                         PortLabelPlacement.ALWAYS_OTHER_SAME_SIDE,
                         PortLabelPlacement.SPACE_EFFICIENT);
-        if (Sets.intersection(validPosition, placement).size() > 1) {
+        if (validPosition.stream().filter(placement::contains).count() > 1) {
             return false;
         }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortSide.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/options/PortSide.java
@@ -13,8 +13,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
-
 /**
  * Definition of port sides on a node. Besides defining the actual available port sides, this enumeration
  * also defines convenience methods as well as constants with all possible port side combinations. The
@@ -44,50 +42,50 @@ public enum PortSide {
     public static final Set<PortSide> SIDES_NONE = Collections.unmodifiableSet(
             EnumSet.noneOf(PortSide.class));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH = Sets.immutableEnumSet(
-            PortSide.NORTH);
+    public static final Set<PortSide> SIDES_NORTH = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_EAST = Sets.immutableEnumSet(
-            PortSide.EAST);
+    public static final Set<PortSide> SIDES_EAST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.EAST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_SOUTH = Sets.immutableEnumSet(
-            PortSide.SOUTH);
+    public static final Set<PortSide> SIDES_SOUTH = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.SOUTH));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_WEST = Sets.immutableEnumSet(
-            PortSide.WEST);
+    public static final Set<PortSide> SIDES_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.WEST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH_SOUTH = Sets.immutableEnumSet(
-            PortSide.NORTH, PortSide.SOUTH);
+    public static final Set<PortSide> SIDES_NORTH_SOUTH = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH, PortSide.SOUTH));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_EAST_WEST = Sets.immutableEnumSet(
-            PortSide.EAST, PortSide.WEST);
+    public static final Set<PortSide> SIDES_EAST_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.EAST, PortSide.WEST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH_WEST = Sets.immutableEnumSet(
-            PortSide.NORTH, PortSide.WEST);
+    public static final Set<PortSide> SIDES_NORTH_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH, PortSide.WEST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH_EAST = Sets.immutableEnumSet(
-            PortSide.NORTH, PortSide.EAST);
+    public static final Set<PortSide> SIDES_NORTH_EAST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH, PortSide.EAST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_SOUTH_WEST = Sets.immutableEnumSet(
-            PortSide.SOUTH, PortSide.WEST);
+    public static final Set<PortSide> SIDES_SOUTH_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.SOUTH, PortSide.WEST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_EAST_SOUTH = Sets.immutableEnumSet(
-            PortSide.EAST, PortSide.SOUTH);
+    public static final Set<PortSide> SIDES_EAST_SOUTH = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.EAST, PortSide.SOUTH));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH_EAST_WEST = Sets.immutableEnumSet(
-            PortSide.NORTH, PortSide.EAST, PortSide.WEST);
+    public static final Set<PortSide> SIDES_NORTH_EAST_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH, PortSide.EAST, PortSide.WEST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_EAST_SOUTH_WEST = Sets.immutableEnumSet(
-            PortSide.EAST, PortSide.SOUTH, PortSide.WEST);
+    public static final Set<PortSide> SIDES_EAST_SOUTH_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.EAST, PortSide.SOUTH, PortSide.WEST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH_SOUTH_WEST = Sets.immutableEnumSet(
-            PortSide.NORTH, PortSide.SOUTH, PortSide.WEST);
+    public static final Set<PortSide> SIDES_NORTH_SOUTH_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH, PortSide.SOUTH, PortSide.WEST));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH_EAST_SOUTH = Sets.immutableEnumSet(
-            PortSide.NORTH, PortSide.EAST, PortSide.SOUTH);
+    public static final Set<PortSide> SIDES_NORTH_EAST_SOUTH = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH, PortSide.EAST, PortSide.SOUTH));
     /** Immutable set containing the given port sides. */
-    public static final Set<PortSide> SIDES_NORTH_EAST_SOUTH_WEST = Sets.immutableEnumSet(
-            PortSide.NORTH, PortSide.EAST, PortSide.SOUTH, PortSide.WEST);
+    public static final Set<PortSide> SIDES_NORTH_EAST_SOUTH_WEST = Collections.unmodifiableSet(EnumSet.of(
+            PortSide.NORTH, PortSide.EAST, PortSide.SOUTH, PortSide.WEST));
     
     
     //////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/AbstractRandomListAccessor.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/AbstractRandomListAccessor.java
@@ -9,9 +9,8 @@
  *******************************************************************************/
 package org.eclipse.elk.core.util;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import com.google.common.collect.Lists;
 
 /**
  * Base class for classes that want to randomly access a list of elements. Access to non-existent list elements is
@@ -30,7 +29,7 @@ public abstract class AbstractRandomListAccessor<T> {
      * Creates a new instance.
      */
     protected AbstractRandomListAccessor() {
-        list = Lists.newArrayList();
+        list = new ArrayList<>();
     }
     
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/BasicProgressMonitor.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/BasicProgressMonitor.java
@@ -22,9 +22,6 @@ import java.util.List;
 import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-
 /**
  * Base class for implementations of progress monitors. This class performs execution time measurement, logs debug
  * output, keeps track of the amount of completed work, and handles sub-tasks properly.
@@ -403,7 +400,7 @@ public class BasicProgressMonitor implements IElkProgressMonitor {
                     try {
                         Files.write(
                                 outputFile,
-                                Lists.newArrayList(logMessage),
+                                new ArrayList<>(java.util.Arrays.asList(logMessage)),
                                 StandardOpenOption.APPEND,
                                 StandardOpenOption.CREATE);
                     } catch (IOException e) {
@@ -438,7 +435,7 @@ public class BasicProgressMonitor implements IElkProgressMonitor {
             // elkjs-exclude-start
             if (persistLogs) {
                 // Find out which file to write to
-                String actualTag = Strings.isNullOrEmpty(tag) ? "Unnamed" : tag;
+                String actualTag = (tag == null || tag.isEmpty()) ? "Unnamed" : tag;
                 Path filePath = retrieveFilePath(actualTag, graphType.getFileExtension());
                 
                 // Write to the file
@@ -446,7 +443,7 @@ public class BasicProgressMonitor implements IElkProgressMonitor {
                     try {
                         Files.write(
                                 filePath,
-                                Lists.newArrayList(loggedGraph.serialize()),
+                                new ArrayList<>(java.util.Arrays.asList(loggedGraph.serialize())),
                                 StandardOpenOption.WRITE,
                                 StandardOpenOption.CREATE);
                     } catch (IOException e) {
@@ -537,7 +534,7 @@ public class BasicProgressMonitor implements IElkProgressMonitor {
         char randChar2 = (char) ('a' + (int) (Math.random() * validCharacterRange));
         
         String name = getTaskName();
-        if (com.google.common.base.Strings.isNullOrEmpty(name)) {
+        if (name == null || name.isEmpty()) {
             name = "Unnamed";
         }
 
@@ -562,7 +559,7 @@ public class BasicProgressMonitor implements IElkProgressMonitor {
         int index = getParentMonitor().getSubMonitors().indexOf(this);
         
         String name = getTaskName();
-        if (com.google.common.base.Strings.isNullOrEmpty(name)) {
+        if (name == null || name.isEmpty()) {
             name = "Unnamed";
         }
         // elkjs-exclude-start

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/BoxLayoutProvider.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/BoxLayoutProvider.java
@@ -26,8 +26,6 @@ import org.eclipse.elk.core.options.BoxLayouterOptions;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.graph.ElkNode;
 
-import com.google.common.collect.Lists;
-
 /**
  * A layout algorithm that does not take edges into account, but treats all nodes as isolated boxes.
  * This is useful for parts of a diagram that consist of objects without connections, such as
@@ -311,7 +309,7 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
         }
 
         // wrap boxes in groups
-        List<Group> groups = Lists.newArrayList();
+        List<Group> groups = new ArrayList<>();
         for (ElkNode node : parentNode.getChildren()) {
             Group g = new Group(node);
             groups.add(g);
@@ -392,7 +390,7 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
         LinkedList<Double> rowHeights = new LinkedList<>();
         ListIterator<Group> boxIter = group.groups.listIterator();
         Group last = null;
-        List<Group> bottoms = Lists.newArrayList();
+        List<Group> bottoms = new ArrayList<>();
         while (boxIter.hasNext()) {
             Group box = boxIter.next();
             double width = box.getWidth();
@@ -483,9 +481,9 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
         // the code below makes relies on this
         Collections.sort(groups, (g1, g2) -> -Double.compare(g1.area(), g2.area()));
         
-        Queue<Group> boxQueue = Lists.newLinkedList(groups);
-        List<Group> toBePlaced = Lists.newArrayList();
-        List<Group> maybeGroup = Lists.newArrayList();
+        Queue<Group> boxQueue = new LinkedList<>(groups);
+        List<Group> toBePlaced = new ArrayList<>();
+        List<Group> maybeGroup = new ArrayList<>();
         
         // current 'large' node and the combined area of 'smaller' nodes
         Group boxToBeat = null;         
@@ -547,7 +545,7 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
         pq.addAll(groups);
         
         int index = 0;
-        List<Group> toBePlaced = Lists.newArrayList();
+        List<Group> toBePlaced = new ArrayList<>();
         
         while (!pq.isEmpty()) {
             // only take a look, we might not want to remove it
@@ -613,7 +611,7 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
         Collections.sort(groups, (g1, g2) -> Double.compare(g1.area(), g2.area()));
         
         ListIterator<Group> groupIterator = groups.listIterator();
-        List<Group> toBePlaced = Lists.newArrayList();
+        List<Group> toBePlaced = new ArrayList<>();
         double commonArea = 0;
 
         while (groupIterator.hasNext()) {
@@ -699,9 +697,10 @@ public class BoxLayoutProvider extends AbstractLayoutProvider {
         }
         
         Group(final Iterable<Group> groups) {
-            this.groups = Lists.newArrayList(groups);
-            this.bottom = Lists.newArrayList();
-            this.right = Lists.newArrayList();
+            this.groups = new ArrayList<>();
+            groups.forEach(this.groups::add);
+            this.bottom = new ArrayList<>();
+            this.right = new ArrayList<>();
             this.size = new KVector();
         }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkSpacings.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkSpacings.java
@@ -9,6 +9,10 @@
  ********************************************************************************/
 package org.eclipse.elk.core.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -19,11 +23,6 @@ import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.graph.ElkGraphElement;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.math.DoubleMath;
 
 /**
  * Utility class to conveniently configure core spacing values ({@link CoreOptions#SPACING_*}) for a graph element or a
@@ -54,7 +53,7 @@ public final class ElkSpacings {
         public static final IProperty<Double> BASE_SPACING_OPTION = CoreOptions.SPACING_NODE_NODE;
         
         // @formatter:off
-        private static final List<IProperty<Double>> DEPENDENT_SPACING_OPTIONS = Lists.newArrayList(
+        private static final List<IProperty<Double>> DEPENDENT_SPACING_OPTIONS = Arrays.asList(
             // Sorted alphabetically
             CoreOptions.SPACING_COMPONENT_COMPONENT,
             CoreOptions.SPACING_EDGE_EDGE,
@@ -72,7 +71,7 @@ public final class ElkSpacings {
         static {
             assert BASE_SPACING_OPTION.getDefault() != null : "Base spacing default value must be non-null.";
             // Avoid division by zero.
-            assert !DoubleMath.fuzzyEquals(0.0d, BASE_SPACING_OPTION.getDefault(),
+            assert !(Math.abs(0.0d - BASE_SPACING_OPTION.getDefault()) <=
                     DOUBLE_EQ_EPSILON) : "Base spacing default value must be different from 0.0d.";
         }
         
@@ -134,13 +133,13 @@ public final class ElkSpacings {
         /** Whether the resulting configurator shall overwrite existing spacing option values. */
         private boolean overwrite = false;
         /** Filters to be applied by the resulting configurator. Elements specified directly here are always applied. */
-        private List<IPropertyHolderOptionFilter> filters = Lists.newArrayList(ELK_OPTION_TARGET_FILTER);
+        private List<IPropertyHolderOptionFilter> filters = new ArrayList<>(Arrays.asList(ELK_OPTION_TARGET_FILTER));
         
         /**
          * Internal mapping of dependent layout options to factors that must be applied to those option's default 
          * values when setting the spacing value for a concrete node.
          */
-        private Map<IProperty<Double>, Double> factorMap = Maps.newHashMap();
+        private Map<IProperty<Double>, Double> factorMap = new HashMap<>();
                 
         /**
          * Constructs a new builder and computes the initial factors based on the passed based value.
@@ -201,7 +200,7 @@ public final class ElkSpacings {
          * @return an immutable list of the currently configured factors.
          */
         public Map<IProperty<Double>, Double> getFactors() {
-            return ImmutableMap.copyOf(factorMap);
+            return Collections.unmodifiableMap(new HashMap<>(factorMap));
         }
 
         /**
@@ -271,7 +270,7 @@ public final class ElkSpacings {
             // Early exit if we are not allowed to overwrite any options and if the specified base matches the default
             // values anyway
             if (!overwrite
-                    && DoubleMath.fuzzyEquals(baseSpacing, getBaseSpacingOption().getDefault(), DOUBLE_EQ_EPSILON)) {
+                    && Math.abs(baseSpacing - getBaseSpacingOption().getDefault()) <= DOUBLE_EQ_EPSILON) {
                 return e -> { };
             }
 

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkUtil.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/ElkUtil.java
@@ -12,12 +12,17 @@ package org.eclipse.elk.core.util;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.elk.core.math.ElkMargin;
 import org.eclipse.elk.core.math.ElkRectangle;
@@ -50,12 +55,6 @@ import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.ElkShape;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.emf.ecore.EObject;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * Utility methods for layout-related things.
@@ -384,9 +383,13 @@ public final class ElkUtil {
 
         node.setDimensions(scalingFactor * node.getWidth(), scalingFactor * node.getHeight());
 
-        final Iterable<ElkLabel> portLabels = Iterables.concat(
-                Iterables.transform(node.getPorts(), p -> p.getLabels()));
-        for (ElkShape shape : Iterables.concat(node.getLabels(), node.getPorts(), portLabels)) {
+        List<ElkShape> scalingShapes = new ArrayList<>();
+        scalingShapes.addAll(node.getLabels());
+        scalingShapes.addAll(node.getPorts());
+        for (ElkPort p : node.getPorts()) {
+            scalingShapes.addAll(p.getLabels());
+        }
+        for (ElkShape shape : scalingShapes) {
             shape.setLocation(scalingFactor * shape.getX(), scalingFactor * shape.getY());
             shape.setDimensions(scalingFactor * shape.getWidth(), scalingFactor * shape.getHeight());
 
@@ -411,11 +414,13 @@ public final class ElkUtil {
         double maxY = 0.0;
         
         // iterate over all nodes and labels and get their coordinate bounds
-        Iterable<ElkLabel> edgeLabels = new ArrayList<>();
+        List<ElkShape> areaShapes = new ArrayList<>();
+        areaShapes.addAll(node.getLabels());
+        areaShapes.addAll(node.getChildren());
         for (ElkEdge edge : node.getContainedEdges()) {
-            edgeLabels = Iterables.concat(edgeLabels, edge.getLabels());
+            areaShapes.addAll(edge.getLabels());
         }
-        for (ElkShape shape : Iterables.concat(node.getLabels(), node.getChildren(), edgeLabels)) {
+        for (ElkShape shape : areaShapes) {
 
             ElkMargin margins = shape.getProperty(CoreOptions.MARGINS);
             if (minX > shape.getX() - margins.left) {
@@ -520,15 +525,15 @@ public final class ElkUtil {
         KVectorChain junctionPoints = new KVectorChain();
 
         // Store the points of the edge in a map for efficiency
-        Map<ElkEdgeSection, ArrayList<KVector>> pointsMap = Maps.newHashMap();
+        Map<ElkEdgeSection, ArrayList<KVector>> pointsMap = new HashMap<>();
         ArrayList<KVector> sectionPoints = getPoints(section);
         pointsMap.put(section, sectionPoints);
 
         // Store the offset of the other edges
-        Map<ElkEdgeSection, KVector> offsetMap = Maps.newHashMap();
+        Map<ElkEdgeSection, KVector> offsetMap = new HashMap<>();
 
         // let allConnectedEdges be the set of edge sections connected to port without the main edge
-        List<ElkEdgeSection> allConnectedSections = Lists.newLinkedList();
+        List<ElkEdgeSection> allConnectedSections = new LinkedList<>();
         for (ElkEdge otherEdge : ElkGraphUtil.allIncidentEdges(port)) {
             if (edge.getSections().size() != 1) {
                 throw new IllegalArgumentException(
@@ -979,12 +984,12 @@ public final class ElkUtil {
      *            the graph to configure.
      */
     public static void configureDefaultsRecursively(final ElkNode graph) {
-        // note that Iterators#filter(Iterator, Class) isn't used on purpose since
-        // it's incompatible with gwt
-        Iterator<EObject> kgeIt = Iterators.filter(graph.eAllContents(),
-            e -> e instanceof ElkGraphElement);
-        while (kgeIt.hasNext()) {
-            EObject kge = kgeIt.next();
+        Iterator<EObject> allIt = graph.eAllContents();
+        while (allIt.hasNext()) {
+            EObject kge = allIt.next();
+            if (!(kge instanceof ElkGraphElement)) {
+                continue;
+            }
             if (kge instanceof ElkNode) {
                 configureWithDefaultValues((ElkNode) kge);
             } else if (kge instanceof ElkPort) {
@@ -1059,7 +1064,7 @@ public final class ElkUtil {
      */
     private static void ensureLabel(final ElkGraphElement klge) {
         if (klge.getLabels().isEmpty()) {
-            if (!Strings.isNullOrEmpty(klge.getIdentifier())) {
+            if (klge.getIdentifier() != null && !klge.getIdentifier().isEmpty()) {
                 ElkLabel label = ElkGraphUtil.createLabel(klge);
                 label.setText(klge.getIdentifier());
             }
@@ -1165,21 +1170,21 @@ public final class ElkUtil {
 
         // Print the identifier if present
         String identifier = element.getIdentifier();
-        if (!Strings.isNullOrEmpty(identifier)) {
+        if (identifier != null && !identifier.isEmpty()) {
             builder.append(' ').append(identifier);
             return;
         }
         // Print the label if present
         if (element instanceof ElkLabel) {
             String text = ((ElkLabel) element).getText();
-            if (!Strings.isNullOrEmpty(text)) {
+            if (text != null && !text.isEmpty()) {
                 builder.append(' ').append(text);
                 return;
             }
         }
         for (ElkLabel label : element.getLabels()) {
             String text = label.getText();
-            if (!Strings.isNullOrEmpty(text)) {
+            if (text != null && !text.isEmpty()) {
                 builder.append(' ').append(text);
                 return;
             }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/IndividualSpacings.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/IndividualSpacings.java
@@ -20,8 +20,6 @@ import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
 import org.eclipse.elk.graph.properties.MapPropertyHolder;
 
-import com.google.common.base.Strings;
-
 /**
  * A property holder which can be used to define individual spacing overrides. The overrides are applied to the
  * element this object is set on, which is done through the {@link CoreOptions#SPACING_INDIVIDUAL} property.
@@ -125,7 +123,7 @@ public class IndividualSpacings extends MapPropertyHolder implements IDataObject
      */
     @Override
     public void parse(final String string) {
-        if (Strings.isNullOrEmpty(string)) {
+        if (string == null || string.isEmpty()) {
             // Nothing to do.
             return;
         }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/PropertyConstantsDelegator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/PropertyConstantsDelegator.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package org.eclipse.elk.core.util;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.elk.core.data.LayoutAlgorithmData;
@@ -20,8 +21,6 @@ import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
 import org.eclipse.elk.graph.properties.Property;
-
-import com.google.common.collect.Maps;
 
 /**
  * Allows to reroute access to properties through other property constants which may provide different default values.
@@ -50,7 +49,7 @@ import com.google.common.collect.Maps;
 public final class PropertyConstantsDelegator {
     
     /** Set of property constants to be used for accessing their respective property. */
-    private Map<IProperty<?>, IProperty<?>> propertyDelegates = Maps.newHashMap();
+    private Map<IProperty<?>, IProperty<?>> propertyDelegates = new HashMap<>();
 
     
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/RandomLayoutProvider.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/RandomLayoutProvider.java
@@ -24,8 +24,6 @@ import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 
-import com.google.common.collect.Iterables;
-
 /**
  * Layout provider that computes random layouts. Can be useful to demonstrate the difference
  * between a good layout and an extremely bad one.
@@ -85,7 +83,9 @@ public class RandomLayoutProvider extends AbstractLayoutProvider {
         double nodesArea = 0.0f, maxWidth = 0.0f, maxHeight = 0.0f;
         int m = 1;
         for (ElkNode node : parent.getChildren()) {
-            m += Iterables.size(ElkGraphUtil.allOutgoingEdges(node));
+            for (ElkEdge ignored : ElkGraphUtil.allOutgoingEdges(node)) {
+                m++;
+            }
             
             double width = node.getWidth();
             maxWidth = Math.max(maxWidth, width);

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/adapters/ElkGraphAdapters.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/adapters/ElkGraphAdapters.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package org.eclipse.elk.core.util.adapters;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -35,8 +36,6 @@ import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.Property;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.emf.common.util.ECollections;
-
-import com.google.common.collect.Lists;
 
 /**
  * Contains implementations of the {@link GraphAdapters} interfaces for the ElkGraph. To obtain an
@@ -215,7 +214,7 @@ public final class ElkGraphAdapters {
         @Override
         public Iterable<NodeAdapter<?>> getNodes() {
             if (childNodes == null) {
-                childNodes = Lists.newArrayListWithExpectedSize(element.getChildren().size());
+                childNodes = new ArrayList<>(element.getChildren().size());
                 for (ElkNode n : element.getChildren()) {
                     childNodes.add(new ElkNodeAdapter(this, n));
                 }
@@ -264,7 +263,7 @@ public final class ElkGraphAdapters {
         @Override
         public List<LabelAdapter<?>> getLabels() {
             if (labelAdapters == null) {
-                labelAdapters = Lists.newArrayListWithExpectedSize(element.getLabels().size());
+                labelAdapters = new ArrayList<>(element.getLabels().size());
                 for (ElkLabel l : element.getLabels()) {
                     labelAdapters.add(new ElkLabelAdapter(l));
                 }
@@ -275,7 +274,7 @@ public final class ElkGraphAdapters {
         @Override
         public List<PortAdapter<?>> getPorts() {
             if (portAdapters == null) {
-                portAdapters = Lists.newArrayListWithExpectedSize(element.getPorts().size());
+                portAdapters = new ArrayList<>(element.getPorts().size());
                 for (ElkPort p : element.getPorts()) {
                     portAdapters.add(new ElkPortAdapter(p));
                 }
@@ -286,7 +285,7 @@ public final class ElkGraphAdapters {
         @Override
         public Iterable<EdgeAdapter<?>> getIncomingEdges() {
             if (incomingEdgeAdapters == null) {
-                incomingEdgeAdapters = Lists.newArrayList();
+                incomingEdgeAdapters = new ArrayList<>();
                 for (ElkEdge e : ElkGraphUtil.allIncomingEdges(element)) {
                     incomingEdgeAdapters.add(new ElkEdgeAdapter(e));
                 }
@@ -297,7 +296,7 @@ public final class ElkGraphAdapters {
         @Override
         public Iterable<EdgeAdapter<?>> getOutgoingEdges() {
             if (outgoingEdgeAdapters == null) {
-                outgoingEdgeAdapters = Lists.newArrayList();
+                outgoingEdgeAdapters = new ArrayList<>();
                 for (ElkEdge e : ElkGraphUtil.allOutgoingEdges(element)) {
                     outgoingEdgeAdapters.add(new ElkEdgeAdapter(e));
                 }
@@ -384,7 +383,7 @@ public final class ElkGraphAdapters {
 
         public List<LabelAdapter<?>> getLabels() {
             if (labelAdapters == null) {
-                labelAdapters = Lists.newArrayListWithExpectedSize(element.getLabels().size());
+                labelAdapters = new ArrayList<>(element.getLabels().size());
                 for (ElkLabel l : element.getLabels()) {
                     labelAdapters.add(new ElkLabelAdapter(l));
                 }
@@ -394,7 +393,7 @@ public final class ElkGraphAdapters {
 
         public Iterable<EdgeAdapter<?>> getIncomingEdges() {
             if (incomingEdgeAdapters == null) {
-                incomingEdgeAdapters = Lists.newArrayListWithCapacity(element.getIncomingEdges().size());
+                incomingEdgeAdapters = new ArrayList<>(element.getIncomingEdges().size());
                 for (ElkEdge e : element.getIncomingEdges()) {
                     incomingEdgeAdapters.add(new ElkEdgeAdapter(e));
                 }
@@ -404,7 +403,7 @@ public final class ElkGraphAdapters {
 
         public Iterable<EdgeAdapter<?>> getOutgoingEdges() {
             if (outgoingEdgeAdapters == null) {
-                outgoingEdgeAdapters = Lists.newArrayListWithCapacity(element.getOutgoingEdges().size());
+                outgoingEdgeAdapters = new ArrayList<>(element.getOutgoingEdges().size());
                 for (ElkEdge e : element.getOutgoingEdges()) {
                     outgoingEdgeAdapters.add(new ElkEdgeAdapter(e));
                 }
@@ -464,7 +463,7 @@ public final class ElkGraphAdapters {
 
         public Iterable<LabelAdapter<?>> getLabels() {
             if (labelAdapters == null) {
-                labelAdapters = Lists.newArrayListWithExpectedSize(element.getLabels().size());
+                labelAdapters = new ArrayList<>(element.getLabels().size());
                 for (ElkLabel l : element.getLabels()) {
                     labelAdapters.add(new ElkLabelAdapter(l));
                 }

--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/selection/DefaultSelectionIterator.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/util/selection/DefaultSelectionIterator.java
@@ -9,16 +9,16 @@
  *******************************************************************************/
 package org.eclipse.elk.core.util.selection;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 
 import org.eclipse.elk.graph.ElkConnectableShape;
 import org.eclipse.elk.graph.ElkEdge;
 import org.eclipse.elk.graph.ElkGraphElement;
 import org.eclipse.elk.graph.ElkPort;
-
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Sets;
 
 /**
  * The default {@link SelectionIterator} for usage in
@@ -59,7 +59,7 @@ public class DefaultSelectionIterator extends SelectionIterator {
     protected Iterator<? extends ElkGraphElement> getChildren(final Object object) {
         // Ensure that the visited set is properly initialized
         if (visited == null) {
-            visited = Sets.newHashSet();
+            visited = new HashSet<>();
         }
         
         if (object instanceof ElkEdge) {
@@ -86,9 +86,10 @@ public class DefaultSelectionIterator extends SelectionIterator {
 
             // If the port should be added to the selection, add it to the result set
             if (addPorts) {
-                Iterator<ElkGraphElement> portIterator =
-                        Iterators.singletonIterator((ElkGraphElement) port);
-                return Iterators.concat(portIterator, resultEdges);
+                List<ElkGraphElement> combined = new ArrayList<>();
+                combined.add(port);
+                resultEdges.forEachRemaining(combined::add);
+                return combined.iterator();
             } else {
                 return resultEdges;
             }

--- a/plugins/org.eclipse.elk.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.elk.graph/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Export-Package: org.eclipse.elk.graph,
  org.eclipse.elk.graph.impl,
  org.eclipse.elk.graph.properties,
  org.eclipse.elk.graph.util
-Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.0",
- com.google.guava
+Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkEdgeImpl.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkEdgeImpl.java
@@ -28,8 +28,7 @@ import org.eclipse.emf.ecore.util.EObjectWithInverseResolvingEList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
+import java.util.stream.Collectors;
 
 /**
  * <!-- begin-user-doc -->
@@ -462,11 +461,11 @@ public class ElkEdgeImpl extends ElkGraphElementImpl implements ElkEdge {
         StringBuilder builder = new StringBuilder("ElkEdge");
         // Use identifier or labels
         String id = getIdentifier();
-        if (!Strings.isNullOrEmpty(id)) {
+        if (id != null && !id.isEmpty()) {
             builder.append(" \"").append(id).append("\"");
         } else if (getLabels().size() > 0) {
             String text = getLabels().get(0).getText();
-            if (!Strings.isNullOrEmpty(text)) {
+            if (text != null && !text.isEmpty()) {
                 builder.append(" \"").append(text).append("\"");
             }
         }
@@ -477,7 +476,7 @@ public class ElkEdgeImpl extends ElkGraphElementImpl implements ElkEdge {
         } else {
             builder.append(" ");
         }
-        builder.append(Joiner.on(", ").join(sources));
+        builder.append(sources.stream().map(Object::toString).collect(Collectors.joining(", ")));
         if (hyperedge) {
             builder.append("]");
         }
@@ -485,7 +484,7 @@ public class ElkEdgeImpl extends ElkGraphElementImpl implements ElkEdge {
         if (hyperedge) {
             builder.append("[");
         }
-        builder.append(Joiner.on(", ").join(targets));
+        builder.append(targets.stream().map(Object::toString).collect(Collectors.joining(", ")));
         if (hyperedge) {
             builder.append("]");
         }

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkLabelImpl.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkLabelImpl.java
@@ -23,8 +23,6 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
-import com.google.common.base.Strings;
-
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Elk Label</b></em>'.
@@ -264,7 +262,7 @@ public class ElkLabelImpl extends ElkShapeImpl implements ElkLabel {
 
         StringBuilder builder = new StringBuilder("ElkLabel");
         // Label text
-        if (!Strings.isNullOrEmpty(text)) {
+        if (text != null && !text.isEmpty()) {
             builder.append(" \"").append(text).append("\"");
         }
         // Position

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkNodeImpl.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkNodeImpl.java
@@ -30,8 +30,6 @@ import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 
-import com.google.common.base.Strings;
-
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Elk Node</b></em>'.
@@ -360,11 +358,11 @@ public class ElkNodeImpl extends ElkConnectableShapeImpl implements ElkNode {
         StringBuilder builder = new StringBuilder("ElkNode");
         // Use identifier or labels
         String id = getIdentifier();
-        if (!Strings.isNullOrEmpty(id)) {
+        if (id != null && !id.isEmpty()) {
             builder.append(" \"").append(id).append("\"");
         } else if (getLabels().size() > 0) {
             String text = getLabels().get(0).getText();
-            if (!Strings.isNullOrEmpty(text)) {
+            if (text != null && !text.isEmpty()) {
                 builder.append(" \"").append(text).append("\"");
             }
         }

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkPortImpl.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/impl/ElkPortImpl.java
@@ -23,8 +23,6 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
-import com.google.common.base.Strings;
-
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Elk Port</b></em>'.
@@ -213,11 +211,11 @@ public class ElkPortImpl extends ElkConnectableShapeImpl implements ElkPort {
         StringBuilder builder = new StringBuilder("ElkPort");
         // Use identifier or labels
         String id = getIdentifier();
-        if (!Strings.isNullOrEmpty(id)) {
+        if (id != null && !id.isEmpty()) {
             builder.append(" \"").append(id).append("\"");
         } else if (getLabels().size() > 0) {
             String text = getLabels().get(0).getText();
-            if (!Strings.isNullOrEmpty(text)) {
+            if (text != null && !text.isEmpty()) {
                 builder.append(" \"").append(text).append("\"");
             }
         }

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/MapPropertyHolder.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/properties/MapPropertyHolder.java
@@ -14,8 +14,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.common.collect.Maps;
-
 /**
  * An implementation of {@link IPropertyHolder} based on a {@link HashMap}.
  *
@@ -107,7 +105,7 @@ public class MapPropertyHolder implements IPropertyHolder, Serializable {
      */
     private Map<IProperty<?>, Object> getProperties() {
         if (propertyMap == null) {
-            propertyMap = Maps.newHashMap();
+            propertyMap = new HashMap<>();
         }
         return propertyMap;
     }

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/ElkGraphUtil.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/ElkGraphUtil.java
@@ -10,6 +10,7 @@
 package org.eclipse.elk.graph.util;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -36,9 +37,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EContentsEList.FeatureFilter;
 import org.eclipse.emf.ecore.util.EContentsEList.FeatureIteratorImpl;
-
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Utility methods that make using the ElkGraph data structure a bit easier and thereby make ELK great again! The
@@ -415,10 +413,12 @@ public final class ElkGraphUtil {
      */
     public static ElkNode findLowestCommonAncestor(final ElkNode node1, final ElkNode node2) {
         // Retrieve iterators over the node ancestors
-        List<ElkNode> ancestors1 = Lists.newArrayList(new AncestorIterator(node1, true));
+        List<ElkNode> ancestors1 = new ArrayList<>();
+        new AncestorIterator(node1, true).forEachRemaining(ancestors1::add);
         ListIterator<ElkNode> iterator1 = ancestors1.listIterator(ancestors1.size());
 
-        List<ElkNode> ancestors2 = Lists.newArrayList(new AncestorIterator(node2, true));
+        List<ElkNode> ancestors2 = new ArrayList<>();
+        new AncestorIterator(node2, true).forEachRemaining(ancestors2::add);
         ListIterator<ElkNode> iterator2 = ancestors2.listIterator(ancestors2.size());
 
         // Traverse the ancestor hierarchies from the end as longs as the elements we find are the same
@@ -452,14 +452,12 @@ public final class ElkGraphUtil {
      * @return iterable with all incoming edges.
      */
     public static Iterable<ElkEdge> allIncomingEdges(final ElkNode node) {
-        List<Iterable<ElkEdge>> incomingEdgeIterables = Lists.newArrayListWithCapacity(1 + node.getPorts().size());
-
-        incomingEdgeIterables.add(node.getIncomingEdges());
+        List<ElkEdge> result = new ArrayList<>();
+        result.addAll(node.getIncomingEdges());
         for (ElkPort port : node.getPorts()) {
-            incomingEdgeIterables.add(port.getIncomingEdges());
+            result.addAll(port.getIncomingEdges());
         }
-
-        return Iterables.concat(incomingEdgeIterables);
+        return result;
     }
 
     /**
@@ -470,14 +468,12 @@ public final class ElkGraphUtil {
      * @return iterable with all outgoing edges.
      */
     public static Iterable<ElkEdge> allOutgoingEdges(final ElkNode node) {
-        List<Iterable<ElkEdge>> outgoingEdgeIterables = Lists.newArrayListWithCapacity(1 + node.getPorts().size());
-
-        outgoingEdgeIterables.add(node.getOutgoingEdges());
+        List<ElkEdge> result = new ArrayList<>();
+        result.addAll(node.getOutgoingEdges());
         for (ElkPort port : node.getPorts()) {
-            outgoingEdgeIterables.add(port.getOutgoingEdges());
+            result.addAll(port.getOutgoingEdges());
         }
-
-        return Iterables.concat(outgoingEdgeIterables);
+        return result;
     }
 
     /**
@@ -487,7 +483,10 @@ public final class ElkGraphUtil {
      * @return iterable with all incident edges.
      */
     public static Iterable<ElkEdge> allIncidentEdges(final ElkConnectableShape shape) {
-        return Iterables.concat(shape.getIncomingEdges(), shape.getOutgoingEdges());
+        List<ElkEdge> result = new ArrayList<>();
+        result.addAll(shape.getIncomingEdges());
+        result.addAll(shape.getOutgoingEdges());
+        return result;
     }
 
     /**
@@ -498,7 +497,14 @@ public final class ElkGraphUtil {
      * @return iterable with all incident edges.
      */
     public static Iterable<ElkEdge> allIncidentEdges(final ElkNode node) {
-        return Iterables.concat(allOutgoingEdges(node), allIncomingEdges(node));
+        List<ElkEdge> result = new ArrayList<>();
+        for (ElkEdge e : allOutgoingEdges(node)) {
+            result.add(e);
+        }
+        for (ElkEdge e : allIncomingEdges(node)) {
+            result.add(e);
+        }
+        return result;
     }
 
     /**
@@ -508,7 +514,10 @@ public final class ElkGraphUtil {
      * @return iterable with all incident shapes.
      */
     public static Iterable<ElkConnectableShape> allIncidentShapes(final ElkEdge edge) {
-        return Iterables.concat(edge.getSources(), edge.getTargets());
+        List<ElkConnectableShape> result = new ArrayList<>();
+        result.addAll(edge.getSources());
+        result.addAll(edge.getTargets());
+        return result;
     }
 
     /**
@@ -519,7 +528,10 @@ public final class ElkGraphUtil {
      * @return iterable over all incident sections.
      */
     public static Iterable<ElkEdgeSection> allIncidentSections(final ElkEdgeSection section) {
-        return Iterables.concat(section.getIncomingSections(), section.getOutgoingSections());
+        List<ElkEdgeSection> result = new ArrayList<>();
+        result.addAll(section.getIncomingSections());
+        result.addAll(section.getOutgoingSections());
+        return result;
     }
 
     /**

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/ElkReflect.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/ElkReflect.java
@@ -10,9 +10,8 @@
 package org.eclipse.elk.graph.util;
 
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.collect.Maps;
 
 /**
  * Provides the means to register a new instance function and a clone function with class types. The functionality to
@@ -35,8 +34,8 @@ import com.google.common.collect.Maps;
  */
 public final class ElkReflect {
 
-    private static final Map<Class<?>, NewInstanceFunction> REGISTRY_NEW = Maps.newHashMap();
-    private static final Map<Class<?>, CloneFunction> REGISTRY_CLONE = Maps.newHashMap();
+    private static final Map<Class<?>, NewInstanceFunction> REGISTRY_NEW = new HashMap<>();
+    private static final Map<Class<?>, CloneFunction> REGISTRY_CLONE = new HashMap<>();
     
     static {
         // special treatment and no new instance function required for EnumSets, register clone here

--- a/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/GraphIdentifierGenerator.java
+++ b/plugins/org.eclipse.elk.graph/src/org/eclipse/elk/graph/util/GraphIdentifierGenerator.java
@@ -22,9 +22,7 @@ import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.emf.ecore.EObject;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Sets;
+import java.util.HashSet;
 
 /**
  * Generates identifiers for graph elements where missing. Inside ELK, this class is mainly used to generate
@@ -214,7 +212,7 @@ public final class GraphIdentifierGenerator {
      * empty or {@code null} itself).
      */
     private String validateIdentifier(final String identifier) {
-        if (Strings.isNullOrEmpty(identifier)) {
+        if (identifier == null || identifier.isEmpty()) {
             return null;
         }
         
@@ -339,10 +337,14 @@ public final class GraphIdentifierGenerator {
     // Uniqueness
     
     private GraphIdentifierGenerator assertAllIdsUnique(final EObject element) {
-        Set<String> knownIds = Sets.newHashSet();
-        Iterator<ElkGraphElement> elementIt = Iterators.filter(element.eAllContents(), ElkGraphElement.class);
-        while (elementIt.hasNext()) {
-            ElkGraphElement e = elementIt.next();
+        Set<String> knownIds = new HashSet<>();
+        Iterator<EObject> allIt = element.eAllContents();
+        while (allIt.hasNext()) {
+            EObject obj = allIt.next();
+            if (!(obj instanceof ElkGraphElement)) {
+                continue;
+            }
+            ElkGraphElement e = (ElkGraphElement) obj;
             while (knownIds.contains(e.getIdentifier())) {
                 String newId = e.getIdentifier() + "_g" + fourDigitPaddedRandomNumber();
                 e.setIdentifier(newId);


### PR DESCRIPTION
 - Lists.newArrayList(), Maps.newHashMap(), Sets.newHashSet() → JDK constructors
  - Strings.isNullOrEmpty(s) → (s == null || s.isEmpty())
  - Joiner.on(s).join(c) → c.stream()...Collectors.joining(...)
  - Guava Predicate/Function/Optional → java.util.function.* / java.util.Optional
  - DoubleMath.fuzzyEquals/fuzzyCompare → public static helpers added to CompareFuzzy
  - ImmutableMap.of, ImmutableSet.of → Map.of / Set.of
  - Multimap/HashMultimap/ArrayListMultimap/LinkedHashMultimap/ListMultimap → Map<K, List<V>> / Map<K, Set<V>> with computeIfAbsent
  - Table/ArrayTable → nested Map<R, Map<C, V>> (using EnumMap for enum keys)
  - Range.closed(a, b) → plain int constants
  - Iterables.concat/filter/size/stream and Lists.reverse → centralized helpers in LGraphUtil
  
  
#1190 