### PR TITLE
layered: tolerate non-facing-side external port dummies in boundary layers

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -506,35 +506,59 @@ public class LayerSweepCrossingMinimizer
             return;
         }
 
+        // The end layer may also hold dummies for ports of other sides: dummies for NORTH/SOUTH
+        // ports carry no layer constraint, so the layerer may place them in the first or last
+        // layer as well (#1192). Write back only the dummies that belong to ports on the side
+        // facing the end of the sweep, in their layer order.
+        PortSide sweepEndSide = onRightMostLayer ? PortSide.EAST : PortSide.WEST;
+        Deque<LPort> dummyOrigins = new ArrayDeque<>();
+        for (; j >= 0 && j < lastLayer.length; j += next(onRightMostLayer)) {
+            LNode node = lastLayer[j];
+            if (isExternalPortDummy(node) && originPort(node).getSide() == sweepEndSide) {
+                dummyOrigins.add(originPort(node));
+            }
+        }
+
+        // Permute exactly the ports whose dummies were found in the end layer; every other port
+        // keeps its position. This keeps the port list duplicate-free even if some side port's
+        // dummy ended up in another layer.
+        Set<LPort> originSet = Sets.newHashSet(dummyOrigins);
         List<LPort> ports = parent.getPorts();
         for (int i = 0; i < ports.size(); i++) {
             LPort port = ports.get(i);
-            if (isOnEndOfSweepSide(port, onRightMostLayer) && isHierarchical(port)) {
-                // Only on external port dummy node has a port as its origin.
-                ports.set(i, originPort(lastLayer[j]));
-                j += next(onRightMostLayer);
+            if (isOnEndOfSweepSide(port, onRightMostLayer) && isHierarchical(port)
+                    && originSet.contains(port)) {
+                // Only an external port dummy node has a port as its origin.
+                ports.set(i, dummyOrigins.poll());
             }
         }
     }
 
     private LNode[] sortPortDummiesByPortPositions(final LNode parentNode,
             final LNode[] layerCloseToNodeEdge, final PortSide side) {
-        Iterable<LPort> ports = CrossMinUtil.inNorthSouthEastWestOrder(parentNode, side);
-
-        LNode[] sortedDummies = new LNode[layerCloseToNodeEdge.length];
-
-        int i = 0;
-        for (LPort port : ports) {
+        // The boundary layer is not guaranteed to consist only of dummies for hierarchical ports
+        // on the sweep-facing side: dummies for NORTH/SOUTH ports carry no layer constraint and
+        // the layerer may place them in the first or last layer as well (#1192). Sort only the
+        // dummies that belong to ports on the given side; leave all other nodes of the layer in
+        // their current relative order.
+        Set<LNode> layerNodes = Sets.newHashSet(layerCloseToNodeEdge);
+        Deque<LNode> sortedSideDummies = new ArrayDeque<>();
+        for (LPort port : CrossMinUtil.inNorthSouthEastWestOrder(parentNode, side)) {
             if (isHierarchical(port)) {
-                sortedDummies[i++] = dummyNodeFor(port);
+                LNode dummy = dummyNodeFor(port);
+                if (dummy != null && layerNodes.contains(dummy)) {
+                    sortedSideDummies.add(dummy);
+                }
             }
         }
 
-        if (i < layerCloseToNodeEdge.length) {
-            throw new IllegalStateException("Expected " + layerCloseToNodeEdge.length
-                    + " hierarchical ports, but found only " + i + ".");
+        Set<LNode> sideDummies = Sets.newHashSet(sortedSideDummies);
+        LNode[] result = new LNode[layerCloseToNodeEdge.length];
+        for (int i = 0; i < layerCloseToNodeEdge.length; i++) {
+            LNode node = layerCloseToNodeEdge[i];
+            result[i] = sideDummies.contains(node) ? sortedSideDummies.poll() : node;
         }
-        return sortedDummies;
+        return result;
     }
 
     private void saveAllNodeOrdersOfChangedGraphs() {

--- a/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/issues/Issue1192Test.java
+++ b/test/org.eclipse.elk.alg.layered.test/src/org/eclipse/elk/alg/layered/issues/Issue1192Test.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Kiel University and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.elk.alg.layered.issues;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.elk.alg.test.PlainJavaInitialization;
+import org.eclipse.elk.core.RecursiveGraphLayoutEngine;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.Direction;
+import org.eclipse.elk.core.options.HierarchyHandling;
+import org.eclipse.elk.core.options.PortConstraints;
+import org.eclipse.elk.core.options.PortSide;
+import org.eclipse.elk.core.util.NullElkProgressMonitor;
+import org.eclipse.elk.graph.ElkConnectableShape;
+import org.eclipse.elk.graph.ElkEdge;
+import org.eclipse.elk.graph.ElkNode;
+import org.eclipse.elk.graph.ElkPort;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Test for issue 1192: layered + INCLUDE_CHILDREN threw
+ * "Expected N hierarchical ports, but found only 0" for a ported compound with cross-hierarchy
+ * edges, because external port dummies of NORTH/SOUTH ports (which carry no layer constraint)
+ * may be placed in the boundary layers that the hierarchical layer sweep assumed to consist of
+ * sweep-facing-side dummies only.
+ */
+@RunWith(Parameterized.class)
+public class Issue1192Test {
+
+    @BeforeClass
+    public static void init() {
+        PlainJavaInitialization.initializePlainJavaLayout();
+    }
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { PortConstraints.FIXED_ORDER }, { PortConstraints.FIXED_SIDE } });
+    }
+
+    @Parameter
+    public PortConstraints portConstraints;
+
+    @Test
+    public void test() {
+        ElkNode root = ElkGraphUtil.createGraph();
+        root.setProperty(CoreOptions.ALGORITHM, "org.eclipse.elk.layered");
+        root.setProperty(CoreOptions.DIRECTION, Direction.RIGHT);
+        root.setProperty(CoreOptions.HIERARCHY_HANDLING, HierarchyHandling.INCLUDE_CHILDREN);
+
+        // Compound node `core` with BOTH ports AND child compounds.
+        ElkNode core = node(root, 120, 60);
+        core.setProperty(CoreOptions.PORT_CONSTRAINTS, portConstraints);
+        ElkPort pNorth1 = port(core, PortSide.NORTH);
+        ElkPort pNorth2 = port(core, PortSide.NORTH);
+        port(core, PortSide.EAST); // referenced by NO edge — yet load-bearing for the crash
+        ElkPort pEast2 = port(core, PortSide.EAST);
+
+        ElkNode boxA = node(core, 120, 60);
+        ElkNode leafA = node(boxA, 80, 40);
+        ElkNode boxB = node(core, 120, 60);
+        ElkNode leafB = node(boxB, 80, 40);
+        ElkNode plain = node(core, 80, 40);
+
+        // Edges fully inside `core`.
+        edge(core, boxA, boxB);
+        edge(core, leafA, plain);
+
+        // Edges crossing core's boundary, contained at the root graph.
+        edge(root, pNorth1, boxA);
+        edge(root, pNorth2, boxB);
+        edge(root, leafB, pEast2);
+
+        new RecursiveGraphLayoutEngine().layout(root, new NullElkProgressMonitor());
+
+        // All edges must actually be routed.
+        for (ElkNode container : new ElkNode[] { root, core }) {
+            for (ElkEdge e : container.getContainedEdges()) {
+                assertFalse("edge " + e + " has no routing", e.getSections().isEmpty());
+            }
+        }
+    }
+
+    private static ElkNode node(ElkNode parent, double w, double h) {
+        ElkNode n = ElkGraphUtil.createNode(parent);
+        n.setDimensions(w, h);
+        return n;
+    }
+
+    private static void edge(ElkNode container, ElkConnectableShape src, ElkConnectableShape tgt) {
+        ElkEdge e = ElkGraphUtil.createEdge(container);
+        e.getSources().add(src);
+        e.getTargets().add(tgt);
+    }
+
+    private static ElkPort port(ElkNode parent, PortSide side) {
+        ElkPort p = ElkGraphUtil.createPort(parent);
+        p.setProperty(CoreOptions.PORT_SIDE, side);
+        return p;
+    }
+}


### PR DESCRIPTION
Relating to issue #1192.

The hierarchical layer sweep assumed that when the first node of a nested graph's boundary layer is an external port dummy, the WHOLE layer consists of dummies for hierarchical ports on the sweep-facing side (`WEST`/`EAST`). That assumption does not hold: dummies for `NORTH`/`SOUTH` ports carry no layer constraint (`LGraphUtil.createExternalPortDummy` only sets an in-layer constraint for them), so the layerer may place them in the first or last layer too. The count mismatch then threw `IllegalStateException: Expected N hierarchical ports, but found only 0`.

`sortPortDummiesByPortPositions` now sorts only the dummies that belong to hierarchical ports on the sweep-facing side and leaves all other nodes of the layer in their current relative order, instead of throwing.

The inverse write-back, `sortPortsByDummyPositionsInLastLayer`, had the same latent assumption and could silently write a `NORTH`/`SOUTH` port into an `EAST`/`WEST` port slot, corrupting the port order. It now writes back only the dummies whose origin port lies on the side facing the end of the sweep, permuting exactly the ports whose dummies were found in that layer.

On graphs where the old invariant held, both methods behave exactly as before.

I'm happy to have my contribution licenced under GPLv3 (https://github.com/eclipse-elk/elk/issues/1185)

### ELK Test Graph
This graph fails before the fix (see issue #1192) and does now pass
```
algorithm: layered
direction: RIGHT
hierarchyHandling: INCLUDE_CHILDREN

node core {
    layout [ size: 120, 60 ]
    portConstraints: FIXED_ORDER
    port p_north_1 { ^port.side: NORTH }
    port p_north_2 { ^port.side: NORTH }
    port p_east_unused { ^port.side: EAST }   // referenced by NO edge — yet load-bearing
    port p_east_2 { ^port.side: EAST }

    node boxA {
        layout [ size: 120, 60 ]
        node leafA { layout [ size: 80, 40 ] }
    }
    node boxB {
        layout [ size: 120, 60 ]
        node leafB { layout [ size: 80, 40 ] }
    }
    node plain { layout [ size: 80, 40 ] }

    // edges fully inside core
    edge boxA -> boxB
    edge boxA.leafA -> plain
}

// edges crossing core's boundary, contained at the root graph (load-bearing)
edge core.p_north_1 -> core.boxA
edge core.p_north_2 -> core.boxB
edge core.boxB.leafB -> core.p_east_2
```